### PR TITLE
kl: add a 'CodeGen' field to the ScmPrimitive struct

### DIFF
--- a/kl/evaluator.go
+++ b/kl/evaluator.go
@@ -18,8 +18,8 @@ type Evaluator struct {
 func NewEvaluator() *Evaluator {
 	var e Evaluator
 
-	e.functionTable = make(map[string]Obj, len(allPrimitives))
-	for _, prim := range allPrimitives {
+	e.functionTable = make(map[string]Obj, len(AllPrimitives))
+	for _, prim := range AllPrimitives {
 		e.functionTable[prim.Name] = Obj(&prim.scmHead)
 	}
 	// Overload for primitive set and value.
@@ -143,6 +143,6 @@ func (e *Evaluator) BootstrapShen() {
 	e.LoadFile("ShenOSKernel-21.0/klambda/types.kl")
 
 	// override
-	isSymbol := MakePrimitive("symbol?", 1, primIsSymbol)
+	isSymbol := MakePrimitive("symbol?", 1, PrimIsSymbol)
 	e.functionTable["symbol?"] = Obj(&isSymbol.scmHead)
 }

--- a/kl/library_test.go
+++ b/kl/library_test.go
@@ -63,12 +63,12 @@ func TestEqual(t *testing.T) {
 
 func TestVectorGet(t *testing.T) {
 	vec := MakeVector(1)
-	primVectorSet(vec, MakeInteger(0), MakeNumber(42))
-	err := primVectorGet(vec, MakeInteger(1))
+	PrimVectorSet(vec, MakeInteger(0), MakeNumber(42))
+	err := PrimVectorGet(vec, MakeInteger(1))
 	if *err != scmHeadError {
 		t.Error("should be error out of range")
 	}
-	if equal(primVectorGet(vec, MakeInteger(0)), MakeNumber(42)) != True {
+	if equal(PrimVectorGet(vec, MakeInteger(0)), MakeNumber(42)) != True {
 		t.Error("vector set or get wrong")
 	}
 }

--- a/kl/primitives.go
+++ b/kl/primitives.go
@@ -9,67 +9,53 @@ import (
 	"unsafe"
 )
 
-var allPrimitives []*ScmPrimitive = []*ScmPrimitive{
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "load-file", Required: 1},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "type", Required: 2, Function: typeFunc},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "get-time", Required: 1, Function: getTime},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "eval-kl", Required: 1},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "close", Required: 1, Function: closeStream},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "open", Required: 2, Function: openStream},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "read-byte", Required: 1, Function: primReadByte},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "write-byte", Required: 2, Function: writeByte},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "absvector?", Required: 1, Function: isVector},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<-address", Required: 2, Function: primVectorGet},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "address->", Required: 3, Function: primVectorSet},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "absvector", Required: 1, Function: primAbsvector},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "str", Required: 1, Function: primStr},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<=", Required: 2, Function: lessEqual},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: ">=", Required: 2, Function: greatEqual},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<", Required: 2, Function: lessThan},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: ">", Required: 2, Function: greatThan},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "error-to-string", Required: 1, Function: primErrorToString},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "simple-error", Required: 1, Function: simpleError},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "=", Required: 2, Function: PrimEqual},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "-", Required: 2, Function: primNumberSubtract},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "*", Required: 2, Function: primNumberMultiply},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "/", Required: 2, Function: primNumberDivide},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "+", Required: 2, Function: PrimNumberAdd},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "string->n", Required: 1, Function: primStringToNumber},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "n->string", Required: 1, Function: primNumberToString},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "number?", Required: 1, Function: primIsNumber},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "string?", Required: 1, Function: primIsString},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "pos", Required: 2, Function: pos},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "tlstr", Required: 1, Function: primTailString},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "cn", Required: 2, Function: stringConcat},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "intern", Required: 1, Function: primIntern},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "hd", Required: 1, Function: PrimHead},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "tl", Required: 1, Function: primTail},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "cons", Required: 2, Function: primCons},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "cons?", Required: 1, Function: primIsPair},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "value", Required: 1},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "set", Required: 2},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "not", Required: 1, Function: primNot},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "if", Required: 3, Function: primIf},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "symbol?", Required: 1, Function: primIsSymbol},
+var AllPrimitives = []*ScmPrimitive{
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "load-file", Required: 1, CodeGen: "PrimLoadFile"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "type", Required: 2, Function: PrimTypeFunc, CodeGen: "PrimTypeFunc"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "get-time", Required: 1, Function: PrimGetTime, CodeGen: "PrimGetTime"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "eval-kl", Required: 1, CodeGen: "PrimEvalKL"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "close", Required: 1, Function: PrimCloseStream, CodeGen: "PrimCloseStream"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "open", Required: 2, Function: PrimOpenStream, CodeGen: "PrimOpenStream"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "read-byte", Required: 1, Function: PrimReadByte, CodeGen: "PrimReadByte"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "write-byte", Required: 2, Function: PrimWriteByte, CodeGen: "PrimWriteByte"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "absvector?", Required: 1, Function: PrimIsVector, CodeGen: "PrimIsVector"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<-address", Required: 2, Function: PrimVectorGet, CodeGen: "PrimVectorGet"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "address->", Required: 3, Function: PrimVectorSet, CodeGen: "PrimVectorSet"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "absvector", Required: 1, Function: PrimAbsvector, CodeGen: "PrimAbsvector"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "str", Required: 1, Function: PrimStr, CodeGen: "PrimStr"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<=", Required: 2, Function: PrimLessEqual, CodeGen: "PrimLessEqual"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: ">=", Required: 2, Function: PrimGreatEqual, CodeGen: "PrimGreatEqual"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<", Required: 2, Function: PrimLessThan, CodeGen: "PrimLessThan"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: ">", Required: 2, Function: PrimGreatThan, CodeGen: "PrimGreatThan"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "error-to-string", Required: 1, Function: PrimErrorToString, CodeGen: "PrimErrorToString"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "simple-error", Required: 1, Function: PrimSimpleError, CodeGen: "PrimSimpleError"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "=", Required: 2, Function: PrimEqual, CodeGen: "PrimEqual"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "-", Required: 2, Function: PrimNumberSubtract, CodeGen: "PrimNumberSubtract"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "*", Required: 2, Function: PrimNumberMultiply, CodeGen: "PrimNumberMultiply"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "/", Required: 2, Function: PrimNumberDivide, CodeGen: "PrimNumberDivide"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "+", Required: 2, Function: PrimNumberAdd, CodeGen: "PrimNumberAdd"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "string->n", Required: 1, Function: PrimStringToNumber, CodeGen: "PrimStringToNumber"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "n->string", Required: 1, Function: PrimNumberToString, CodeGen: "PrimNumberToString"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "number?", Required: 1, Function: PrimIsNumber, CodeGen: "PrimIsNumber"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "string?", Required: 1, Function: PrimIsString, CodeGen: "PrimIsString"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "pos", Required: 2, Function: PrimPos, CodeGen: "PrimPos"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "tlstr", Required: 1, Function: PrimTailString, CodeGen: "PrimTailString"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "cn", Required: 2, Function: PrimStringConcat, CodeGen: "PrimStringConcat"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "intern", Required: 1, Function: PrimIntern, CodeGen: "PrimIntern"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "hd", Required: 1, Function: PrimHead, CodeGen: "PrimHead"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "tl", Required: 1, Function: PrimTail, CodeGen: "PrimTail"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "cons", Required: 2, Function: PrimCons, CodeGen: "PrimCons"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "cons?", Required: 1, Function: PrimIsPair, CodeGen: "PrimIsPair"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "value", Required: 1, CodeGen: "PrimValue"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "set", Required: 2, CodeGen: "PrimSet"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "not", Required: 1, Function: PrimNot, CodeGen: "PrimNot"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "if", Required: 3, Function: PrimIf, CodeGen: "PrimIf"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "symbol?", Required: 1, Function: PrimIsSymbol, CodeGen: "PrimIsSymbol"},
 	// &ScmPrimitive{scmHead: scmHeadPrimitive, Name: "hash", Required: 2, Function: primHash},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "read-file-as-bytelist", Required: 1, Function: primReadFileAsByteList},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "read-file-as-string", Required: 1, Function: primReadFileAsString},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "variable?", Required: 1, Function: primIsVariable},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "integer?", Required: 1, Function: primIsInteger},
-}
-
-var primitiveIdx map[string]*ScmPrimitive
-
-func init() {
-	primitiveIdx = make(map[string]*ScmPrimitive)
-	for i, prim := range allPrimitives {
-		prim.id = i
-		primitiveIdx[prim.Name] = prim
-	}
-}
-
-func GetPrimitiveByID(id int) *ScmPrimitive {
-	return allPrimitives[id]
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "read-file-as-bytelist", Required: 1, Function: PrimReadFileAsByteList, CodeGen: "PrimReadFileAsByteList"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "read-file-as-string", Required: 1, Function: PrimReadFileAsString, CodeGen: "PrimReadFileAsString"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "variable?", Required: 1, Function: PrimIsVariable, CodeGen: "PrimIsVariable"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "integer?", Required: 1, Function: PrimIsInteger, CodeGen: "PrimIsInteger"},
 }
 
 func PrimNumberAdd(args ...Obj) Obj {
@@ -78,25 +64,25 @@ func PrimNumberAdd(args ...Obj) Obj {
 	return MakeNumber(x1.val + y1.val)
 }
 
-func primNumberSubtract(args ...Obj) Obj {
+func PrimNumberSubtract(args ...Obj) Obj {
 	x1 := mustNumber(args[0])
 	y1 := mustNumber(args[1])
 	return MakeNumber(x1.val - y1.val)
 }
 
-func primNumberMultiply(args ...Obj) Obj {
+func PrimNumberMultiply(args ...Obj) Obj {
 	x1 := mustNumber(args[0])
 	y1 := mustNumber(args[1])
 	return MakeNumber(x1.val * y1.val)
 }
 
-func primNumberDivide(args ...Obj) Obj {
+func PrimNumberDivide(args ...Obj) Obj {
 	x1 := mustNumber(args[0])
 	y1 := mustNumber(args[1])
 	return MakeNumber(x1.val / y1.val)
 }
 
-func primIntern(args ...Obj) Obj {
+func PrimIntern(args ...Obj) Obj {
 	str := mustString(args[0])
 	switch str {
 	case "true":
@@ -111,29 +97,29 @@ func PrimHead(args ...Obj) Obj {
 	return car(args[0])
 }
 
-func primTail(args ...Obj) Obj {
+func PrimTail(args ...Obj) Obj {
 	return cdr(args[0])
 }
 
-func primIsNumber(args ...Obj) Obj {
+func PrimIsNumber(args ...Obj) Obj {
 	if *args[0] == scmHeadNumber {
 		return True
 	}
 	return False
 }
 
-func primStringToNumber(args ...Obj) Obj {
+func PrimStringToNumber(args ...Obj) Obj {
 	str := mustString(args[0])
 	n := ([]rune(str))[0]
 	return MakeInteger(int(n))
 }
 
-func primNumberToString(args ...Obj) Obj {
+func PrimNumberToString(args ...Obj) Obj {
 	n := mustInteger(args[0])
 	return MakeString(string(rune(n)))
 }
 
-func primStr(args ...Obj) Obj {
+func PrimStr(args ...Obj) Obj {
 	switch *args[0] {
 	case scmHeadPair:
 		// Pair may contain recursive list.
@@ -170,18 +156,18 @@ func primStr(args ...Obj) Obj {
 	case scmHeadRaw:
 		return MakeString("#<raw>")
 	default:
-		return MakeString("primStr unknown")
+		return MakeString("PrimStr unknown")
 	}
 	return MakeString("wrong input, the object is not atom ...")
 }
 
-func stringConcat(args ...Obj) Obj {
+func PrimStringConcat(args ...Obj) Obj {
 	s1 := mustString(args[0])
 	s2 := mustString(args[1])
 	return MakeString(s1 + s2)
 }
 
-func primTailString(args ...Obj) Obj {
+func PrimTailString(args ...Obj) Obj {
 	str := mustString(args[0])
 	if len(str) == 0 {
 		return MakeError("empty string")
@@ -189,7 +175,7 @@ func primTailString(args ...Obj) Obj {
 	return MakeString(string([]rune(str)[1:]))
 }
 
-func pos(args ...Obj) Obj {
+func PrimPos(args ...Obj) Obj {
 	s := []rune(mustString(args[0]))
 	n := mustInteger(args[1])
 	if n >= len(s) {
@@ -228,17 +214,17 @@ func PrimValue(key Obj) Obj {
 	return MakeError(fmt.Sprintf("variable %s not bound", symVal.str))
 }
 
-func simpleError(args ...Obj) Obj {
+func PrimSimpleError(args ...Obj) Obj {
 	str := mustString(args[0])
 	return MakeError(str)
 }
 
-func primErrorToString(args ...Obj) Obj {
+func PrimErrorToString(args ...Obj) Obj {
 	e := mustError(args[0])
 	return MakeString(e.err)
 }
 
-func greatThan(args ...Obj) Obj {
+func PrimGreatThan(args ...Obj) Obj {
 	x := mustNumber(args[0])
 	y := mustNumber(args[1])
 	if x.val > y.val {
@@ -247,7 +233,7 @@ func greatThan(args ...Obj) Obj {
 	return False
 }
 
-func lessThan(args ...Obj) Obj {
+func PrimLessThan(args ...Obj) Obj {
 	x := mustNumber(args[0])
 	y := mustNumber(args[1])
 	if x.val < y.val {
@@ -256,7 +242,7 @@ func lessThan(args ...Obj) Obj {
 	return False
 }
 
-func lessEqual(args ...Obj) Obj {
+func PrimLessEqual(args ...Obj) Obj {
 	x := mustNumber(args[0])
 	y := mustNumber(args[1])
 	if x.val <= y.val {
@@ -265,7 +251,7 @@ func lessEqual(args ...Obj) Obj {
 	return False
 }
 
-func greatEqual(args ...Obj) Obj {
+func PrimGreatEqual(args ...Obj) Obj {
 	x := mustNumber(args[0])
 	y := mustNumber(args[1])
 	if x.val >= y.val {
@@ -274,7 +260,7 @@ func greatEqual(args ...Obj) Obj {
 	return False
 }
 
-func primAbsvector(args ...Obj) Obj {
+func PrimAbsvector(args ...Obj) Obj {
 	n := mustInteger(args[0])
 	if n < 0 {
 		return MakeError("absvector wrong argument")
@@ -282,7 +268,7 @@ func primAbsvector(args ...Obj) Obj {
 	return MakeVector(n)
 }
 
-func primVectorSet(args ...Obj) Obj {
+func PrimVectorSet(args ...Obj) Obj {
 	vec := mustVector(args[0])
 	off := mustInteger(args[1])
 	val := args[2]
@@ -290,7 +276,7 @@ func primVectorSet(args ...Obj) Obj {
 	return args[0]
 }
 
-func primVectorGet(args ...Obj) Obj {
+func PrimVectorGet(args ...Obj) Obj {
 	vec := mustVector(args[0])
 	off := mustInteger(args[1])
 	if off >= len(vec) {
@@ -303,14 +289,14 @@ func primVectorGet(args ...Obj) Obj {
 	return ret
 }
 
-func isVector(args ...Obj) Obj {
+func PrimIsVector(args ...Obj) Obj {
 	if *args[0] == scmHeadVector {
 		return True
 	}
 	return False
 }
 
-func writeByte(args ...Obj) Obj {
+func PrimWriteByte(args ...Obj) Obj {
 	n := mustInteger(args[0])
 	s := mustStream(args[1])
 	w, ok := s.raw.(io.Writer)
@@ -326,7 +312,7 @@ func writeByte(args ...Obj) Obj {
 	return args[0]
 }
 
-func primReadByte(args ...Obj) Obj {
+func PrimReadByte(args ...Obj) Obj {
 	s := mustStream(args[0])
 	r, ok := s.raw.(io.Reader)
 	if !ok {
@@ -343,7 +329,7 @@ func primReadByte(args ...Obj) Obj {
 	return MakeInteger(int(buf[0]))
 }
 
-func openStream(args ...Obj) Obj {
+func PrimOpenStream(args ...Obj) Obj {
 	file := mustString(args[0])
 	var flag int
 	mode := GetSymbol(args[1])
@@ -363,14 +349,14 @@ func openStream(args ...Obj) Obj {
 	return MakeStream(f)
 }
 
-func closeStream(args ...Obj) Obj {
+func PrimCloseStream(args ...Obj) Obj {
 	s := mustStream(args[0])
 	c := s.raw.(io.Closer)
 	c.Close()
 	return Nil
 }
 
-func getTime(args ...Obj) Obj {
+func PrimGetTime(args ...Obj) Obj {
 	kind := GetSymbol(args[0])
 	switch kind {
 	case "unix":
@@ -381,54 +367,54 @@ func getTime(args ...Obj) Obj {
 	return MakeError(fmt.Sprintf("get-time does not understand the parameter %s", kind))
 }
 
-func typeFunc(args ...Obj) Obj {
+func PrimTypeFunc(args ...Obj) Obj {
 	// TODO: seems meanless
 	return args[0]
 }
 
-func primIsString(args ...Obj) Obj {
+func PrimIsString(args ...Obj) Obj {
 	if *args[0] == scmHeadString {
 		return True
 	}
 	return False
 }
 
-func primIsPair(args ...Obj) Obj {
+func PrimIsPair(args ...Obj) Obj {
 	if *args[0] == scmHeadPair {
 		return True
 	}
 	return False
 }
 
-func primNot(args ...Obj) Obj {
+func PrimNot(args ...Obj) Obj {
 	if args[0] == False {
 		return True
 	} else if args[0] == True {
 		return False
 	}
-	return MakeError("primNot")
+	return MakeError("PrimNot")
 
 }
 
-func primIf(args ...Obj) Obj {
+func PrimIf(args ...Obj) Obj {
 	switch args[0] {
 	case True:
 		return args[1]
 	case False:
 		return args[2]
 	}
-	return MakeError("primIf")
+	return MakeError("PrimIf")
 }
 
 func PrimEqual(args ...Obj) Obj {
 	return equal(args[0], args[1])
 }
 
-func primCons(args ...Obj) Obj {
+func PrimCons(args ...Obj) Obj {
 	return cons(args[0], args[1])
 }
 
-func primIsSymbol(args ...Obj) Obj {
+func PrimIsSymbol(args ...Obj) Obj {
 	if IsSymbol(args[0]) {
 		return True
 	}
@@ -491,7 +477,7 @@ func objHash(x Obj) int {
 	return sum
 }
 
-func primReadFileAsByteList(args ...Obj) Obj {
+func PrimReadFileAsByteList(args ...Obj) Obj {
 	fileName := mustString(args[0])
 	buf, err := ioutil.ReadFile(fileName)
 	if err != nil {
@@ -508,7 +494,7 @@ func primReadFileAsByteList(args ...Obj) Obj {
 	return cdr(ret)
 }
 
-func primReadFileAsString(args ...Obj) Obj {
+func PrimReadFileAsString(args ...Obj) Obj {
 	fileName := mustString(args[0])
 	buf, err := ioutil.ReadFile(fileName)
 	if err != nil {
@@ -518,7 +504,7 @@ func primReadFileAsString(args ...Obj) Obj {
 	return MakeString(string(buf))
 }
 
-func primIsVariable(args ...Obj) Obj {
+func PrimIsVariable(args ...Obj) Obj {
 	if *args[0] != scmHeadSymbol {
 		return False
 	}
@@ -530,7 +516,7 @@ func primIsVariable(args ...Obj) Obj {
 	return True
 }
 
-func primIsInteger(args ...Obj) Obj {
+func PrimIsInteger(args ...Obj) Obj {
 	if *args[0] != scmHeadNumber {
 		return False
 	}
@@ -539,4 +525,8 @@ func primIsInteger(args ...Obj) Obj {
 		return True
 	}
 	return False
+}
+
+func PrimEvalKL(args ...Obj) Obj {
+	panic("not implement")
 }

--- a/kl/primitives_test.go
+++ b/kl/primitives_test.go
@@ -2,31 +2,32 @@ package kl
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
 func TestReadByte(t *testing.T) {
 	buf := bytes.NewBufferString("a")
 	stream := MakeStream(buf)
-	b := primReadByte(stream)
+	b := PrimReadByte(stream)
 	if mustInteger(b) != 97 {
 		t.Error("should be 97")
 	}
 
-	b = primReadByte(stream)
+	b = PrimReadByte(stream)
 	if mustInteger(b) != -1 {
 		t.Error("read EOF should return -1")
 	}
 }
 
 func TestIntern(t *testing.T) {
-	if primIntern(MakeString("true")) != True {
+	if PrimIntern(MakeString("true")) != True {
 		t.Error("intern(true) should be boolean")
 	}
-	if primIntern(MakeString("false")) != False {
+	if PrimIntern(MakeString("false")) != False {
 		t.Error("intern(false) should be boolean")
 	}
-	if equal(primIntern(MakeString("asdf")), MakeSymbol("asdf")) != True {
+	if equal(PrimIntern(MakeString("asdf")), MakeSymbol("asdf")) != True {
 		t.FailNow()
 	}
 }
@@ -38,7 +39,7 @@ func TestHash(t *testing.T) {
 		MakeSymbol("sdsd"),
 		MakeString("sdsd"),
 		MakeError("sdsd"),
-		Obj(&allPrimitives[3].scmHead),
+		Obj(&AllPrimitives[3].scmHead),
 		True,
 		False,
 		Nil,
@@ -52,5 +53,11 @@ func TestHash(t *testing.T) {
 			t.FailNow()
 		}
 		m[hash] = o
+	}
+}
+
+func TestListAllPrimName(t *testing.T) {
+	for _, prim := range AllPrimitives {
+		fmt.Printf(" %s", prim.Name)
 	}
 }

--- a/kl/stub_test.go
+++ b/kl/stub_test.go
@@ -53,7 +53,7 @@ func init() {
 			ctx.Return(n)
 			return
 		} else {
-			n = primNumberSubtract(n, MakeInteger(1))
+			n = PrimNumberSubtract(n, MakeInteger(1))
 			ctx.TailApply(__defun_recur, n)
 			return
 		}
@@ -66,8 +66,8 @@ func init() {
 			ctx.Return(sum)
 			return
 		} else {
-			sum = primNumberMultiply(sum, n)
-			n = primNumberSubtract(n, MakeInteger(1))
+			sum = PrimNumberMultiply(sum, n)
+			n = PrimNumberSubtract(n, MakeInteger(1))
 			ctx.TailApply(__defun_fact, sum, n)
 			return
 		}

--- a/kl/types.go
+++ b/kl/types.go
@@ -76,10 +76,10 @@ type scmProcedure struct {
 
 type ScmPrimitive struct {
 	scmHead
-	id       int
 	Name     string
 	Required int
 	Function func(...Obj) Obj
+	CodeGen  string
 }
 
 type scmError struct {


### PR DESCRIPTION
This is a step prepared for generating Go code from Shen.
The following changes are contained in this commit:

- Add a 'CodeGen' field to the ScmPrimitive struct
- Export the allPrimitives variable
- Rename all primitives to PrimXXX