### PR TITLE
*: add the kl interpreter back, bump to Go1.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
-.PHONY: all docker esc generate generate test
+.PHONY: all kl docker esc generate generate test
 
-all: shen
+all: kl shen
 
 generate: esc
 	${GOPATH}/bin/esc -o runtime/asset.go -pkg=runtime bytecode
 
 esc: ${GOPATH}/bin/esc
 	go get -u -v github.com/mjibson/esc
+
+kl:
+	go install github.com/tiancaiamao/shen-go/cmd/kl
 
 shen:
 	go build -o shen cmd/shen/main.go

--- a/cmd/kl/main.go
+++ b/cmd/kl/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+
+	"github.com/tiancaiamao/shen-go/kl"
+)
+
+var pprof bool
+var shen bool
+
+func init() {
+	flag.BoolVar(&pprof, "pprof", false, "enable pprof")
+	flag.BoolVar(&shen, "shen", false, "run shen REPL")
+}
+
+func main() {
+	flag.Parse()
+
+	if pprof {
+		go http.ListenAndServe(":8080", nil)
+	}
+
+	e := kl.NewEvaluator()
+	if shen {
+		e.BootstrapShen()
+		e.Eval(kl.Cons(kl.MakeSymbol("shen.shen"), kl.Nil))
+		return
+	}
+
+	r := kl.NewSexpReader(os.Stdin)
+	for i := 0; ; i++ {
+		fmt.Printf("%d #> ", i)
+		sexp, err := r.Read()
+		if err != nil {
+			if err != io.EOF {
+				fmt.Println("read error:", err)
+			}
+			break
+		}
+
+		res := e.Eval(sexp)
+		fmt.Println(kl.ObjString(res))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tiancaiamao/shen-go
+
+go 1.13

--- a/kl/eval.go
+++ b/kl/eval.go
@@ -1,0 +1,356 @@
+package kl
+
+import (
+	"fmt"
+)
+
+type Environment struct {
+	parent *Environment
+	bind   map[string]Obj
+}
+
+func (env *Environment) Get(sym string) (Obj, bool) {
+	for env != nil {
+		if v, ok := env.bind[sym]; ok {
+			return v, true
+		}
+		env = env.parent
+	}
+	return Nil, false
+}
+
+func (env *Environment) Extend(symbols, values []Obj) *Environment {
+	if len(symbols) == 0 {
+		return env
+	}
+
+	bind := make(map[string]Obj)
+	for i := 0; i < len(symbols); i++ {
+		name := GetSymbol(symbols[i])
+		bind[name] = values[i]
+	}
+	return &Environment{
+		parent: env,
+		bind:   bind,
+	}
+}
+
+type controlFlowKind int
+
+const (
+	controlFlowReturn controlFlowKind = iota
+	controlFlowEval
+	controlFlowApply
+)
+
+// Trampoline are used by native code to implement tail call.
+type Trampoline struct {
+	kind controlFlowKind
+	// arguments for apply
+	f    Obj
+	args []Obj
+	// return result
+	result Obj
+}
+
+func (ctl *Trampoline) TailApply(f Obj, args []Obj) {
+	ctl.f = f
+	ctl.args = args
+	ctl.kind = controlFlowApply
+}
+
+func (ctl *Trampoline) Return(result Obj) {
+	ctl.result = result
+	ctl.kind = controlFlowReturn
+}
+
+type controlFlow struct {
+	Trampoline
+	inException bool
+	// arguments for eval
+	exp Obj
+	env *Environment
+}
+
+// trampoline is introduced for tail call optimization.
+func (e *Evaluator) trampoline(exp Obj, env *Environment) Obj {
+	var ctl = controlFlow{
+		Trampoline: Trampoline{
+			kind: controlFlowEval,
+		},
+		exp: exp,
+		env: env,
+	}
+	for ctl.kind != controlFlowReturn {
+		switch ctl.kind {
+		case controlFlowEval:
+			e.eval(&ctl)
+		case controlFlowApply:
+			e.apply(&ctl)
+		}
+	}
+	return ctl.result
+}
+
+func (ctl *controlFlow) TailEval(exp Obj, env *Environment) {
+	ctl.exp = exp
+	ctl.env = env
+	ctl.kind = controlFlowEval
+}
+
+// Exception can be replaced by Return totally, just defined as a name alias.
+func (ctl *controlFlow) Exception(err Obj) {
+	mustError(err)
+	ctl.result = err
+	ctl.kind = controlFlowReturn
+}
+
+func (e *Evaluator) eval(ctl *controlFlow) {
+	exp := ctl.exp
+	env := ctl.env
+
+	switch *exp { // handle constant
+	case scmHeadNumber, scmHeadString, scmHeadVector, scmHeadBoolean, scmHeadNull, scmHeadProcedure, scmHeadPrimitive:
+		ctl.Return(exp)
+		return
+	}
+
+	if ok, _ := isSymbol(exp); ok {
+		if val, ok := env.Get(GetSymbol(exp)); ok {
+			exp = val
+		}
+		ctl.Return(exp)
+		return
+	}
+
+	pair := mustPair(exp)
+	if ok, sym := isSymbol(pair.car); ok {
+		exp = pair.cdr // handle special form
+		switch symbolArray[sym.offset].str {
+		case "quote":
+			// Extension to make vm work.
+			// TODO: remove it later
+			ctl.Return(car(exp))
+			return
+		case "defun": // (defun f (x y) z)
+			proc := makeProcedure(cadr(exp), caddr(exp), env)
+			funName := car(exp)
+			e.functionTable[GetSymbol(funName)] = proc
+			ctl.Return(funName)
+			return
+		case "lambda": // (lambda x x)
+			ctl.Return(makeProcedure(car(exp), cadr(exp), env))
+			return
+		case "freeze": // (freeze body)
+			ctl.Return(makeProcedure(Nil, car(exp), env))
+			return
+		case "let": // (let x y z)
+			args := e.trampoline(cadr(exp), env)
+			if *args == scmHeadError {
+				ctl.Exception(args)
+				return
+			}
+			newEnv := env.Extend([]Obj{car(exp)}, []Obj{args})
+			ctl.TailEval(caddr(exp), newEnv)
+			return
+		case "and":
+			e.evalAnd(car(exp), cadr(exp), env, ctl)
+			return
+		case "or":
+			e.evalOr(car(exp), cadr(exp), env, ctl)
+			return
+		case "if": // (if a b c)
+			if listLength(pair.cdr) == 3 {
+				e.evalIf(car(exp), cadr(exp), caddr(exp), env, ctl)
+				return
+			} // if may also be a function for partial apply
+		case "cond": // (cond (false 1) (true 2))
+			e.evalCond(exp, env, ctl)
+			return
+		case "trap-error": // (trap-error ~body ~handler)
+			e.evalTrapError(exp, env, ctl)
+			return
+		case "do": // (do A A)
+			if tmp := e.trampoline(car(exp), env); *tmp == scmHeadError {
+				ctl.Exception(tmp)
+				return
+			}
+			ctl.TailEval(cadr(exp), env)
+			return
+		}
+	}
+
+	fn := e.evalFunction(pair.car, env)
+	if *fn == scmHeadError {
+		ctl.Exception(fn)
+		return
+	}
+	args := e.evalArgumentList(pair.cdr, env)
+	if !ctl.inException && len(args) == 1 && *args[0] == scmHeadError {
+		ctl.Exception(args[0])
+		return
+	}
+	ctl.TailApply(fn, args)
+	return
+}
+
+func (e *Evaluator) evalFunction(fn Obj, env *Environment) Obj {
+	if ok, _ := isSymbol(fn); ok {
+		str := GetSymbol(fn)
+		if proc, ok := env.Get(str); ok {
+			return proc
+		}
+		if val, ok := e.functionTable[str]; ok {
+			return val
+		}
+	}
+
+	switch *fn {
+	case scmHeadPrimitive, scmHeadProcedure:
+		return fn
+	case scmHeadPair:
+		return e.trampoline(fn, env)
+	}
+	panic(fmt.Sprintf("can't apply non function: %#v", (*scmHead)(fn)))
+}
+
+func (e *Evaluator) evalIf(a, b, c Obj, env *Environment, ctl *controlFlow) {
+	t := e.trampoline(a, env)
+	switch t {
+	case True:
+		ctl.TailEval(b, env)
+		return
+	case False:
+		ctl.TailEval(c, env)
+		return
+	}
+	panic("second argument of if should be boolean")
+}
+
+func (e *Evaluator) evalAnd(a, b Obj, env *Environment, ctl *controlFlow) {
+	if e.trampoline(a, env) == False {
+		ctl.Return(False)
+		return
+	}
+	ctl.TailEval(b, env)
+}
+
+func (e *Evaluator) evalOr(a, b Obj, env *Environment, ctl *controlFlow) {
+	if e.trampoline(a, env) == True {
+		ctl.Return(True)
+		return
+	}
+	ctl.TailEval(b, env)
+}
+
+func (e *Evaluator) evalCond(l Obj, env *Environment, ctl *controlFlow) {
+	for *l == scmHeadPair {
+		curr := car(l)
+		if e.trampoline(car(curr), env) == True {
+			ctl.TailEval(cadr(curr), env)
+			return
+		}
+		l = cdr(l)
+	}
+	ctl.Return(Nil)
+	return
+}
+
+func (e *Evaluator) evalTrapError(exp Obj, env *Environment, ctl *controlFlow) {
+	v := e.trampoline(car(exp), env)
+	if *v == scmHeadError {
+		ctl.inException = true
+		handler := e.evalFunction(cadr(exp), env)
+		ctl.TailApply(handler, []Obj{v})
+		return
+	}
+	ctl.Return(v)
+	return
+}
+
+func (e *Evaluator) apply(ctl *controlFlow) {
+	f := ctl.f
+	args := ctl.args
+
+	if *f == scmHeadPrimitive {
+		prim := mustPrimitive(f)
+		switch {
+		case prim.Name == "native":
+			method := GetSymbol(args[0])
+			prim1, ok := e.nativeFunc[method]
+			if !ok {
+				ctl.Return(MakeError("undefined native " + method))
+				return
+			}
+			prim = prim1
+			ctl.Return(prim.Function(args[1:]...))
+			return
+		case len(args) < prim.Required:
+			ctl.Return(partialApply(prim.Required, args, nil, f))
+			return
+		case len(args) == prim.Required:
+			ctl.Return(prim.Function(args...))
+			return
+		}
+	} else if *f == scmHeadProcedure {
+		proc := mustProcedure(f)
+		switch {
+		case len(args) < proc.arity:
+			ctl.Return(partialApply(proc.arity, args, proc.env, f))
+			return
+		case len(args) == proc.arity:
+			newEnv := proc.env.Extend(proc.arg, args)
+			ctl.TailEval(proc.body, newEnv)
+			return
+		case len(args) > proc.arity:
+			newEnv := proc.env.Extend(proc.arg, args[:proc.arity])
+			res := e.trampoline(proc.body, newEnv)
+			ctl.TailApply(res, args[proc.arity:])
+			return
+		}
+	}
+	panic("can't apply object")
+}
+
+// partialApply works when Required > providArgs
+func partialApply(required int, providArgs []Obj, env *Environment, proc Obj) Obj {
+	// Partial apply...
+	// (f x y z) => (lambda (z) (f x y z)) with x y in env
+	symbols := makeTempSymbols(required)
+	env1 := env.Extend(symbols[:len(providArgs)], providArgs)
+
+	args := Nil
+	for i, count := len(symbols)-1, required-len(providArgs); count > 0; count-- {
+		args = cons(symbols[i], args)
+		i--
+	}
+
+	body := Nil
+	for i := len(symbols) - 1; i >= 0; i-- {
+		body = cons(symbols[i], body)
+	}
+	body = cons(proc, body)
+
+	return makeProcedure(args, body, env1)
+}
+
+func (e *Evaluator) evalArgumentList(args Obj, env *Environment) []Obj {
+	var ret []Obj
+	for *args == scmHeadPair {
+		v := e.trampoline(car(args), env)
+		if *v == scmHeadError {
+			return []Obj{v}
+		}
+		ret = append(ret, v)
+		args = cdr(args)
+	}
+	return ret
+}
+
+func makeTempSymbols(n int) []Obj {
+	ret := make([]Obj, n)
+	for i := 0; i < n; i++ {
+		ret[i] = MakeSymbol(fmt.Sprintf("tmp%d", i))
+	}
+	return ret
+}

--- a/kl/evaluator.go
+++ b/kl/evaluator.go
@@ -1,0 +1,149 @@
+package kl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"runtime"
+)
+
+type Evaluator struct {
+	functionTable map[string]Obj
+	Silence       bool
+
+	nativeFunc map[string]*ScmPrimitive
+}
+
+func NewEvaluator() *Evaluator {
+	var e Evaluator
+
+	e.functionTable = make(map[string]Obj, len(allPrimitives))
+	for _, prim := range allPrimitives {
+		e.functionTable[prim.Name] = Obj(&prim.scmHead)
+	}
+	// Overload for primitive set and value.
+	tmp := &ScmPrimitive{scmHead: scmHeadPrimitive, Name: "set", Required: 2, Function: e.primSet}
+	e.functionTable["set"] = Obj(&tmp.scmHead)
+	tmp = &ScmPrimitive{scmHead: scmHeadPrimitive, Name: "value", Required: 1, Function: e.primValue}
+	e.functionTable["value"] = Obj(&tmp.scmHead)
+	tmp = &ScmPrimitive{scmHead: scmHeadPrimitive, Name: "eval-kl", Required: 1, Function: e.primEvalKL}
+	e.functionTable["eval-kl"] = Obj(&tmp.scmHead)
+	tmp = &ScmPrimitive{scmHead: scmHeadPrimitive, Name: "load-file", Required: 1, Function: e.primLoadFile}
+	e.functionTable["load-file"] = Obj(&tmp.scmHead)
+
+	e.nativeFunc = make(map[string]*ScmPrimitive)
+	e.RegistNativeCall(MakePrimitive("primitive?", 1, NativeIsPrimitive))
+	e.RegistNativeCall(MakePrimitive("primitive-arity", 1, NativePrimitiveArity))
+	e.RegistNativeCall(MakePrimitive("primitive-id", 1, NativePrimitiveID))
+
+	PrimSet(MakeSymbol("*stinput*"), MakeStream(os.Stdin))
+	PrimSet(MakeSymbol("*stoutput*"), MakeStream(os.Stdout))
+	dir, _ := os.Getwd()
+	PrimSet(MakeSymbol("*home-directory*"), MakeString(dir))
+	PrimSet(MakeSymbol("*language*"), MakeString("Go"))
+	PrimSet(MakeSymbol("*implementation*"), MakeString("interpreter"))
+	PrimSet(MakeSymbol("*relase*"), MakeString(runtime.Version()))
+	PrimSet(MakeSymbol("*os*"), MakeString(runtime.GOOS))
+	PrimSet(MakeSymbol("*porters*"), MakeString("Arthur Mao"))
+	PrimSet(MakeSymbol("*port*"), MakeString("0.0.1"))
+
+	// Extended by shen-go implementation
+	PrimSet(MakeSymbol("*package-path*"), MakeString(PackagePath()))
+	return &e
+}
+
+func (e *Evaluator) primSet(args ...Obj) Obj {
+	return PrimSet(args[0], args[1])
+}
+
+func (e *Evaluator) primValue(args ...Obj) Obj {
+	return PrimValue(args[0])
+}
+
+func (e *Evaluator) primEvalKL(args ...Obj) Obj {
+	return e.trampoline(args[0], nil)
+}
+
+func (e *Evaluator) primLoadFile(args ...Obj) Obj {
+	path := mustString(args[0])
+	return e.LoadFile(path)
+}
+
+func (e *Evaluator) LoadFile(file string) Obj {
+	var filePath string
+	if _, err := os.Stat(file); err == nil {
+		filePath = file
+	} else {
+		filePath = path.Join(PackagePath(), file)
+		if _, err := os.Stat(filePath); err != nil {
+			return MakeError(err.Error())
+		}
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return MakeError(err.Error())
+	}
+	defer f.Close()
+
+	r := NewSexpReader(f)
+	for {
+		exp, err := r.Read()
+		if err != nil {
+			if err != io.EOF {
+				return MakeError(err.Error())
+			}
+			break
+		}
+
+		res := e.trampoline(exp, nil)
+		if *res == scmHeadError {
+			return res
+		}
+	}
+	if !e.Silence {
+		fmt.Println(filePath)
+	}
+	return MakeString(file)
+}
+
+func (e *Evaluator) Eval(exp Obj) (res Obj) {
+	defer func() {
+		if r := recover(); r != nil {
+			var buf [4096]byte
+			n := runtime.Stack(buf[:], false)
+			fmt.Println("Panic:", r)
+			fmt.Println("Recovered in Eval:", ObjString(exp))
+			fmt.Println(string(buf[:n]))
+			res = Nil
+		}
+	}()
+	res = e.trampoline(exp, nil)
+	return
+}
+
+func (e *Evaluator) RegistNativeCall(prim *ScmPrimitive) {
+	e.nativeFunc[prim.Name] = prim
+}
+
+func (e *Evaluator) BootstrapShen() {
+	e.LoadFile("ShenOSKernel-21.0/klambda/toplevel.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/core.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/sys.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/sequent.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/yacc.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/reader.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/prolog.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/track.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/load.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/writer.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/macros.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/declarations.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/t-star.kl")
+	e.LoadFile("ShenOSKernel-21.0/klambda/types.kl")
+
+	// override
+	isSymbol := MakePrimitive("symbol?", 1, primIsSymbol)
+	e.functionTable["symbol?"] = Obj(&isSymbol.scmHead)
+}

--- a/kl/library.go
+++ b/kl/library.go
@@ -1,0 +1,149 @@
+package kl
+
+import (
+	"math"
+	"os"
+	"path"
+)
+
+func PackagePath() string {
+	gopath := os.Getenv("GOPATH")
+	return path.Join(gopath, "src/github.com/tiancaiamao/shen-go")
+}
+
+func cadr(o Obj) Obj {
+	return car(cdr(o))
+}
+
+func caddr(o Obj) Obj {
+	return car(cdr(cdr(o)))
+}
+
+func cdddr(o Obj) Obj {
+	return cdr(cdr(cdr(o)))
+}
+
+func cadddr(o Obj) Obj {
+	return car(cdr(cdr(cdr(o))))
+}
+
+func reverse(o Obj) Obj {
+	ret := Nil
+	for o != Nil {
+		ret = cons(car(o), ret)
+		o = cdr(o)
+	}
+	return ret
+}
+
+func equal(x, y Obj) Obj {
+	if *x != *y {
+		return False
+	}
+
+	switch *x {
+	case scmHeadNumber:
+		if mustNumber(x).val != mustNumber(y).val {
+			return False
+		}
+	case scmHeadString:
+		if mustString(x) != mustString(y) {
+			return False
+		}
+	case scmHeadBoolean:
+		if x != y {
+			return False
+		}
+	case scmHeadSymbol:
+		if mustSymbol(x).offset != mustSymbol(y).offset {
+			return False
+		}
+	case scmHeadNull:
+		if *y != scmHeadNull {
+			return False
+		}
+	case scmHeadPair:
+		// TODO: maybe cycle exists!
+		if x != y {
+			if equal(car(x), car(y)) == False {
+				return False
+			}
+			if equal(cdr(x), cdr(y)) == False {
+				return False
+			}
+		}
+	case scmHeadStream, scmHeadProcedure, scmHeadPrimitive:
+		if x != y {
+			return False
+		}
+	case scmHeadVector:
+		v1 := mustVector(x)
+		v2 := mustVector(y)
+		if len(v1) != len(v2) {
+			return False
+		}
+		for i := 0; i < len(v1); i++ {
+			if v1[i] != nil || v2[i] != nil {
+				if equal(v1[i], v2[i]) != True {
+					return False
+				}
+			}
+		}
+	}
+
+	return True
+}
+
+func listLength(l Obj) int {
+	count := 0
+	for *l == scmHeadPair {
+		count++
+		l = cdr(l)
+	}
+	return count
+}
+
+func ListToSlice(l Obj) []Obj {
+	var ret []Obj
+	for *l == scmHeadPair {
+		ret = append(ret, car(l))
+		l = cdr(l)
+	}
+	return ret
+}
+
+func GetInteger(o Obj) int {
+	return int(mustNumber(o).val)
+}
+
+func Cadr(o Obj) Obj {
+	return cadr(o)
+}
+
+func Car(o Obj) Obj {
+	return car(o)
+}
+
+func Cdr(o Obj) Obj {
+	return cdr(o)
+}
+
+func Cons(x, y Obj) Obj {
+	return cons(x, y)
+}
+
+// isInteger determinate whether a float64 is actually a precise integer.
+// Judge is according to IEEE754 standard.
+func isPreciseInteger(f float64) bool {
+	exp := math.Ilogb(f)
+	if exp < 0 && exp != math.MinInt32 {
+		return false
+	}
+
+	if exp >= 52 {
+		return true
+	}
+
+	bits := math.Float64bits(f)
+	return (bits << uint(12+exp)) == 0
+}

--- a/kl/library_test.go
+++ b/kl/library_test.go
@@ -1,0 +1,96 @@
+package kl
+
+import (
+	"testing"
+)
+
+func TestReverse(t *testing.T) {
+	if reverse(Nil) != Nil {
+		t.FailNow()
+	}
+
+	l := cons(MakeInteger(1), cons(MakeInteger(2), cons(MakeInteger(3), Nil)))
+	r := reverse(l)
+	if mustInteger(car(r)) != 3 {
+		t.FailNow()
+	}
+	if mustInteger(cadr(r)) != 2 {
+		t.FailNow()
+	}
+	if mustInteger(caddr(r)) != 1 {
+		t.FailNow()
+	}
+	if cdddr(r) != Nil {
+		t.FailNow()
+	}
+
+	// (1 (1 2 3))
+	l1 := cons(MakeInteger(1), cons(l, Nil))
+	// ((1 2 3) 1)
+	l2 := cons(l, cons(MakeInteger(1), Nil))
+
+	if equal(reverse(l1), l2) != True {
+		t.Error("fuck1")
+	}
+	if equal(reverse(l2), l1) != True {
+		t.Error("fuck2")
+	}
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		x      Obj
+		y      Obj
+		expect Obj
+	}{
+		{True, True, True},
+		{True, False, False},
+		{False, True, False},
+		{True, MakeNumber(10), False},
+		{Nil, Nil, True},
+		{Nil, False, False},
+		{MakeString("asd"), MakeString("abc"), False},
+		{MakeVector(1), MakeVector(2), False},
+		{MakeVector(0), MakeVector(0), True},
+	}
+
+	for _, test := range tests {
+		if equal(test.x, test.y) != test.expect {
+			t.Error(test.x, test.y)
+		}
+	}
+}
+
+func TestVectorGet(t *testing.T) {
+	vec := MakeVector(1)
+	primVectorSet(vec, MakeInteger(0), MakeNumber(42))
+	err := primVectorGet(vec, MakeInteger(1))
+	if *err != scmHeadError {
+		t.Error("should be error out of range")
+	}
+	if equal(primVectorGet(vec, MakeInteger(0)), MakeNumber(42)) != True {
+		t.Error("vector set or get wrong")
+	}
+}
+
+func TestIsPreciseInteger(t *testing.T) {
+	testPreciseInteger(t, 0.0, true)
+	testPreciseInteger(t, 1.0, true)
+	testPreciseInteger(t, 3, true)
+	testPreciseInteger(t, 7.0, true)
+	testPreciseInteger(t, -1.0, true)
+	testPreciseInteger(t, 2251799813685248.0, true)
+
+	testPreciseInteger(t, 2.14, false)
+	testPreciseInteger(t, 0.14, false)
+	testPreciseInteger(t, -0.14, false)
+	testPreciseInteger(t, 1.1, false)
+	testPreciseInteger(t, 1024.5, false)
+	testPreciseInteger(t, 2251799813685248.5, false)
+}
+
+func testPreciseInteger(t *testing.T, f float64, expect bool) {
+	if isPreciseInteger(f) != expect {
+		t.Error("testPreciseInteger wrong:", f, expect)
+	}
+}

--- a/kl/primitives.go
+++ b/kl/primitives.go
@@ -1,0 +1,573 @@
+package kl
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"time"
+	"unsafe"
+)
+
+var allPrimitives []*ScmPrimitive = []*ScmPrimitive{
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "load-file", Required: 1},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "type", Required: 2, Function: typeFunc},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "get-time", Required: 1, Function: getTime},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "eval-kl", Required: 1},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "close", Required: 1, Function: closeStream},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "open", Required: 2, Function: openStream},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "read-byte", Required: 1, Function: primReadByte},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "write-byte", Required: 2, Function: writeByte},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "absvector?", Required: 1, Function: isVector},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<-address", Required: 2, Function: primVectorGet},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "address->", Required: 3, Function: primVectorSet},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "absvector", Required: 1, Function: primAbsvector},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "str", Required: 1, Function: primStr},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<=", Required: 2, Function: lessEqual},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: ">=", Required: 2, Function: greatEqual},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<", Required: 2, Function: lessThan},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: ">", Required: 2, Function: greatThan},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "error-to-string", Required: 1, Function: primErrorToString},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "simple-error", Required: 1, Function: simpleError},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "=", Required: 2, Function: PrimEqual},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "-", Required: 2, Function: primNumberSubtract},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "*", Required: 2, Function: primNumberMultiply},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "/", Required: 2, Function: primNumberDivide},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "+", Required: 2, Function: PrimNumberAdd},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "string->n", Required: 1, Function: primStringToNumber},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "n->string", Required: 1, Function: primNumberToString},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "number?", Required: 1, Function: primIsNumber},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "string?", Required: 1, Function: primIsString},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "pos", Required: 2, Function: pos},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "tlstr", Required: 1, Function: primTailString},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "cn", Required: 2, Function: stringConcat},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "intern", Required: 1, Function: primIntern},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "hd", Required: 1, Function: PrimHead},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "tl", Required: 1, Function: primTail},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "cons", Required: 2, Function: primCons},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "cons?", Required: 1, Function: primIsPair},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "value", Required: 1},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "set", Required: 2},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "not", Required: 1, Function: primNot},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "if", Required: 3, Function: primIf},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "symbol?", Required: 1, Function: primIsSymbol},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "native", Required: 9999},
+	// &ScmPrimitive{scmHead: scmHeadPrimitive, Name: "hash", Required: 2, Function: primHash},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "read-file-as-bytelist", Required: 1, Function: primReadFileAsByteList},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "read-file-as-string", Required: 1, Function: primReadFileAsString},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "variable?", Required: 1, Function: primIsVariable},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "integer?", Required: 1, Function: primIsInteger},
+}
+
+var primitiveIdx map[string]*ScmPrimitive
+
+func init() {
+	primitiveIdx = make(map[string]*ScmPrimitive)
+	for i, prim := range allPrimitives {
+		prim.id = i
+		primitiveIdx[prim.Name] = prim
+	}
+}
+
+func NativeIsPrimitive(args ...Obj) Obj {
+	if *args[0] != scmHeadSymbol {
+		return False
+	}
+	str := GetSymbol(args[0])
+	_, ok := primitiveIdx[str]
+	if ok {
+		return True
+	}
+	return False
+}
+
+func NativePrimitiveArity(args ...Obj) Obj {
+	str := GetSymbol(args[0])
+	prim, ok := primitiveIdx[str]
+	if !ok {
+		return MakeInteger(-1)
+	}
+	return MakeInteger(prim.Required)
+}
+
+func NativePrimitiveID(args ...Obj) Obj {
+	str := GetSymbol(args[0])
+	prim, ok := primitiveIdx[str]
+	if !ok {
+		return MakeError("not a primitive")
+	}
+	return MakeInteger(prim.id)
+}
+
+func GetPrimitiveByID(id int) *ScmPrimitive {
+	return allPrimitives[id]
+}
+
+func PrimNumberAdd(args ...Obj) Obj {
+	x1 := mustNumber(args[0])
+	y1 := mustNumber(args[1])
+	return MakeNumber(x1.val + y1.val)
+}
+
+func primNumberSubtract(args ...Obj) Obj {
+	x1 := mustNumber(args[0])
+	y1 := mustNumber(args[1])
+	return MakeNumber(x1.val - y1.val)
+}
+
+func primNumberMultiply(args ...Obj) Obj {
+	x1 := mustNumber(args[0])
+	y1 := mustNumber(args[1])
+	return MakeNumber(x1.val * y1.val)
+}
+
+func primNumberDivide(args ...Obj) Obj {
+	x1 := mustNumber(args[0])
+	y1 := mustNumber(args[1])
+	return MakeNumber(x1.val / y1.val)
+}
+
+func primIntern(args ...Obj) Obj {
+	str := mustString(args[0])
+	switch str {
+	case "true":
+		return True
+	case "false":
+		return False
+	}
+	return MakeSymbol(str)
+}
+
+func PrimHead(args ...Obj) Obj {
+	return car(args[0])
+}
+
+func primTail(args ...Obj) Obj {
+	return cdr(args[0])
+}
+
+func primIsNumber(args ...Obj) Obj {
+	if *args[0] == scmHeadNumber {
+		return True
+	}
+	return False
+}
+
+func primStringToNumber(args ...Obj) Obj {
+	str := mustString(args[0])
+	n := ([]rune(str))[0]
+	return MakeInteger(int(n))
+}
+
+func primNumberToString(args ...Obj) Obj {
+	n := mustInteger(args[0])
+	return MakeString(string(rune(n)))
+}
+
+func primStr(args ...Obj) Obj {
+	switch *args[0] {
+	case scmHeadPair:
+		// Pair may contain recursive list.
+		return MakeError("can't str pair object")
+	case scmHeadNull:
+		return MakeString("()")
+	case scmHeadSymbol:
+		str := GetSymbol(args[0])
+		return MakeString(str)
+	case scmHeadNumber:
+		f := mustNumber(args[0])
+		if !isPreciseInteger(f.val) {
+			return MakeString(fmt.Sprintf("%f", f.val))
+		}
+		return MakeString(fmt.Sprintf("%d", int(f.val)))
+	case scmHeadString:
+		return MakeString(fmt.Sprintf(`"%s"`, mustString(args[0])))
+	case scmHeadProcedure:
+		return MakeString("#<procedure>")
+	case scmHeadPrimitive:
+		prim := mustPrimitive(args[0])
+		return MakeString(fmt.Sprintf("#<primitive %s>", prim.Name))
+	case scmHeadBoolean:
+		if args[0] == True {
+			return MakeString("true")
+		} else if args[0] == False {
+			return MakeString("false")
+		}
+	case scmHeadError:
+		e := mustError(args[0])
+		return MakeString(e.err)
+	case scmHeadStream:
+		return MakeString("<stream>")
+	case scmHeadRaw:
+		return MakeString("#<raw>")
+	default:
+		return MakeString("primStr unknown")
+	}
+	return MakeString("wrong input, the object is not atom ...")
+}
+
+func stringConcat(args ...Obj) Obj {
+	s1 := mustString(args[0])
+	s2 := mustString(args[1])
+	return MakeString(s1 + s2)
+}
+
+func primTailString(args ...Obj) Obj {
+	str := mustString(args[0])
+	if len(str) == 0 {
+		return MakeError("empty string")
+	}
+	return MakeString(string([]rune(str)[1:]))
+}
+
+func pos(args ...Obj) Obj {
+	s := []rune(mustString(args[0]))
+	n := mustInteger(args[1])
+	if n >= len(s) {
+		return MakeError(fmt.Sprintf("%d is not valid index for %s", n, string(s)))
+	}
+	return MakeString(string([]rune(s)[n]))
+}
+
+func and(args ...Obj) Obj {
+	if args[0] == True && args[1] == True {
+		return True
+	}
+	return False
+}
+
+func or(args ...Obj) Obj {
+	if args[0] == False || args[1] == False {
+		return False
+	}
+	return True
+}
+
+func PrimSet(key Obj, val Obj) Obj {
+	sym := mustSymbol(key)
+	symVal := &symbolArray[sym.offset]
+	symVal.value = val
+	return val
+}
+
+func PrimValue(key Obj) Obj {
+	sym := mustSymbol(key)
+	symVal := &symbolArray[sym.offset]
+	if symVal.value != nil {
+		return symVal.value
+	}
+	return MakeError(fmt.Sprintf("variable %s not bound", symVal.str))
+}
+
+func simpleError(args ...Obj) Obj {
+	str := mustString(args[0])
+	return MakeError(str)
+}
+
+func primErrorToString(args ...Obj) Obj {
+	e := mustError(args[0])
+	return MakeString(e.err)
+}
+
+func greatThan(args ...Obj) Obj {
+	x := mustNumber(args[0])
+	y := mustNumber(args[1])
+	if x.val > y.val {
+		return True
+	}
+	return False
+}
+
+func lessThan(args ...Obj) Obj {
+	x := mustNumber(args[0])
+	y := mustNumber(args[1])
+	if x.val < y.val {
+		return True
+	}
+	return False
+}
+
+func lessEqual(args ...Obj) Obj {
+	x := mustNumber(args[0])
+	y := mustNumber(args[1])
+	if x.val <= y.val {
+		return True
+	}
+	return False
+}
+
+func greatEqual(args ...Obj) Obj {
+	x := mustNumber(args[0])
+	y := mustNumber(args[1])
+	if x.val >= y.val {
+		return True
+	}
+	return False
+}
+
+func primAbsvector(args ...Obj) Obj {
+	n := mustInteger(args[0])
+	if n < 0 {
+		return MakeError("absvector wrong argument")
+	}
+	return MakeVector(n)
+}
+
+func primVectorSet(args ...Obj) Obj {
+	vec := mustVector(args[0])
+	off := mustInteger(args[1])
+	val := args[2]
+	vec[off] = val
+	return args[0]
+}
+
+func primVectorGet(args ...Obj) Obj {
+	vec := mustVector(args[0])
+	off := mustInteger(args[1])
+	if off >= len(vec) {
+		return MakeError(fmt.Sprintf("index %d out of range %d", off, len(vec)))
+	}
+	ret := vec[off]
+	if ret == nil {
+		return undefined
+	}
+	return ret
+}
+
+func isVector(args ...Obj) Obj {
+	if *args[0] == scmHeadVector {
+		return True
+	}
+	return False
+}
+
+func writeByte(args ...Obj) Obj {
+	n := mustInteger(args[0])
+	s := mustStream(args[1])
+	w, ok := s.raw.(io.Writer)
+	if !ok {
+		return MakeError("stream is not opened in out mode")
+	}
+	var b [1]byte
+	b[0] = byte(n)
+	_, err := w.Write(b[:])
+	if err != nil {
+		return MakeError(err.Error())
+	}
+	return args[0]
+}
+
+func primReadByte(args ...Obj) Obj {
+	s := mustStream(args[0])
+	r, ok := s.raw.(io.Reader)
+	if !ok {
+		return MakeError("stream is closed of not opened in in mode")
+	}
+	var buf [1]byte
+	_, err := r.Read(buf[:])
+	if err != nil {
+		if err == io.EOF {
+			return MakeInteger(-1)
+		}
+		return MakeError(err.Error())
+	}
+	return MakeInteger(int(buf[0]))
+}
+
+func openStream(args ...Obj) Obj {
+	file := mustString(args[0])
+	var flag int
+	mode := GetSymbol(args[1])
+	switch mode {
+	case "in":
+		flag |= os.O_RDONLY
+	case "out":
+		flag |= os.O_WRONLY | os.O_CREATE
+	default:
+		flag = os.O_RDWR | os.O_CREATE
+	}
+
+	f, err := os.OpenFile(file, flag, 0666)
+	if err != nil {
+		return MakeError(err.Error())
+	}
+	return MakeStream(f)
+}
+
+func closeStream(args ...Obj) Obj {
+	s := mustStream(args[0])
+	c := s.raw.(io.Closer)
+	c.Close()
+	return Nil
+}
+
+func getTime(args ...Obj) Obj {
+	kind := GetSymbol(args[0])
+	switch kind {
+	case "unix":
+		return MakeNumber(float64(time.Now().Unix()))
+	case "run":
+		return MakeNumber(time.Since(uptime).Seconds())
+	}
+	return MakeError(fmt.Sprintf("get-time does not understand the parameter %s", kind))
+}
+
+func typeFunc(args ...Obj) Obj {
+	// TODO: seems meanless
+	return args[0]
+}
+
+func primIsString(args ...Obj) Obj {
+	if *args[0] == scmHeadString {
+		return True
+	}
+	return False
+}
+
+func primIsPair(args ...Obj) Obj {
+	if *args[0] == scmHeadPair {
+		return True
+	}
+	return False
+}
+
+func primNot(args ...Obj) Obj {
+	if args[0] == False {
+		return True
+	} else if args[0] == True {
+		return False
+	}
+	return MakeError("primNot")
+
+}
+
+func primIf(args ...Obj) Obj {
+	switch args[0] {
+	case True:
+		return args[1]
+	case False:
+		return args[2]
+	}
+	return MakeError("primIf")
+}
+
+func PrimEqual(args ...Obj) Obj {
+	return equal(args[0], args[1])
+}
+
+func primCons(args ...Obj) Obj {
+	return cons(args[0], args[1])
+}
+
+func primIsSymbol(args ...Obj) Obj {
+	if IsSymbol(args[0]) {
+		return True
+	}
+	return False
+}
+
+// A --> number --> number
+func primHash(args ...Obj) Obj {
+	mod := mustNumber(args[1]).val
+	ret := objHash(args[0]) % int(mod)
+	return MakeInteger(ret)
+}
+
+func objHash(x Obj) int {
+	// initialize value is its type, then mixed with value part.
+	sum := (int)(*x)
+	switch *x {
+	case scmHeadNull:
+	case scmHeadBoolean:
+		if x == True {
+			sum = sum<<23 + 17
+		} else {
+			sum = sum<<23 + 13
+		}
+	case scmHeadNumber:
+		sum = sum<<23 + *((*int)(unsafe.Pointer(&mustNumber(x).val)))
+	case scmHeadString:
+		str := mustString(x)
+		for _, s := range str {
+			sum = ((sum + 13) << 7) + int(s)
+		}
+	case scmHeadSymbol:
+		str := GetSymbol(x)
+		for _, s := range str {
+			sum = ((sum + 13) << 7) + int(s)
+		}
+	case scmHeadVector:
+		objs := mustVector(x)
+		for _, o := range objs {
+			sum = ((sum + 17) << 13) + objHash(o)
+		}
+	case scmHeadError:
+		str := mustError(x).err
+		for _, s := range str {
+			sum = ((sum + 123) << 7) + int(s)
+		}
+	case scmHeadPair:
+		sum = objHash(car(x)) ^ objHash(cdr(x))
+	case scmHeadProcedure:
+		sum = sum ^ *((*int)(unsafe.Pointer(mustProcedure(x))))
+	case scmHeadStream:
+		sum = sum ^ *((*int)(unsafe.Pointer(mustStream(x))))
+	case scmHeadPrimitive:
+		for _, s := range mustPrimitive(x).Name {
+			sum = ((sum + 17) << 7) + int(s)
+		}
+	case scmHeadRaw:
+		sum = sum ^ *((*int)(unsafe.Pointer(mustStream(x))))
+	}
+	return sum
+}
+
+func primReadFileAsByteList(args ...Obj) Obj {
+	fileName := mustString(args[0])
+	buf, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return MakeError(err.Error())
+	}
+
+	ret := cons(Nil, Nil)
+	curr := mustPair(ret)
+	for _, b := range buf {
+		tmp := cons(MakeInteger(int(b)), Nil)
+		curr.cdr = tmp
+		curr = mustPair(tmp)
+	}
+	return cdr(ret)
+}
+
+func primReadFileAsString(args ...Obj) Obj {
+	fileName := mustString(args[0])
+	buf, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return MakeError(err.Error())
+	}
+
+	return MakeString(string(buf))
+}
+
+func primIsVariable(args ...Obj) Obj {
+	if *args[0] != scmHeadSymbol {
+		return False
+	}
+
+	sym := GetSymbol(args[0])
+	if len(sym) == 0 || sym[0] < 'A' || sym[0] > 'Z' {
+		return False
+	}
+	return True
+}
+
+func primIsInteger(args ...Obj) Obj {
+	if *args[0] != scmHeadNumber {
+		return False
+	}
+	f := mustNumber(args[0]).val
+	if isPreciseInteger(f) {
+		return True
+	}
+	return False
+}

--- a/kl/primitives_test.go
+++ b/kl/primitives_test.go
@@ -1,0 +1,56 @@
+package kl
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReadByte(t *testing.T) {
+	buf := bytes.NewBufferString("a")
+	stream := MakeStream(buf)
+	b := primReadByte(stream)
+	if mustInteger(b) != 97 {
+		t.Error("should be 97")
+	}
+
+	b = primReadByte(stream)
+	if mustInteger(b) != -1 {
+		t.Error("read EOF should return -1")
+	}
+}
+
+func TestIntern(t *testing.T) {
+	if primIntern(MakeString("true")) != True {
+		t.Error("intern(true) should be boolean")
+	}
+	if primIntern(MakeString("false")) != False {
+		t.Error("intern(false) should be boolean")
+	}
+	if equal(primIntern(MakeString("asdf")), MakeSymbol("asdf")) != True {
+		t.FailNow()
+	}
+}
+
+func TestHash(t *testing.T) {
+	objs := []Obj{
+		MakeInteger(3),
+		MakeNumber(3.1),
+		MakeSymbol("sdsd"),
+		MakeString("sdsd"),
+		MakeError("sdsd"),
+		Obj(&allPrimitives[3].scmHead),
+		True,
+		False,
+		Nil,
+	}
+
+	m := make(map[int]Obj)
+	for _, o := range objs {
+		hash := objHash(o)
+		t.Log(hash, ObjString(o))
+		if m[hash] != nil {
+			t.FailNow()
+		}
+		m[hash] = o
+	}
+}

--- a/kl/reader.go
+++ b/kl/reader.go
@@ -1,0 +1,142 @@
+package kl
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"unicode"
+)
+
+type SexpReader struct {
+	reader *bufio.Reader
+	buf    []rune
+}
+
+func NewSexpReader(r io.Reader) *SexpReader {
+	return &SexpReader{
+		reader: bufio.NewReader(r),
+	}
+}
+
+func (r *SexpReader) Read() (Obj, error) {
+	b, err := peekFirstRune(r.reader)
+	if err != nil {
+		return Nil, err
+	}
+
+	switch b {
+	case rune('^'):
+		return r.readerMacro()
+	case rune('('):
+		return r.readSexp()
+	case rune('"'):
+		return r.readString()
+	}
+
+	r.resetBuf()
+	r.appendBuf(b)
+	b, _, err = r.reader.ReadRune()
+	for err == nil {
+		if notSymbolChar(b) {
+			r.reader.UnreadRune()
+			break
+		}
+		r.appendBuf(b)
+		b, _, err = r.reader.ReadRune()
+	}
+
+	return tokenToObj(string(r.buf)), err
+}
+
+func (r *SexpReader) readerMacro() (Obj, error) {
+	rune, _, err := r.reader.ReadRune()
+	if err != nil {
+		return Nil, err
+	}
+	obj, err := r.Read()
+	if err != nil {
+		return obj, err
+	}
+
+	switch rune {
+	case '\'': // quote macro
+		return quoteMacro(obj)
+	}
+
+	return obj, nil
+}
+
+func RconsForm(o Obj) Obj {
+	return rconsForm(o)
+}
+
+func rconsForm(o Obj) Obj {
+	if *o == scmHeadPair {
+		return cons(MakeSymbol("cons"),
+			cons(rconsForm(car(o)),
+				cons(rconsForm(cdr(o)), Nil)))
+	}
+	return o
+}
+
+func quoteMacro(o Obj) (Obj, error) {
+	return rconsForm(o), nil
+}
+
+func (r *SexpReader) readString() (Obj, error) {
+	r.resetBuf()
+	b, _, err := r.reader.ReadRune()
+	for err == nil && b != rune('"') {
+		r.appendBuf(b)
+		b, _, err = r.reader.ReadRune()
+	}
+	return MakeString(string(r.buf)), err
+}
+
+func (r *SexpReader) readSexp() (Obj, error) {
+	ret := Nil
+	b, err := peekFirstRune(r.reader)
+	for err == nil && b != rune(')') {
+		var obj Obj
+		r.reader.UnreadRune()
+		obj, err = r.Read()
+		if err == nil {
+			ret = cons(obj, ret)
+			b, err = peekFirstRune(r.reader)
+		}
+	}
+	return reverse(ret), err
+}
+
+func (r *SexpReader) resetBuf() {
+	r.buf = r.buf[:0]
+}
+
+func (r *SexpReader) appendBuf(b rune) {
+	r.buf = append(r.buf, b)
+}
+
+func peekFirstRune(r *bufio.Reader) (rune, error) {
+	b, _, err := r.ReadRune()
+	for err == nil && unicode.IsSpace(b) {
+		b, _, err = r.ReadRune()
+	}
+	return b, err
+}
+
+func notSymbolChar(c rune) bool {
+	return unicode.IsSpace(c) || c == '(' || c == '"' || c == ')'
+}
+
+func tokenToObj(str string) Obj {
+	switch str {
+	case "true":
+		return True
+	case "false":
+		return False
+	}
+	if v, err := strconv.ParseFloat(str, 64); err == nil {
+		return MakeNumber(v)
+	}
+	return MakeSymbol(str)
+}

--- a/kl/reader_test.go
+++ b/kl/reader_test.go
@@ -1,0 +1,65 @@
+package kl
+
+import (
+	"io"
+	// "fmt"
+	"strings"
+	"testing"
+)
+
+func TestSexpReader(t *testing.T) {
+	IF := MakeSymbol("if")
+	tests := []struct {
+		input  string
+		expect Obj
+	}{
+		{"1234", MakeInteger(1234)},
+		{`"string"`, MakeString("string")},
+		{"symbol", MakeSymbol("symbol")},
+		{"()", Nil},
+		{"(1 2)", cons(MakeInteger(1), cons(MakeInteger(2), Nil))},
+		{"true", True},
+		{"false", False},
+		{"(if true (if false 1 2) 3)", cons(IF, cons(True,
+			cons(
+				cons(IF, cons(False, cons(MakeInteger(1), cons(MakeInteger(2), Nil)))),
+				cons(MakeInteger(3), Nil))))},
+		{`"abc
+de"`, MakeString("abc\nde")},
+	}
+	for _, test := range tests {
+		r := NewSexpReader(strings.NewReader(test.input))
+		o, err := r.Read()
+		if err != nil && err != io.EOF {
+			t.Error("read error", err)
+		}
+		if equal(o, test.expect) == False {
+			t.Errorf("%s fail, expect: %#v, but get: %#v\n", test.input, (*scmHead)(test.expect), (*scmHead)(o))
+		}
+	}
+
+	r := NewSexpReader(strings.NewReader("(if true 1 false) 2"))
+	o1, err := r.Read()
+	if err != nil && err != io.EOF {
+		t.Fatal("read error", err)
+	}
+	if equal(o1, cons(MakeSymbol("if"), cons(True, cons(MakeInteger(1), cons(False, Nil))))) == False {
+		t.Errorf("if true... %#v", (*scmHead)(o1))
+	}
+
+	o2, err := r.Read()
+	if err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+	if equal(o2, MakeInteger(2)) == False {
+		t.Error("read another sexp")
+	}
+}
+
+func TestReaderMacro(t *testing.T) {
+	a, _ := NewSexpReader(strings.NewReader("^'(a b c)")).Read()
+	b, _ := NewSexpReader(strings.NewReader("(cons a (cons b (cons c ())))")).Read()
+	if equal(a, b) == False {
+		t.Error("fail:", ObjString(a), ObjString(b))
+	}
+}

--- a/kl/stub.go
+++ b/kl/stub.go
@@ -1,0 +1,137 @@
+package kl
+
+import (
+	"unsafe"
+)
+
+type scmNative struct {
+	scmHead
+	fn       func(*Trampoline, ...Obj)
+	require  int
+	captured []Obj
+}
+
+func MakeNative(fn func(*Trampoline, ...Obj), require int, captured ...Obj) Obj {
+	tmp := scmNative{
+		scmHead:  scmHeadNative,
+		fn:       fn,
+		require:  require,
+		captured: captured,
+	}
+	return &tmp.scmHead
+}
+
+func MustNative(o Obj) *scmNative {
+	if *o != scmHeadNative {
+		panic("mustNative")
+	}
+	return (*scmNative)(unsafe.Pointer(o))
+}
+
+// type Trampoline struct {
+// 	pc   *scmFunc
+// 	args []Obj
+// }
+
+// func (t *Trampoline) Return(res Obj) {
+// 	t.pc = nil
+// 	t.args = t.args[:0]
+// 	t.args = append(t.args, res)
+// }
+
+// func (t *Trampoline) TailCall(f Obj, args ...Obj) {
+// 	t.pc = MustFunc(f)
+// 	t.args = t.args[:0]
+// 	t.args = append(t.args, args...)
+// }
+
+// func (t *Trampoline) partialApply() {
+// 	provided := len(t.pc.captured) + len(t.args)
+// 	required := t.pc.require
+// 	if provided == required {
+// 		t.pc.fn(t, t.args...)
+// 		return
+// 	}
+
+// 	tmp := make([]Obj, 0, t.pc.require)
+// 	tmp = append(tmp, t.pc.captured...)
+// 	if provided < required {
+// 		tmp = append(tmp, t.args...)
+// 		t.Return(MakeFunc(t.pc.fn, t.pc.require, tmp...))
+// 		return
+// 	}
+
+// 	tmp = append(tmp, t.args[:provided-required]...)
+// 	fn := Call(MakeFunc(t.pc.fn, t.pc.require), tmp...)
+// 	t.TailCall(fn, t.args[provided-required:]...)
+// 	return
+// }
+
+// func (t *Trampoline) Run(pc *scmFunc, args ...Obj) Obj {
+// 	t.pc = pc
+// 	t.args = args
+// 	for t.pc != nil {
+// 		t.partialApply()
+// 	}
+// 	return t.args[0]
+// }
+
+// func Call(f Obj, args ...Obj) Obj {
+// 	fn := MustFunc(f)
+// 	var ctx Trampoline
+// 	return ctx.Run(fn, args...)
+// }
+
+// func BuiltinEQ(x, y Obj) Obj {
+// 	return equal(x, y)
+// }
+
+// func BuiltinSub(x, y Obj) Obj {
+// 	x1 := mustNumber(x)
+// 	y1 := mustNumber(y)
+// 	return MakeNumber(x1.val - y1.val)
+// }
+
+// func BuiltinAdd(x, y Obj) Obj {
+// 	x1 := mustNumber(x)
+// 	y1 := mustNumber(y)
+// 	return MakeNumber(x1.val + y1.val)
+// }
+
+// func BuiltinMul(x, y Obj) Obj {
+// 	x1 := mustNumber(x)
+// 	y1 := mustNumber(y)
+// 	return MakeNumber(x1.val * y1.val)
+// }
+
+// func BuiltinCons(x, y Obj) Obj {
+// 	return cons(x, y)
+// }
+
+// func BuiltinHD(x Obj) Obj {
+// 	return car(x)
+// }
+
+// func BuiltinTL(x Obj) Obj {
+// 	return cdr(x)
+// }
+
+// func BuiltinConsP(x Obj) Obj {
+// 	return primIsPair(x)
+// }
+
+// func BuiltinSet(symbol, val Obj) Obj {
+// 	sym := mustSymbol(symbol)
+// 	symVal := &symbolArray[sym.offset]
+// 	symVal.value = val
+// 	return val
+// }
+
+// func BuiltinValue(arg Obj) Obj {
+// 	sym := mustSymbol(arg)
+// 	symVal := &symbolArray[sym.offset]
+// 	if symVal.value != nil {
+// 		return symVal.value
+// 	}
+// 	return MakeError(fmt.Sprintf("variable %s not bound", symVal.str))
+// }

--- a/kl/types.go
+++ b/kl/types.go
@@ -1,0 +1,452 @@
+package kl
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"time"
+	"unsafe"
+)
+
+// All kinds of Scheme object.
+type Obj *scmHead
+
+type scmHead int
+
+const (
+	scmHeadNumber    scmHead = 0
+	scmHeadPair              = 1
+	scmHeadVector            = 2
+	scmHeadNull              = 3
+	scmHeadString            = 4
+	scmHeadSymbol            = 5
+	scmHeadBoolean           = 6
+	scmHeadProcedure         = 14
+	scmHeadStream            = 17
+	scmHeadPrimitive         = 21
+	scmHeadError             = 22
+	scmHeadNative            = 23
+	scmHeadRaw               = 42
+)
+
+type scmNumber struct {
+	scmHead
+	val float64
+}
+
+type scmSymbol struct {
+	scmHead
+	offset int
+}
+
+type scmPair struct {
+	scmHead
+	car Obj
+	cdr Obj
+}
+
+type scmVector struct {
+	scmHead
+	vector []Obj
+}
+
+type scmString struct {
+	scmHead
+	str string
+}
+
+type scmStream struct {
+	scmHead
+	raw interface{}
+}
+
+type scmBoolean struct {
+	scmHead
+	bool
+}
+
+type scmProcedure struct {
+	scmHead
+	name  string
+	arg   []Obj
+	arity int
+	body  Obj
+	env   *Environment
+}
+
+type ScmPrimitive struct {
+	scmHead
+	id       int
+	Name     string
+	Required int
+	Function func(...Obj) Obj
+}
+
+type scmError struct {
+	scmHead
+	err string
+}
+
+// MakeRaw makes a struct into a raw object.
+// Usage:
+// type T struct {
+//    scmHead int
+//    ... // xxx
+// }
+// tmp := &T{}
+// raw := MakeRaw(&tmp.scmHead)
+func MakeRaw(scmHead *int) Obj {
+	*scmHead = scmHeadRaw
+	return Obj(unsafe.Pointer(scmHead))
+}
+
+func MakeError(err string) Obj {
+	tmp := scmError{scmHeadError, err}
+	return &tmp.scmHead
+}
+
+func mustError(o Obj) *scmError {
+	if *o != scmHeadError {
+		panic("mustError")
+	}
+	return (*scmError)(unsafe.Pointer(o))
+}
+
+func IsError(o Obj) bool {
+	return *o == scmHeadError
+}
+
+func IsNumber(o Obj) bool {
+	return *o == scmHeadNumber
+}
+
+func IsSymbol(o Obj) bool {
+	return *o == scmHeadSymbol
+}
+
+func MakePrimitive(name string, arity int, f func(...Obj) Obj) *ScmPrimitive {
+	return &ScmPrimitive{
+		scmHead:  scmHeadPrimitive,
+		Name:     name,
+		Required: arity,
+		Function: f,
+	}
+}
+
+func isPrimitive(o Obj) (bool, *ScmPrimitive) {
+	if *o != scmHeadPrimitive {
+		return false, nil
+	}
+	return true, (*ScmPrimitive)(unsafe.Pointer(o))
+}
+
+func mustPrimitive(o Obj) *ScmPrimitive {
+	if *o != scmHeadPrimitive {
+		panic("mustPrimitive")
+	}
+	return (*ScmPrimitive)(unsafe.Pointer(o))
+}
+
+func mustVector(o Obj) []Obj {
+	if (*o) != scmHeadVector {
+		panic("mustVector")
+	}
+	tmp := (*scmVector)(unsafe.Pointer(o))
+	return tmp.vector
+}
+
+func mustProcedure(o Obj) *scmProcedure {
+	if (*o) != scmHeadProcedure {
+		panic("mustProcedure")
+	}
+	return (*scmProcedure)(unsafe.Pointer(o))
+}
+
+func mustString(o Obj) string {
+	if (*o) != scmHeadString {
+		panic("mustString")
+	}
+	return (*scmString)(unsafe.Pointer(o)).str
+}
+
+func mustInteger(o Obj) int {
+	if (*o) != scmHeadNumber {
+		panic("mustNumber")
+	}
+	f := (*scmNumber)(unsafe.Pointer(o)).val
+	return int(f)
+}
+
+func mustNumber(o Obj) *scmNumber {
+	if (*o) != scmHeadNumber {
+		panic("mustNumber")
+	}
+	return (*scmNumber)(unsafe.Pointer(o))
+}
+
+func mustSymbol(o Obj) *scmSymbol {
+	if (*o) != scmHeadSymbol {
+		panic("mustSymbol")
+	}
+	return (*scmSymbol)(unsafe.Pointer(o))
+}
+
+func isSymbol(o Obj) (bool, *scmSymbol) {
+	if *o == scmHeadSymbol {
+		return true, (*scmSymbol)(unsafe.Pointer(o))
+	}
+	return false, nil
+}
+
+func mustStream(o Obj) *scmStream {
+	if (*o) != scmHeadStream {
+		panic("mustStream")
+	}
+	return (*scmStream)(unsafe.Pointer(o))
+}
+
+func mustPair(o Obj) *scmPair {
+	if (*o) != scmHeadPair {
+		fmt.Println(ObjString(o))
+		panic("mustPair")
+	}
+	return (*scmPair)(unsafe.Pointer(o))
+}
+
+func isPair(o Obj) (bool, *scmPair) {
+	if (*o) == scmHeadPair {
+		return true, (*scmPair)(unsafe.Pointer(o))
+	}
+	return false, nil
+}
+
+const intConstCount = 8192
+
+var True, False, Nil, undefined Obj
+var uptime time.Time
+var intConst [intConstCount]Obj
+
+type symbolArrayObj struct {
+	str      string // The string of this symbol
+	value    Obj    // The value bind to this symbol
+	function Obj    // The function bind to this symbol
+}
+
+var symbolArray []symbolArrayObj
+
+type trieNode struct {
+	children [256]*trieNode
+	value    int
+}
+
+var trieRoot *trieNode
+
+func trieFindOrInsert(str string) *trieNode {
+	p := trieRoot
+	for i := 0; i < len(str); i++ {
+		v := str[i]
+		if p.children[v] == nil {
+			p.children[v] = &trieNode{value: -1}
+		}
+		p = p.children[v]
+	}
+	return p
+}
+
+func init() {
+	uptime = time.Now()
+	tmp1 := &scmBoolean{scmHeadBoolean, false}
+	False = Obj(&tmp1.scmHead)
+
+	tmp2 := &scmBoolean{scmHeadBoolean, true}
+	True = Obj(&tmp2.scmHead)
+
+	tmp3 := &scmPair{scmHeadNull, nil, nil}
+	Nil = Obj(&tmp3.scmHead)
+
+	var tmp4 int
+	undefined = MakeRaw(&tmp4)
+
+	for i := 0; i < intConstCount; i++ {
+		intConst[i] = makeInteger(i)
+	}
+
+	symbolArray = make([]symbolArrayObj, 0, 4096)
+	trieRoot = &trieNode{}
+}
+
+func MakeInteger(v int) Obj {
+	if v >= 0 && v < intConstCount {
+		return intConst[v]
+	}
+	return makeInteger(v)
+}
+
+func makeInteger(v int) Obj {
+	tmp := scmNumber{scmHeadNumber, float64(v)}
+	return &tmp.scmHead
+}
+
+func MakeNumber(f float64) Obj {
+	if isPreciseInteger(f) {
+		if f >= 0 && int(f) < intConstCount {
+			return intConst[int(f)]
+		}
+	}
+
+	tmp := scmNumber{scmHeadNumber, f}
+	return &tmp.scmHead
+}
+
+func MakeStream(raw interface{}) Obj {
+	tmp := scmStream{
+		scmHeadStream,
+		raw,
+	}
+	return &tmp.scmHead
+}
+
+func GetString(o Obj) string {
+	return mustString(o)
+}
+
+func GetSymbol(o Obj) string {
+	return symbolArray[mustSymbol(o).offset].str
+}
+
+func BindSymbolFunc(sym Obj, f Obj) {
+	o := &symbolArray[mustSymbol(sym).offset]
+	o.function = f
+}
+
+func GetSymbolFunc(sym Obj) Obj {
+	o := &symbolArray[mustSymbol(sym).offset]
+	return o.function
+}
+
+func cons(x, y Obj) Obj {
+	tmp := scmPair{
+		scmHead: scmHeadPair,
+		car:     x,
+		cdr:     y,
+	}
+	return &tmp.scmHead
+}
+
+func car(x Obj) Obj {
+	return mustPair(x).car
+}
+
+func cdr(x Obj) Obj {
+	return mustPair(x).cdr
+}
+
+func MakeVector(n int) Obj {
+	tmp := scmVector{
+		scmHeadVector,
+		make([]Obj, n),
+	}
+	return &tmp.scmHead
+}
+
+func MakeString(s string) Obj {
+	tmp := scmString{scmHeadString, s}
+	return &tmp.scmHead
+}
+
+func MakeSymbol(s string) Obj {
+	var idx int
+	p := trieFindOrInsert(s)
+	if p.value < 0 {
+		idx = len(symbolArray)
+		symbolArray = append(symbolArray, symbolArrayObj{str: s})
+		p.value = idx
+	} else {
+		idx = p.value
+	}
+
+	tmp := scmSymbol{
+		scmHeadSymbol,
+		idx,
+	}
+	return &tmp.scmHead
+}
+
+func makeProcedure(arg Obj, body Obj, env *Environment) Obj {
+	tmp := scmProcedure{
+		scmHead: scmHeadProcedure,
+		body:    body,
+		env:     env,
+	}
+	if *arg == scmHeadSymbol {
+		tmp.arg = []Obj{arg}
+		tmp.arity = 1
+	} else {
+		tmp.arg = ListToSlice(arg)
+		tmp.arity = len(tmp.arg)
+	}
+	return &tmp.scmHead
+}
+
+func ObjString(o Obj) string {
+	return (*scmHead)(o).GoString()
+}
+
+func (o *scmPair) fmt(buf io.Writer, start bool) {
+	if start {
+		fmt.Fprintf(buf, "(%s", ObjString(o.car))
+	} else {
+		fmt.Fprintf(buf, " %s", ObjString(o.car))
+	}
+	switch *o.cdr {
+	case scmHeadNull:
+		fmt.Fprintf(buf, ")")
+	case scmHeadPair:
+		mustPair(o.cdr).fmt(buf, false)
+	default:
+		fmt.Fprintf(buf, " . %s)", ObjString(o.cdr))
+	}
+}
+
+func (o *scmHead) GoString() string {
+	switch *o {
+	case scmHeadNumber:
+		f := mustNumber(o)
+		if !isPreciseInteger(f.val) {
+			return fmt.Sprintf("%f", f.val)
+		}
+		return fmt.Sprintf("%d", int(f.val))
+	case scmHeadPair:
+		var buf bytes.Buffer
+		mustPair(o).fmt(&buf, true)
+		return buf.String()
+	case scmHeadVector:
+		return fmt.Sprintf("#vector")
+	case scmHeadNull:
+		return fmt.Sprintf("()")
+	case scmHeadString:
+		return fmt.Sprintf(`"%s"`, mustString(o))
+	case scmHeadSymbol:
+		return fmt.Sprintf("%s", GetSymbol(o))
+	case scmHeadBoolean:
+		if o == True {
+			return fmt.Sprintf("true")
+		} else if o == False {
+			return fmt.Sprintf("false")
+		} else {
+			return fmt.Sprintf("Boolean(something wrong)")
+		}
+	case scmHeadError:
+		return fmt.Sprintf("Error(%s)", mustError(o).err)
+	case scmHeadProcedure:
+		return fmt.Sprintf("#procedure")
+	case scmHeadStream:
+		return fmt.Sprintf("#stream")
+	case scmHeadPrimitive:
+		prim := mustPrimitive(o)
+		return fmt.Sprintf("#primitive(%s)", prim.Name)
+	case scmHeadRaw:
+		return "#raw"
+	}
+	return fmt.Sprintf("unknown type %d", *o)
+}


### PR DESCRIPTION
Revert this commit https://github.com/tiancaiamao/shen-go/commit/527cc497719bbbc2c9307bed1416621c86f550fe

- As the title says, now I add the kl interpreter back.
- Split a `Trampoline` struct from the `controlFlow` struct
- Add file stub.go and a new scmHead type scmNative
- Update Go compiler to 1.13