### PR TITLE
kl: support try-catch exception in stub.go

### DIFF
--- a/kl/primitives.go
+++ b/kl/primitives.go
@@ -28,7 +28,7 @@ var AllPrimitives = []*ScmPrimitive{
 	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "<", Required: 2, Function: PrimLessThan, CodeGen: "PrimLessThan"},
 	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: ">", Required: 2, Function: PrimGreatThan, CodeGen: "PrimGreatThan"},
 	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "error-to-string", Required: 1, Function: PrimErrorToString, CodeGen: "PrimErrorToString"},
-	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "simple-error", Required: 1, Function: PrimSimpleError, CodeGen: "PrimSimpleError"},
+	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "simple-error", Required: 1, Function: simpleError, CodeGen: "PrimSimpleError"},
 	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "=", Required: 2, Function: PrimEqual, CodeGen: "PrimEqual"},
 	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "-", Required: 2, Function: PrimNumberSubtract, CodeGen: "PrimNumberSubtract"},
 	&ScmPrimitive{scmHead: scmHeadPrimitive, Name: "*", Required: 2, Function: PrimNumberMultiply, CodeGen: "PrimNumberMultiply"},
@@ -214,7 +214,7 @@ func PrimValue(key Obj) Obj {
 	return MakeError(fmt.Sprintf("variable %s not bound", symVal.str))
 }
 
-func PrimSimpleError(args ...Obj) Obj {
+func simpleError(args ...Obj) Obj {
 	str := mustString(args[0])
 	return MakeError(str)
 }

--- a/kl/stub.go
+++ b/kl/stub.go
@@ -80,3 +80,32 @@ func Call(f Obj, args ...Obj) Obj {
 	}
 	return t.result
 }
+
+type tryResult struct {
+	data Obj
+}
+
+func Try(f Obj) (res tryResult) {
+	defer func() {
+		if err := recover(); err != nil {
+			val := err.(Obj)
+			res = tryResult{data: val}
+		}
+	}()
+	MustNative(f)
+	val := Call(f, Nil)
+	res = tryResult{data: val}
+	return
+}
+
+func (t tryResult) Catch(f Obj) Obj {
+	if IsError(t.data) {
+		return Call(f, t.data)
+	}
+	return t.data
+}
+
+func PrimSimpleError(args ...Obj) Obj {
+	str := mustString(args[0])
+	panic(MakeError(str))
+}


### PR DESCRIPTION
```
// (trap-error (+ 2 (simple-error "xxx")) (lambda X (error-to-string X)))

res := Try(MakeNative(func(ctx *Trampoline, args ...Obj) {
  regXX := MakeString("xxx")
  regYY := PrimSimpleError(regXX)
  res := PrimNumberAdd(MakeNumber(2), regYY)
  ctx.Return(res)
  return
}, 1)).Catch(MakeNative(func(ctx *Trampoline, args ...Obj) {
  err := args[0]
  res := PrimErrorToString(err)
  ctx.Return(res)
  return
}, 1))
```

Use `defer` and `panic` to implement `try-catch`.
`trap-error` may need this feature when translating the Shen code to Go.