### PR TITLE
kl: fix `kl -shen` panic and integration test

### DIFF
--- a/kl/evaluator.go
+++ b/kl/evaluator.go
@@ -90,7 +90,7 @@ func (e *Evaluator) LoadFile(file string) Obj {
 			break
 		}
 
-		res := e.evalExp(exp, nil)
+		res := e.evalExp(exp, Nil)
 		if *res == scmHeadError {
 			return res
 		}


### PR DESCRIPTION
Fix those two problem:

* evalExp(exp, env), env should be Nil, not nil
* evalTrapError() leave stale data the ControlFlow stack

The first one is, use command `kl -shen` can't start the binary.
The second, after `kl -shen` fixed, the test suite fail:

```
(load "README.shen")
(load "tests.shen")
```