### PR TITLE
*: refactor the Evaluator interface and the Call() function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ docker:
 	cp -a /tmp/shen ./shen
 
 test:
-	go test github.com/tiancaiamao/shen-go/kl
+	cd kl; go test

--- a/cmd/kl/main.go
+++ b/cmd/kl/main.go
@@ -52,8 +52,8 @@ func main() {
 
 	if shen {
 		e.BootstrapShen()
-		e.Eval(kl.Cons(kl.MakeSymbol("shen.initialise"), kl.Nil))
-		e.Eval(kl.Cons(kl.MakeSymbol("shen.repl"), kl.Nil))
+		kl.Eval(e, kl.Cons(kl.MakeSymbol("shen.initialise"), kl.Nil))
+		kl.Eval(e, kl.Cons(kl.MakeSymbol("shen.repl"), kl.Nil))
 		return
 	}
 
@@ -68,7 +68,7 @@ func main() {
 			break
 		}
 
-		res := e.Eval(sexp)
+		res := kl.Eval(e, sexp)
 		fmt.Println(kl.ObjString(res))
 	}
 }

--- a/cmd/shen/core.go
+++ b/cmd/shen/core.go
@@ -68,35 +68,35 @@ var __defun__shen_4err_1condition Obj             // shen.err-condition
 var __defun__shen_4sys_1error Obj                 // shen.sys-error
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg744 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg744)
+		__e.Return(reg744)
 		return
 	}, 0))
-	__defun__shen_4shen_1_6kl = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4shen_1_6kl = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V128 := __args[0]
 		_ = V128
 		V129 := __args[1]
 		_ = V129
-		reg745 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg745 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4_5define_6, X)
+			__e.TailApply(__defun__shen_4_5define_6, X)
 			return
 		}, 1)
 		reg747 := PrimCons(V128, V129)
-		reg748 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg748 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4shen_1syntax_1error, V128, X)
+			__e.TailApply(__defun__shen_4shen_1syntax_1error, V128, X)
 			return
 		}, 1)
-		__ctx.TailApply(__defun__compile, reg745, reg747, reg748)
+		__e.TailApply(__defun__compile, reg745, reg747, reg748)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.shen->kl", value: __defun__shen_4shen_1_6kl})
 
-	__defun__shen_4shen_1syntax_1error = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4shen_1syntax_1error = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V136 := __args[0]
 		_ = V136
 		V137 := __args[1]
@@ -107,134 +107,134 @@ func init() {
 			reg753 := MakeString(" here:\n\n ")
 			reg754 := MakeNumber(50)
 			reg755 := PrimHead(V137)
-			reg756 := __e.Call(__defun__shen_4next_150, reg754, reg755)
+			reg756 := Call(__e, __defun__shen_4next_150, reg754, reg755)
 			reg757 := MakeString("\n")
 			reg758 := MakeSymbol("shen.a")
-			reg759 := __e.Call(__defun__shen_4app, reg756, reg757, reg758)
+			reg759 := Call(__e, __defun__shen_4app, reg756, reg757, reg758)
 			reg760 := PrimStringConcat(reg753, reg759)
 			reg761 := MakeSymbol("shen.a")
-			reg762 := __e.Call(__defun__shen_4app, V136, reg760, reg761)
+			reg762 := Call(__e, __defun__shen_4app, V136, reg760, reg761)
 			reg763 := PrimStringConcat(reg752, reg762)
 			reg764 := PrimSimpleError(reg763)
-			__ctx.Return(reg764)
+			__e.Return(reg764)
 			return
 		} else {
 			reg765 := MakeString("syntax error in ")
 			reg766 := MakeString("\n")
 			reg767 := MakeSymbol("shen.a")
-			reg768 := __e.Call(__defun__shen_4app, V136, reg766, reg767)
+			reg768 := Call(__e, __defun__shen_4app, V136, reg766, reg767)
 			reg769 := PrimStringConcat(reg765, reg768)
 			reg770 := PrimSimpleError(reg769)
-			__ctx.Return(reg770)
+			__e.Return(reg770)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.shen-syntax-error", value: __defun__shen_4shen_1syntax_1error})
 
-	__defun__shen_4_5define_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5define_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V139 := __args[0]
 		_ = V139
-		reg771 := __e.Call(__defun__shen_4_5name_6, V139)
+		reg771 := Call(__e, __defun__shen_4_5name_6, V139)
 		Parse__shen_4_5name_6 := reg771
 		_ = Parse__shen_4_5name_6
-		reg772 := __e.Call(__defun__fail)
+		reg772 := Call(__e, __defun__fail)
 		reg773 := PrimEqual(reg772, Parse__shen_4_5name_6)
 		reg774 := PrimNot(reg773)
 		var reg793 Obj
 		if reg774 == True {
-			reg775 := __e.Call(__defun__shen_4_5signature_6, Parse__shen_4_5name_6)
+			reg775 := Call(__e, __defun__shen_4_5signature_6, Parse__shen_4_5name_6)
 			Parse__shen_4_5signature_6 := reg775
 			_ = Parse__shen_4_5signature_6
-			reg776 := __e.Call(__defun__fail)
+			reg776 := Call(__e, __defun__fail)
 			reg777 := PrimEqual(reg776, Parse__shen_4_5signature_6)
 			reg778 := PrimNot(reg777)
 			var reg791 Obj
 			if reg778 == True {
-				reg779 := __e.Call(__defun__shen_4_5rules_6, Parse__shen_4_5signature_6)
+				reg779 := Call(__e, __defun__shen_4_5rules_6, Parse__shen_4_5signature_6)
 				Parse__shen_4_5rules_6 := reg779
 				_ = Parse__shen_4_5rules_6
-				reg780 := __e.Call(__defun__fail)
+				reg780 := Call(__e, __defun__fail)
 				reg781 := PrimEqual(reg780, Parse__shen_4_5rules_6)
 				reg782 := PrimNot(reg781)
 				var reg789 Obj
 				if reg782 == True {
 					reg783 := PrimHead(Parse__shen_4_5rules_6)
-					reg784 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5name_6)
-					reg785 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5rules_6)
-					reg786 := __e.Call(__defun__shen_4compile__to__machine__code, reg784, reg785)
-					reg787 := __e.Call(__defun__shen_4pair, reg783, reg786)
+					reg784 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5name_6)
+					reg785 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5rules_6)
+					reg786 := Call(__e, __defun__shen_4compile__to__machine__code, reg784, reg785)
+					reg787 := Call(__e, __defun__shen_4pair, reg783, reg786)
 					reg789 = reg787
 				} else {
-					reg788 := __e.Call(__defun__fail)
+					reg788 := Call(__e, __defun__fail)
 					reg789 = reg788
 				}
 				reg791 = reg789
 			} else {
-				reg790 := __e.Call(__defun__fail)
+				reg790 := Call(__e, __defun__fail)
 				reg791 = reg790
 			}
 			reg793 = reg791
 		} else {
-			reg792 := __e.Call(__defun__fail)
+			reg792 := Call(__e, __defun__fail)
 			reg793 = reg792
 		}
 		YaccParse := reg793
 		_ = YaccParse
-		reg794 := __e.Call(__defun__fail)
+		reg794 := Call(__e, __defun__fail)
 		reg795 := PrimEqual(YaccParse, reg794)
 		if reg795 == True {
-			reg796 := __e.Call(__defun__shen_4_5name_6, V139)
+			reg796 := Call(__e, __defun__shen_4_5name_6, V139)
 			Parse__shen_4_5name_6 := reg796
 			_ = Parse__shen_4_5name_6
-			reg797 := __e.Call(__defun__fail)
+			reg797 := Call(__e, __defun__fail)
 			reg798 := PrimEqual(reg797, Parse__shen_4_5name_6)
 			reg799 := PrimNot(reg798)
 			if reg799 == True {
-				reg800 := __e.Call(__defun__shen_4_5rules_6, Parse__shen_4_5name_6)
+				reg800 := Call(__e, __defun__shen_4_5rules_6, Parse__shen_4_5name_6)
 				Parse__shen_4_5rules_6 := reg800
 				_ = Parse__shen_4_5rules_6
-				reg801 := __e.Call(__defun__fail)
+				reg801 := Call(__e, __defun__fail)
 				reg802 := PrimEqual(reg801, Parse__shen_4_5rules_6)
 				reg803 := PrimNot(reg802)
 				if reg803 == True {
 					reg804 := PrimHead(Parse__shen_4_5rules_6)
-					reg805 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5name_6)
-					reg806 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5rules_6)
-					reg807 := __e.Call(__defun__shen_4compile__to__machine__code, reg805, reg806)
-					__ctx.TailApply(__defun__shen_4pair, reg804, reg807)
+					reg805 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5name_6)
+					reg806 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5rules_6)
+					reg807 := Call(__e, __defun__shen_4compile__to__machine__code, reg805, reg806)
+					__e.TailApply(__defun__shen_4pair, reg804, reg807)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<define>", value: __defun__shen_4_5define_6})
 
-	__defun__shen_4_5name_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5name_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V141 := __args[0]
 		_ = V141
 		reg811 := PrimHead(V141)
 		reg812 := PrimIsPair(reg811)
 		if reg812 == True {
-			reg813 := __e.Call(__defun__shen_4hdhd, V141)
+			reg813 := Call(__e, __defun__shen_4hdhd, V141)
 			Parse__X := reg813
 			_ = Parse__X
-			reg814 := __e.Call(__defun__shen_4tlhd, V141)
-			reg815 := __e.Call(__defun__shen_4hdtl, V141)
-			reg816 := __e.Call(__defun__shen_4pair, reg814, reg815)
+			reg814 := Call(__e, __defun__shen_4tlhd, V141)
+			reg815 := Call(__e, __defun__shen_4hdtl, V141)
+			reg816 := Call(__e, __defun__shen_4pair, reg814, reg815)
 			reg817 := PrimHead(reg816)
 			reg818 := PrimIsSymbol(Parse__X)
 			var reg825 Obj
 			if reg818 == True {
-				reg819 := __e.Call(__defun__shen_4sysfunc_2, Parse__X)
+				reg819 := Call(__e, __defun__shen_4sysfunc_2, Parse__X)
 				reg820 := PrimNot(reg819)
 				var reg823 Obj
 				if reg820 == True {
@@ -255,20 +255,20 @@ func init() {
 			} else {
 				reg826 := MakeString(" is not a legitimate function name.\n")
 				reg827 := MakeSymbol("shen.a")
-				reg828 := __e.Call(__defun__shen_4app, Parse__X, reg826, reg827)
+				reg828 := Call(__e, __defun__shen_4app, Parse__X, reg826, reg827)
 				reg829 := PrimSimpleError(reg828)
 				reg830 = reg829
 			}
-			__ctx.TailApply(__defun__shen_4pair, reg817, reg830)
+			__e.TailApply(__defun__shen_4pair, reg817, reg830)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<name>", value: __defun__shen_4_5name_6})
 
-	__defun__shen_4sysfunc_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4sysfunc_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V143 := __args[0]
 		_ = V143
 		reg833 := MakeString("shen")
@@ -276,13 +276,13 @@ func init() {
 		reg835 := MakeSymbol("shen.external-symbols")
 		reg836 := MakeSymbol("*property-vector*")
 		reg837 := PrimValue(reg836)
-		reg838 := __e.Call(__defun__get, reg834, reg835, reg837)
-		__ctx.TailApply(__defun__element_2, V143, reg838)
+		reg838 := Call(__e, __defun__get, reg834, reg835, reg837)
+		__e.TailApply(__defun__element_2, V143, reg838)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.sysfunc?", value: __defun__shen_4sysfunc_2})
 
-	__defun__shen_4_5signature_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5signature_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V147 := __args[0]
 		_ = V147
 		reg840 := PrimHead(V147)
@@ -290,7 +290,7 @@ func init() {
 		var reg849 Obj
 		if reg841 == True {
 			reg842 := MakeSymbol("{")
-			reg843 := __e.Call(__defun__shen_4hdhd, V147)
+			reg843 := Call(__e, __defun__shen_4hdhd, V147)
 			reg844 := PrimEqual(reg842, reg843)
 			var reg847 Obj
 			if reg844 == True {
@@ -306,15 +306,15 @@ func init() {
 			reg849 = reg848
 		}
 		if reg849 == True {
-			reg850 := __e.Call(__defun__shen_4tlhd, V147)
-			reg851 := __e.Call(__defun__shen_4hdtl, V147)
-			reg852 := __e.Call(__defun__shen_4pair, reg850, reg851)
+			reg850 := Call(__e, __defun__shen_4tlhd, V147)
+			reg851 := Call(__e, __defun__shen_4hdtl, V147)
+			reg852 := Call(__e, __defun__shen_4pair, reg850, reg851)
 			NewStream144 := reg852
 			_ = NewStream144
-			reg853 := __e.Call(__defun__shen_4_5signature_1help_6, NewStream144)
+			reg853 := Call(__e, __defun__shen_4_5signature_1help_6, NewStream144)
 			Parse__shen_4_5signature_1help_6 := reg853
 			_ = Parse__shen_4_5signature_1help_6
-			reg854 := __e.Call(__defun__fail)
+			reg854 := Call(__e, __defun__fail)
 			reg855 := PrimEqual(reg854, Parse__shen_4_5signature_1help_6)
 			reg856 := PrimNot(reg855)
 			if reg856 == True {
@@ -323,7 +323,7 @@ func init() {
 				var reg866 Obj
 				if reg858 == True {
 					reg859 := MakeSymbol("}")
-					reg860 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5signature_1help_6)
+					reg860 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5signature_1help_6)
 					reg861 := PrimEqual(reg859, reg860)
 					var reg864 Obj
 					if reg861 == True {
@@ -339,42 +339,42 @@ func init() {
 					reg866 = reg865
 				}
 				if reg866 == True {
-					reg867 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5signature_1help_6)
-					reg868 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5signature_1help_6)
-					reg869 := __e.Call(__defun__shen_4pair, reg867, reg868)
+					reg867 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5signature_1help_6)
+					reg868 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5signature_1help_6)
+					reg869 := Call(__e, __defun__shen_4pair, reg867, reg868)
 					NewStream145 := reg869
 					_ = NewStream145
 					reg870 := PrimHead(NewStream145)
-					reg871 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5signature_1help_6)
-					reg872 := __e.Call(__defun__shen_4curry_1type, reg871)
-					reg873 := __e.Call(__defun__shen_4demodulate, reg872)
-					__ctx.TailApply(__defun__shen_4pair, reg870, reg873)
+					reg871 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5signature_1help_6)
+					reg872 := Call(__e, __defun__shen_4curry_1type, reg871)
+					reg873 := Call(__e, __defun__shen_4demodulate, reg872)
+					__e.TailApply(__defun__shen_4pair, reg870, reg873)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<signature>", value: __defun__shen_4_5signature_6})
 
-	__defun__shen_4curry_1type = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4curry_1type = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V149 := __args[0]
 		_ = V149
-		reg878 := __e.Call(__defun__shen_4curry_1type_1h, V149)
-		__ctx.TailApply(__defun__shen_4active_1cons, reg878)
+		reg878 := Call(__e, __defun__shen_4curry_1type_1h, V149)
+		__e.TailApply(__defun__shen_4active_1cons, reg878)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.curry-type", value: __defun__shen_4curry_1type})
 
-	__defun__shen_4active_1cons = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4active_1cons = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V151 := __args[0]
 		_ = V151
 		reg880 := PrimIsPair(V151)
@@ -454,33 +454,33 @@ func init() {
 		}
 		if reg914 == True {
 			reg915 := PrimHead(V151)
-			reg916 := __e.Call(__defun__shen_4active_1cons, reg915)
+			reg916 := Call(__e, __defun__shen_4active_1cons, reg915)
 			reg917 := PrimTail(V151)
 			reg918 := PrimTail(reg917)
 			reg919 := PrimHead(reg918)
-			reg920 := __e.Call(__defun__shen_4active_1cons, reg919)
+			reg920 := Call(__e, __defun__shen_4active_1cons, reg919)
 			reg921 := PrimCons(reg916, reg920)
-			__ctx.Return(reg921)
+			__e.Return(reg921)
 			return
 		} else {
 			reg922 := PrimIsPair(V151)
 			if reg922 == True {
 				reg923 := PrimHead(V151)
-				reg924 := __e.Call(__defun__shen_4active_1cons, reg923)
+				reg924 := Call(__e, __defun__shen_4active_1cons, reg923)
 				reg925 := PrimTail(V151)
-				reg926 := __e.Call(__defun__shen_4active_1cons, reg925)
+				reg926 := Call(__e, __defun__shen_4active_1cons, reg925)
 				reg927 := PrimCons(reg924, reg926)
-				__ctx.Return(reg927)
+				__e.Return(reg927)
 				return
 			} else {
-				__ctx.Return(V151)
+				__e.Return(V151)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.active-cons", value: __defun__shen_4active_1cons})
 
-	__defun__shen_4curry_1type_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4curry_1type_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V153 := __args[0]
 		_ = V153
 		reg928 := PrimIsPair(V153)
@@ -587,7 +587,7 @@ func init() {
 			reg978 := PrimCons(reg976, reg977)
 			reg979 := PrimCons(reg974, reg978)
 			reg980 := PrimCons(reg973, reg979)
-			__ctx.TailApply(__defun__shen_4curry_1type_1h, reg980)
+			__e.TailApply(__defun__shen_4curry_1type_1h, reg980)
 			return
 		} else {
 			reg982 := PrimIsPair(V153)
@@ -694,21 +694,21 @@ func init() {
 				reg1032 := PrimCons(reg1030, reg1031)
 				reg1033 := PrimCons(reg1028, reg1032)
 				reg1034 := PrimCons(reg1027, reg1033)
-				__ctx.TailApply(__defun__shen_4curry_1type_1h, reg1034)
+				__e.TailApply(__defun__shen_4curry_1type_1h, reg1034)
 				return
 			} else {
 				reg1036 := PrimIsPair(V153)
 				if reg1036 == True {
-					reg1037 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg1037 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						Z := __args[0]
 						_ = Z
-						__ctx.TailApply(__defun__shen_4curry_1type_1h, Z)
+						__e.TailApply(__defun__shen_4curry_1type_1h, Z)
 						return
 					}, 1)
-					__ctx.TailApply(__defun__map, reg1037, V153)
+					__e.TailApply(__defun__map, reg1037, V153)
 					return
 				} else {
-					__ctx.Return(V153)
+					__e.Return(V153)
 					return
 				}
 			}
@@ -716,23 +716,23 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.curry-type-h", value: __defun__shen_4curry_1type_1h})
 
-	__defun__shen_4_5signature_1help_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5signature_1help_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V155 := __args[0]
 		_ = V155
 		reg1040 := PrimHead(V155)
 		reg1041 := PrimIsPair(reg1040)
 		var reg1066 Obj
 		if reg1041 == True {
-			reg1042 := __e.Call(__defun__shen_4hdhd, V155)
+			reg1042 := Call(__e, __defun__shen_4hdhd, V155)
 			Parse__X := reg1042
 			_ = Parse__X
-			reg1043 := __e.Call(__defun__shen_4tlhd, V155)
-			reg1044 := __e.Call(__defun__shen_4hdtl, V155)
-			reg1045 := __e.Call(__defun__shen_4pair, reg1043, reg1044)
-			reg1046 := __e.Call(__defun__shen_4_5signature_1help_6, reg1045)
+			reg1043 := Call(__e, __defun__shen_4tlhd, V155)
+			reg1044 := Call(__e, __defun__shen_4hdtl, V155)
+			reg1045 := Call(__e, __defun__shen_4pair, reg1043, reg1044)
+			reg1046 := Call(__e, __defun__shen_4_5signature_1help_6, reg1045)
 			Parse__shen_4_5signature_1help_6 := reg1046
 			_ = Parse__shen_4_5signature_1help_6
-			reg1047 := __e.Call(__defun__fail)
+			reg1047 := Call(__e, __defun__fail)
 			reg1048 := PrimEqual(reg1047, Parse__shen_4_5signature_1help_6)
 			reg1049 := PrimNot(reg1048)
 			var reg1064 Obj
@@ -742,128 +742,128 @@ func init() {
 				reg1052 := Nil
 				reg1053 := PrimCons(reg1051, reg1052)
 				reg1054 := PrimCons(reg1050, reg1053)
-				reg1055 := __e.Call(__defun__element_2, Parse__X, reg1054)
+				reg1055 := Call(__e, __defun__element_2, Parse__X, reg1054)
 				reg1056 := PrimNot(reg1055)
 				var reg1062 Obj
 				if reg1056 == True {
 					reg1057 := PrimHead(Parse__shen_4_5signature_1help_6)
-					reg1058 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5signature_1help_6)
+					reg1058 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5signature_1help_6)
 					reg1059 := PrimCons(Parse__X, reg1058)
-					reg1060 := __e.Call(__defun__shen_4pair, reg1057, reg1059)
+					reg1060 := Call(__e, __defun__shen_4pair, reg1057, reg1059)
 					reg1062 = reg1060
 				} else {
-					reg1061 := __e.Call(__defun__fail)
+					reg1061 := Call(__e, __defun__fail)
 					reg1062 = reg1061
 				}
 				reg1064 = reg1062
 			} else {
-				reg1063 := __e.Call(__defun__fail)
+				reg1063 := Call(__e, __defun__fail)
 				reg1064 = reg1063
 			}
 			reg1066 = reg1064
 		} else {
-			reg1065 := __e.Call(__defun__fail)
+			reg1065 := Call(__e, __defun__fail)
 			reg1066 = reg1065
 		}
 		YaccParse := reg1066
 		_ = YaccParse
-		reg1067 := __e.Call(__defun__fail)
+		reg1067 := Call(__e, __defun__fail)
 		reg1068 := PrimEqual(YaccParse, reg1067)
 		if reg1068 == True {
-			reg1069 := __e.Call(__defun___5e_6, V155)
+			reg1069 := Call(__e, __defun___5e_6, V155)
 			Parse___5e_6 := reg1069
 			_ = Parse___5e_6
-			reg1070 := __e.Call(__defun__fail)
+			reg1070 := Call(__e, __defun__fail)
 			reg1071 := PrimEqual(reg1070, Parse___5e_6)
 			reg1072 := PrimNot(reg1071)
 			if reg1072 == True {
 				reg1073 := PrimHead(Parse___5e_6)
 				reg1074 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg1073, reg1074)
+				__e.TailApply(__defun__shen_4pair, reg1073, reg1074)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<signature-help>", value: __defun__shen_4_5signature_1help_6})
 
-	__defun__shen_4_5rules_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5rules_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V157 := __args[0]
 		_ = V157
-		reg1077 := __e.Call(__defun__shen_4_5rule_6, V157)
+		reg1077 := Call(__e, __defun__shen_4_5rule_6, V157)
 		Parse__shen_4_5rule_6 := reg1077
 		_ = Parse__shen_4_5rule_6
-		reg1078 := __e.Call(__defun__fail)
+		reg1078 := Call(__e, __defun__fail)
 		reg1079 := PrimEqual(reg1078, Parse__shen_4_5rule_6)
 		reg1080 := PrimNot(reg1079)
 		var reg1094 Obj
 		if reg1080 == True {
-			reg1081 := __e.Call(__defun__shen_4_5rules_6, Parse__shen_4_5rule_6)
+			reg1081 := Call(__e, __defun__shen_4_5rules_6, Parse__shen_4_5rule_6)
 			Parse__shen_4_5rules_6 := reg1081
 			_ = Parse__shen_4_5rules_6
-			reg1082 := __e.Call(__defun__fail)
+			reg1082 := Call(__e, __defun__fail)
 			reg1083 := PrimEqual(reg1082, Parse__shen_4_5rules_6)
 			reg1084 := PrimNot(reg1083)
 			var reg1092 Obj
 			if reg1084 == True {
 				reg1085 := PrimHead(Parse__shen_4_5rules_6)
-				reg1086 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5rule_6)
-				reg1087 := __e.Call(__defun__shen_4linearise, reg1086)
-				reg1088 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5rules_6)
+				reg1086 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5rule_6)
+				reg1087 := Call(__e, __defun__shen_4linearise, reg1086)
+				reg1088 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5rules_6)
 				reg1089 := PrimCons(reg1087, reg1088)
-				reg1090 := __e.Call(__defun__shen_4pair, reg1085, reg1089)
+				reg1090 := Call(__e, __defun__shen_4pair, reg1085, reg1089)
 				reg1092 = reg1090
 			} else {
-				reg1091 := __e.Call(__defun__fail)
+				reg1091 := Call(__e, __defun__fail)
 				reg1092 = reg1091
 			}
 			reg1094 = reg1092
 		} else {
-			reg1093 := __e.Call(__defun__fail)
+			reg1093 := Call(__e, __defun__fail)
 			reg1094 = reg1093
 		}
 		YaccParse := reg1094
 		_ = YaccParse
-		reg1095 := __e.Call(__defun__fail)
+		reg1095 := Call(__e, __defun__fail)
 		reg1096 := PrimEqual(YaccParse, reg1095)
 		if reg1096 == True {
-			reg1097 := __e.Call(__defun__shen_4_5rule_6, V157)
+			reg1097 := Call(__e, __defun__shen_4_5rule_6, V157)
 			Parse__shen_4_5rule_6 := reg1097
 			_ = Parse__shen_4_5rule_6
-			reg1098 := __e.Call(__defun__fail)
+			reg1098 := Call(__e, __defun__fail)
 			reg1099 := PrimEqual(reg1098, Parse__shen_4_5rule_6)
 			reg1100 := PrimNot(reg1099)
 			if reg1100 == True {
 				reg1101 := PrimHead(Parse__shen_4_5rule_6)
-				reg1102 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5rule_6)
-				reg1103 := __e.Call(__defun__shen_4linearise, reg1102)
+				reg1102 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5rule_6)
+				reg1103 := Call(__e, __defun__shen_4linearise, reg1102)
 				reg1104 := Nil
 				reg1105 := PrimCons(reg1103, reg1104)
-				__ctx.TailApply(__defun__shen_4pair, reg1101, reg1105)
+				__e.TailApply(__defun__shen_4pair, reg1101, reg1105)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<rules>", value: __defun__shen_4_5rules_6})
 
-	__defun__shen_4_5rule_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5rule_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V165 := __args[0]
 		_ = V165
-		reg1108 := __e.Call(__defun__shen_4_5patterns_6, V165)
+		reg1108 := Call(__e, __defun__shen_4_5patterns_6, V165)
 		Parse__shen_4_5patterns_6 := reg1108
 		_ = Parse__shen_4_5patterns_6
-		reg1109 := __e.Call(__defun__fail)
+		reg1109 := Call(__e, __defun__fail)
 		reg1110 := PrimEqual(reg1109, Parse__shen_4_5patterns_6)
 		reg1111 := PrimNot(reg1110)
 		var reg1168 Obj
@@ -873,7 +873,7 @@ func init() {
 			var reg1121 Obj
 			if reg1113 == True {
 				reg1114 := MakeSymbol("->")
-				reg1115 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5patterns_6)
+				reg1115 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5patterns_6)
 				reg1116 := PrimEqual(reg1114, reg1115)
 				var reg1119 Obj
 				if reg1116 == True {
@@ -890,15 +890,15 @@ func init() {
 			}
 			var reg1166 Obj
 			if reg1121 == True {
-				reg1122 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5patterns_6)
-				reg1123 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5patterns_6)
-				reg1124 := __e.Call(__defun__shen_4pair, reg1122, reg1123)
+				reg1122 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5patterns_6)
+				reg1123 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5patterns_6)
+				reg1124 := Call(__e, __defun__shen_4pair, reg1122, reg1123)
 				NewStream158 := reg1124
 				_ = NewStream158
-				reg1125 := __e.Call(__defun__shen_4_5action_6, NewStream158)
+				reg1125 := Call(__e, __defun__shen_4_5action_6, NewStream158)
 				Parse__shen_4_5action_6 := reg1125
 				_ = Parse__shen_4_5action_6
-				reg1126 := __e.Call(__defun__fail)
+				reg1126 := Call(__e, __defun__fail)
 				reg1127 := PrimEqual(reg1126, Parse__shen_4_5action_6)
 				reg1128 := PrimNot(reg1127)
 				var reg1164 Obj
@@ -908,7 +908,7 @@ func init() {
 					var reg1138 Obj
 					if reg1130 == True {
 						reg1131 := MakeSymbol("where")
-						reg1132 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5action_6)
+						reg1132 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5action_6)
 						reg1133 := PrimEqual(reg1131, reg1132)
 						var reg1136 Obj
 						if reg1133 == True {
@@ -925,24 +925,24 @@ func init() {
 					}
 					var reg1162 Obj
 					if reg1138 == True {
-						reg1139 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5action_6)
-						reg1140 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5action_6)
-						reg1141 := __e.Call(__defun__shen_4pair, reg1139, reg1140)
+						reg1139 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5action_6)
+						reg1140 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5action_6)
+						reg1141 := Call(__e, __defun__shen_4pair, reg1139, reg1140)
 						NewStream159 := reg1141
 						_ = NewStream159
-						reg1142 := __e.Call(__defun__shen_4_5guard_6, NewStream159)
+						reg1142 := Call(__e, __defun__shen_4_5guard_6, NewStream159)
 						Parse__shen_4_5guard_6 := reg1142
 						_ = Parse__shen_4_5guard_6
-						reg1143 := __e.Call(__defun__fail)
+						reg1143 := Call(__e, __defun__fail)
 						reg1144 := PrimEqual(reg1143, Parse__shen_4_5guard_6)
 						reg1145 := PrimNot(reg1144)
 						var reg1160 Obj
 						if reg1145 == True {
 							reg1146 := PrimHead(Parse__shen_4_5guard_6)
-							reg1147 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5patterns_6)
+							reg1147 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5patterns_6)
 							reg1148 := MakeSymbol("where")
-							reg1149 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5guard_6)
-							reg1150 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5action_6)
+							reg1149 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5guard_6)
+							reg1150 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5action_6)
 							reg1151 := Nil
 							reg1152 := PrimCons(reg1150, reg1151)
 							reg1153 := PrimCons(reg1149, reg1152)
@@ -950,41 +950,41 @@ func init() {
 							reg1155 := Nil
 							reg1156 := PrimCons(reg1154, reg1155)
 							reg1157 := PrimCons(reg1147, reg1156)
-							reg1158 := __e.Call(__defun__shen_4pair, reg1146, reg1157)
+							reg1158 := Call(__e, __defun__shen_4pair, reg1146, reg1157)
 							reg1160 = reg1158
 						} else {
-							reg1159 := __e.Call(__defun__fail)
+							reg1159 := Call(__e, __defun__fail)
 							reg1160 = reg1159
 						}
 						reg1162 = reg1160
 					} else {
-						reg1161 := __e.Call(__defun__fail)
+						reg1161 := Call(__e, __defun__fail)
 						reg1162 = reg1161
 					}
 					reg1164 = reg1162
 				} else {
-					reg1163 := __e.Call(__defun__fail)
+					reg1163 := Call(__e, __defun__fail)
 					reg1164 = reg1163
 				}
 				reg1166 = reg1164
 			} else {
-				reg1165 := __e.Call(__defun__fail)
+				reg1165 := Call(__e, __defun__fail)
 				reg1166 = reg1165
 			}
 			reg1168 = reg1166
 		} else {
-			reg1167 := __e.Call(__defun__fail)
+			reg1167 := Call(__e, __defun__fail)
 			reg1168 = reg1167
 		}
 		YaccParse := reg1168
 		_ = YaccParse
-		reg1169 := __e.Call(__defun__fail)
+		reg1169 := Call(__e, __defun__fail)
 		reg1170 := PrimEqual(YaccParse, reg1169)
 		if reg1170 == True {
-			reg1171 := __e.Call(__defun__shen_4_5patterns_6, V165)
+			reg1171 := Call(__e, __defun__shen_4_5patterns_6, V165)
 			Parse__shen_4_5patterns_6 := reg1171
 			_ = Parse__shen_4_5patterns_6
-			reg1172 := __e.Call(__defun__fail)
+			reg1172 := Call(__e, __defun__fail)
 			reg1173 := PrimEqual(reg1172, Parse__shen_4_5patterns_6)
 			reg1174 := PrimNot(reg1173)
 			var reg1204 Obj
@@ -994,7 +994,7 @@ func init() {
 				var reg1184 Obj
 				if reg1176 == True {
 					reg1177 := MakeSymbol("->")
-					reg1178 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5patterns_6)
+					reg1178 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5patterns_6)
 					reg1179 := PrimEqual(reg1177, reg1178)
 					var reg1182 Obj
 					if reg1179 == True {
@@ -1011,50 +1011,50 @@ func init() {
 				}
 				var reg1202 Obj
 				if reg1184 == True {
-					reg1185 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5patterns_6)
-					reg1186 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5patterns_6)
-					reg1187 := __e.Call(__defun__shen_4pair, reg1185, reg1186)
+					reg1185 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5patterns_6)
+					reg1186 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5patterns_6)
+					reg1187 := Call(__e, __defun__shen_4pair, reg1185, reg1186)
 					NewStream160 := reg1187
 					_ = NewStream160
-					reg1188 := __e.Call(__defun__shen_4_5action_6, NewStream160)
+					reg1188 := Call(__e, __defun__shen_4_5action_6, NewStream160)
 					Parse__shen_4_5action_6 := reg1188
 					_ = Parse__shen_4_5action_6
-					reg1189 := __e.Call(__defun__fail)
+					reg1189 := Call(__e, __defun__fail)
 					reg1190 := PrimEqual(reg1189, Parse__shen_4_5action_6)
 					reg1191 := PrimNot(reg1190)
 					var reg1200 Obj
 					if reg1191 == True {
 						reg1192 := PrimHead(Parse__shen_4_5action_6)
-						reg1193 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5patterns_6)
-						reg1194 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5action_6)
+						reg1193 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5patterns_6)
+						reg1194 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5action_6)
 						reg1195 := Nil
 						reg1196 := PrimCons(reg1194, reg1195)
 						reg1197 := PrimCons(reg1193, reg1196)
-						reg1198 := __e.Call(__defun__shen_4pair, reg1192, reg1197)
+						reg1198 := Call(__e, __defun__shen_4pair, reg1192, reg1197)
 						reg1200 = reg1198
 					} else {
-						reg1199 := __e.Call(__defun__fail)
+						reg1199 := Call(__e, __defun__fail)
 						reg1200 = reg1199
 					}
 					reg1202 = reg1200
 				} else {
-					reg1201 := __e.Call(__defun__fail)
+					reg1201 := Call(__e, __defun__fail)
 					reg1202 = reg1201
 				}
 				reg1204 = reg1202
 			} else {
-				reg1203 := __e.Call(__defun__fail)
+				reg1203 := Call(__e, __defun__fail)
 				reg1204 = reg1203
 			}
 			YaccParse := reg1204
 			_ = YaccParse
-			reg1205 := __e.Call(__defun__fail)
+			reg1205 := Call(__e, __defun__fail)
 			reg1206 := PrimEqual(YaccParse, reg1205)
 			if reg1206 == True {
-				reg1207 := __e.Call(__defun__shen_4_5patterns_6, V165)
+				reg1207 := Call(__e, __defun__shen_4_5patterns_6, V165)
 				Parse__shen_4_5patterns_6 := reg1207
 				_ = Parse__shen_4_5patterns_6
-				reg1208 := __e.Call(__defun__fail)
+				reg1208 := Call(__e, __defun__fail)
 				reg1209 := PrimEqual(reg1208, Parse__shen_4_5patterns_6)
 				reg1210 := PrimNot(reg1209)
 				var reg1271 Obj
@@ -1064,7 +1064,7 @@ func init() {
 					var reg1220 Obj
 					if reg1212 == True {
 						reg1213 := MakeSymbol("<-")
-						reg1214 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5patterns_6)
+						reg1214 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5patterns_6)
 						reg1215 := PrimEqual(reg1213, reg1214)
 						var reg1218 Obj
 						if reg1215 == True {
@@ -1081,15 +1081,15 @@ func init() {
 					}
 					var reg1269 Obj
 					if reg1220 == True {
-						reg1221 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5patterns_6)
-						reg1222 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5patterns_6)
-						reg1223 := __e.Call(__defun__shen_4pair, reg1221, reg1222)
+						reg1221 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5patterns_6)
+						reg1222 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5patterns_6)
+						reg1223 := Call(__e, __defun__shen_4pair, reg1221, reg1222)
 						NewStream161 := reg1223
 						_ = NewStream161
-						reg1224 := __e.Call(__defun__shen_4_5action_6, NewStream161)
+						reg1224 := Call(__e, __defun__shen_4_5action_6, NewStream161)
 						Parse__shen_4_5action_6 := reg1224
 						_ = Parse__shen_4_5action_6
-						reg1225 := __e.Call(__defun__fail)
+						reg1225 := Call(__e, __defun__fail)
 						reg1226 := PrimEqual(reg1225, Parse__shen_4_5action_6)
 						reg1227 := PrimNot(reg1226)
 						var reg1267 Obj
@@ -1099,7 +1099,7 @@ func init() {
 							var reg1237 Obj
 							if reg1229 == True {
 								reg1230 := MakeSymbol("where")
-								reg1231 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5action_6)
+								reg1231 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5action_6)
 								reg1232 := PrimEqual(reg1230, reg1231)
 								var reg1235 Obj
 								if reg1232 == True {
@@ -1116,25 +1116,25 @@ func init() {
 							}
 							var reg1265 Obj
 							if reg1237 == True {
-								reg1238 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5action_6)
-								reg1239 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5action_6)
-								reg1240 := __e.Call(__defun__shen_4pair, reg1238, reg1239)
+								reg1238 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5action_6)
+								reg1239 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5action_6)
+								reg1240 := Call(__e, __defun__shen_4pair, reg1238, reg1239)
 								NewStream162 := reg1240
 								_ = NewStream162
-								reg1241 := __e.Call(__defun__shen_4_5guard_6, NewStream162)
+								reg1241 := Call(__e, __defun__shen_4_5guard_6, NewStream162)
 								Parse__shen_4_5guard_6 := reg1241
 								_ = Parse__shen_4_5guard_6
-								reg1242 := __e.Call(__defun__fail)
+								reg1242 := Call(__e, __defun__fail)
 								reg1243 := PrimEqual(reg1242, Parse__shen_4_5guard_6)
 								reg1244 := PrimNot(reg1243)
 								var reg1263 Obj
 								if reg1244 == True {
 									reg1245 := PrimHead(Parse__shen_4_5guard_6)
-									reg1246 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5patterns_6)
+									reg1246 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5patterns_6)
 									reg1247 := MakeSymbol("where")
-									reg1248 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5guard_6)
+									reg1248 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5guard_6)
 									reg1249 := MakeSymbol("shen.choicepoint!")
-									reg1250 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5action_6)
+									reg1250 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5action_6)
 									reg1251 := Nil
 									reg1252 := PrimCons(reg1250, reg1251)
 									reg1253 := PrimCons(reg1249, reg1252)
@@ -1145,41 +1145,41 @@ func init() {
 									reg1258 := Nil
 									reg1259 := PrimCons(reg1257, reg1258)
 									reg1260 := PrimCons(reg1246, reg1259)
-									reg1261 := __e.Call(__defun__shen_4pair, reg1245, reg1260)
+									reg1261 := Call(__e, __defun__shen_4pair, reg1245, reg1260)
 									reg1263 = reg1261
 								} else {
-									reg1262 := __e.Call(__defun__fail)
+									reg1262 := Call(__e, __defun__fail)
 									reg1263 = reg1262
 								}
 								reg1265 = reg1263
 							} else {
-								reg1264 := __e.Call(__defun__fail)
+								reg1264 := Call(__e, __defun__fail)
 								reg1265 = reg1264
 							}
 							reg1267 = reg1265
 						} else {
-							reg1266 := __e.Call(__defun__fail)
+							reg1266 := Call(__e, __defun__fail)
 							reg1267 = reg1266
 						}
 						reg1269 = reg1267
 					} else {
-						reg1268 := __e.Call(__defun__fail)
+						reg1268 := Call(__e, __defun__fail)
 						reg1269 = reg1268
 					}
 					reg1271 = reg1269
 				} else {
-					reg1270 := __e.Call(__defun__fail)
+					reg1270 := Call(__e, __defun__fail)
 					reg1271 = reg1270
 				}
 				YaccParse := reg1271
 				_ = YaccParse
-				reg1272 := __e.Call(__defun__fail)
+				reg1272 := Call(__e, __defun__fail)
 				reg1273 := PrimEqual(YaccParse, reg1272)
 				if reg1273 == True {
-					reg1274 := __e.Call(__defun__shen_4_5patterns_6, V165)
+					reg1274 := Call(__e, __defun__shen_4_5patterns_6, V165)
 					Parse__shen_4_5patterns_6 := reg1274
 					_ = Parse__shen_4_5patterns_6
-					reg1275 := __e.Call(__defun__fail)
+					reg1275 := Call(__e, __defun__fail)
 					reg1276 := PrimEqual(reg1275, Parse__shen_4_5patterns_6)
 					reg1277 := PrimNot(reg1276)
 					if reg1277 == True {
@@ -1188,7 +1188,7 @@ func init() {
 						var reg1287 Obj
 						if reg1279 == True {
 							reg1280 := MakeSymbol("<-")
-							reg1281 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5patterns_6)
+							reg1281 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5patterns_6)
 							reg1282 := PrimEqual(reg1280, reg1281)
 							var reg1285 Obj
 							if reg1282 == True {
@@ -1204,159 +1204,159 @@ func init() {
 							reg1287 = reg1286
 						}
 						if reg1287 == True {
-							reg1288 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5patterns_6)
-							reg1289 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5patterns_6)
-							reg1290 := __e.Call(__defun__shen_4pair, reg1288, reg1289)
+							reg1288 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5patterns_6)
+							reg1289 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5patterns_6)
+							reg1290 := Call(__e, __defun__shen_4pair, reg1288, reg1289)
 							NewStream163 := reg1290
 							_ = NewStream163
-							reg1291 := __e.Call(__defun__shen_4_5action_6, NewStream163)
+							reg1291 := Call(__e, __defun__shen_4_5action_6, NewStream163)
 							Parse__shen_4_5action_6 := reg1291
 							_ = Parse__shen_4_5action_6
-							reg1292 := __e.Call(__defun__fail)
+							reg1292 := Call(__e, __defun__fail)
 							reg1293 := PrimEqual(reg1292, Parse__shen_4_5action_6)
 							reg1294 := PrimNot(reg1293)
 							if reg1294 == True {
 								reg1295 := PrimHead(Parse__shen_4_5action_6)
-								reg1296 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5patterns_6)
+								reg1296 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5patterns_6)
 								reg1297 := MakeSymbol("shen.choicepoint!")
-								reg1298 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5action_6)
+								reg1298 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5action_6)
 								reg1299 := Nil
 								reg1300 := PrimCons(reg1298, reg1299)
 								reg1301 := PrimCons(reg1297, reg1300)
 								reg1302 := Nil
 								reg1303 := PrimCons(reg1301, reg1302)
 								reg1304 := PrimCons(reg1296, reg1303)
-								__ctx.TailApply(__defun__shen_4pair, reg1295, reg1304)
+								__e.TailApply(__defun__shen_4pair, reg1295, reg1304)
 								return
 							} else {
-								__ctx.TailApply(__defun__fail)
+								__e.TailApply(__defun__fail)
 								return
 							}
 						} else {
-							__ctx.TailApply(__defun__fail)
+							__e.TailApply(__defun__fail)
 							return
 						}
 					} else {
-						__ctx.TailApply(__defun__fail)
+						__e.TailApply(__defun__fail)
 						return
 					}
 				} else {
-					__ctx.Return(YaccParse)
+					__e.Return(YaccParse)
 					return
 				}
 			} else {
-				__ctx.Return(YaccParse)
+				__e.Return(YaccParse)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<rule>", value: __defun__shen_4_5rule_6})
 
-	__defun__shen_4fail__if = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4fail__if = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V168 := __args[0]
 		_ = V168
 		V169 := __args[1]
 		_ = V169
-		reg1309 := __e.Call(V168, V169)
+		reg1309 := Call(__e, V168, V169)
 		if reg1309 == True {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		} else {
-			__ctx.Return(V169)
+			__e.Return(V169)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.fail_if", value: __defun__shen_4fail__if})
 
-	__defun__shen_4succeeds_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4succeeds_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V175 := __args[0]
 		_ = V175
-		reg1311 := __e.Call(__defun__fail)
+		reg1311 := Call(__e, __defun__fail)
 		reg1312 := PrimEqual(V175, reg1311)
 		if reg1312 == True {
 			reg1313 := False
-			__ctx.Return(reg1313)
+			__e.Return(reg1313)
 			return
 		} else {
 			reg1314 := True
-			__ctx.Return(reg1314)
+			__e.Return(reg1314)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.succeeds?", value: __defun__shen_4succeeds_2})
 
-	__defun__shen_4_5patterns_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5patterns_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V177 := __args[0]
 		_ = V177
-		reg1315 := __e.Call(__defun__shen_4_5pattern_6, V177)
+		reg1315 := Call(__e, __defun__shen_4_5pattern_6, V177)
 		Parse__shen_4_5pattern_6 := reg1315
 		_ = Parse__shen_4_5pattern_6
-		reg1316 := __e.Call(__defun__fail)
+		reg1316 := Call(__e, __defun__fail)
 		reg1317 := PrimEqual(reg1316, Parse__shen_4_5pattern_6)
 		reg1318 := PrimNot(reg1317)
 		var reg1331 Obj
 		if reg1318 == True {
-			reg1319 := __e.Call(__defun__shen_4_5patterns_6, Parse__shen_4_5pattern_6)
+			reg1319 := Call(__e, __defun__shen_4_5patterns_6, Parse__shen_4_5pattern_6)
 			Parse__shen_4_5patterns_6 := reg1319
 			_ = Parse__shen_4_5patterns_6
-			reg1320 := __e.Call(__defun__fail)
+			reg1320 := Call(__e, __defun__fail)
 			reg1321 := PrimEqual(reg1320, Parse__shen_4_5patterns_6)
 			reg1322 := PrimNot(reg1321)
 			var reg1329 Obj
 			if reg1322 == True {
 				reg1323 := PrimHead(Parse__shen_4_5patterns_6)
-				reg1324 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern_6)
-				reg1325 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5patterns_6)
+				reg1324 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern_6)
+				reg1325 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5patterns_6)
 				reg1326 := PrimCons(reg1324, reg1325)
-				reg1327 := __e.Call(__defun__shen_4pair, reg1323, reg1326)
+				reg1327 := Call(__e, __defun__shen_4pair, reg1323, reg1326)
 				reg1329 = reg1327
 			} else {
-				reg1328 := __e.Call(__defun__fail)
+				reg1328 := Call(__e, __defun__fail)
 				reg1329 = reg1328
 			}
 			reg1331 = reg1329
 		} else {
-			reg1330 := __e.Call(__defun__fail)
+			reg1330 := Call(__e, __defun__fail)
 			reg1331 = reg1330
 		}
 		YaccParse := reg1331
 		_ = YaccParse
-		reg1332 := __e.Call(__defun__fail)
+		reg1332 := Call(__e, __defun__fail)
 		reg1333 := PrimEqual(YaccParse, reg1332)
 		if reg1333 == True {
-			reg1334 := __e.Call(__defun___5e_6, V177)
+			reg1334 := Call(__e, __defun___5e_6, V177)
 			Parse___5e_6 := reg1334
 			_ = Parse___5e_6
-			reg1335 := __e.Call(__defun__fail)
+			reg1335 := Call(__e, __defun__fail)
 			reg1336 := PrimEqual(reg1335, Parse___5e_6)
 			reg1337 := PrimNot(reg1336)
 			if reg1337 == True {
 				reg1338 := PrimHead(Parse___5e_6)
 				reg1339 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg1338, reg1339)
+				__e.TailApply(__defun__shen_4pair, reg1338, reg1339)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<patterns>", value: __defun__shen_4_5patterns_6})
 
-	__defun__shen_4_5pattern_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5pattern_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V190 := __args[0]
 		_ = V190
 		reg1342 := PrimHead(V190)
 		reg1343 := PrimIsPair(reg1342)
 		var reg1350 Obj
 		if reg1343 == True {
-			reg1344 := __e.Call(__defun__shen_4hdhd, V190)
+			reg1344 := Call(__e, __defun__shen_4hdhd, V190)
 			reg1345 := PrimIsPair(reg1344)
 			var reg1348 Obj
 			if reg1345 == True {
@@ -1373,18 +1373,18 @@ func init() {
 		}
 		var reg1403 Obj
 		if reg1350 == True {
-			reg1351 := __e.Call(__defun__shen_4hdhd, V190)
-			reg1352 := __e.Call(__defun__shen_4hdtl, V190)
-			reg1353 := __e.Call(__defun__shen_4pair, reg1351, reg1352)
+			reg1351 := Call(__e, __defun__shen_4hdhd, V190)
+			reg1352 := Call(__e, __defun__shen_4hdtl, V190)
+			reg1353 := Call(__e, __defun__shen_4pair, reg1351, reg1352)
 			reg1354 := PrimHead(reg1353)
 			reg1355 := PrimIsPair(reg1354)
 			var reg1366 Obj
 			if reg1355 == True {
 				reg1356 := MakeSymbol("@p")
-				reg1357 := __e.Call(__defun__shen_4hdhd, V190)
-				reg1358 := __e.Call(__defun__shen_4hdtl, V190)
-				reg1359 := __e.Call(__defun__shen_4pair, reg1357, reg1358)
-				reg1360 := __e.Call(__defun__shen_4hdhd, reg1359)
+				reg1357 := Call(__e, __defun__shen_4hdhd, V190)
+				reg1358 := Call(__e, __defun__shen_4hdtl, V190)
+				reg1359 := Call(__e, __defun__shen_4pair, reg1357, reg1358)
+				reg1360 := Call(__e, __defun__shen_4hdhd, reg1359)
 				reg1361 := PrimEqual(reg1356, reg1360)
 				var reg1364 Obj
 				if reg1361 == True {
@@ -1401,75 +1401,75 @@ func init() {
 			}
 			var reg1401 Obj
 			if reg1366 == True {
-				reg1367 := __e.Call(__defun__shen_4hdhd, V190)
-				reg1368 := __e.Call(__defun__shen_4hdtl, V190)
-				reg1369 := __e.Call(__defun__shen_4pair, reg1367, reg1368)
-				reg1370 := __e.Call(__defun__shen_4tlhd, reg1369)
-				reg1371 := __e.Call(__defun__shen_4hdhd, V190)
-				reg1372 := __e.Call(__defun__shen_4hdtl, V190)
-				reg1373 := __e.Call(__defun__shen_4pair, reg1371, reg1372)
-				reg1374 := __e.Call(__defun__shen_4hdtl, reg1373)
-				reg1375 := __e.Call(__defun__shen_4pair, reg1370, reg1374)
+				reg1367 := Call(__e, __defun__shen_4hdhd, V190)
+				reg1368 := Call(__e, __defun__shen_4hdtl, V190)
+				reg1369 := Call(__e, __defun__shen_4pair, reg1367, reg1368)
+				reg1370 := Call(__e, __defun__shen_4tlhd, reg1369)
+				reg1371 := Call(__e, __defun__shen_4hdhd, V190)
+				reg1372 := Call(__e, __defun__shen_4hdtl, V190)
+				reg1373 := Call(__e, __defun__shen_4pair, reg1371, reg1372)
+				reg1374 := Call(__e, __defun__shen_4hdtl, reg1373)
+				reg1375 := Call(__e, __defun__shen_4pair, reg1370, reg1374)
 				NewStream179 := reg1375
 				_ = NewStream179
-				reg1376 := __e.Call(__defun__shen_4_5pattern1_6, NewStream179)
+				reg1376 := Call(__e, __defun__shen_4_5pattern1_6, NewStream179)
 				Parse__shen_4_5pattern1_6 := reg1376
 				_ = Parse__shen_4_5pattern1_6
-				reg1377 := __e.Call(__defun__fail)
+				reg1377 := Call(__e, __defun__fail)
 				reg1378 := PrimEqual(reg1377, Parse__shen_4_5pattern1_6)
 				reg1379 := PrimNot(reg1378)
 				var reg1399 Obj
 				if reg1379 == True {
-					reg1380 := __e.Call(__defun__shen_4_5pattern2_6, Parse__shen_4_5pattern1_6)
+					reg1380 := Call(__e, __defun__shen_4_5pattern2_6, Parse__shen_4_5pattern1_6)
 					Parse__shen_4_5pattern2_6 := reg1380
 					_ = Parse__shen_4_5pattern2_6
-					reg1381 := __e.Call(__defun__fail)
+					reg1381 := Call(__e, __defun__fail)
 					reg1382 := PrimEqual(reg1381, Parse__shen_4_5pattern2_6)
 					reg1383 := PrimNot(reg1382)
 					var reg1397 Obj
 					if reg1383 == True {
-						reg1384 := __e.Call(__defun__shen_4tlhd, V190)
-						reg1385 := __e.Call(__defun__shen_4hdtl, V190)
-						reg1386 := __e.Call(__defun__shen_4pair, reg1384, reg1385)
+						reg1384 := Call(__e, __defun__shen_4tlhd, V190)
+						reg1385 := Call(__e, __defun__shen_4hdtl, V190)
+						reg1386 := Call(__e, __defun__shen_4pair, reg1384, reg1385)
 						reg1387 := PrimHead(reg1386)
 						reg1388 := MakeSymbol("@p")
-						reg1389 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern1_6)
-						reg1390 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern2_6)
+						reg1389 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern1_6)
+						reg1390 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern2_6)
 						reg1391 := Nil
 						reg1392 := PrimCons(reg1390, reg1391)
 						reg1393 := PrimCons(reg1389, reg1392)
 						reg1394 := PrimCons(reg1388, reg1393)
-						reg1395 := __e.Call(__defun__shen_4pair, reg1387, reg1394)
+						reg1395 := Call(__e, __defun__shen_4pair, reg1387, reg1394)
 						reg1397 = reg1395
 					} else {
-						reg1396 := __e.Call(__defun__fail)
+						reg1396 := Call(__e, __defun__fail)
 						reg1397 = reg1396
 					}
 					reg1399 = reg1397
 				} else {
-					reg1398 := __e.Call(__defun__fail)
+					reg1398 := Call(__e, __defun__fail)
 					reg1399 = reg1398
 				}
 				reg1401 = reg1399
 			} else {
-				reg1400 := __e.Call(__defun__fail)
+				reg1400 := Call(__e, __defun__fail)
 				reg1401 = reg1400
 			}
 			reg1403 = reg1401
 		} else {
-			reg1402 := __e.Call(__defun__fail)
+			reg1402 := Call(__e, __defun__fail)
 			reg1403 = reg1402
 		}
 		YaccParse := reg1403
 		_ = YaccParse
-		reg1404 := __e.Call(__defun__fail)
+		reg1404 := Call(__e, __defun__fail)
 		reg1405 := PrimEqual(YaccParse, reg1404)
 		if reg1405 == True {
 			reg1406 := PrimHead(V190)
 			reg1407 := PrimIsPair(reg1406)
 			var reg1414 Obj
 			if reg1407 == True {
-				reg1408 := __e.Call(__defun__shen_4hdhd, V190)
+				reg1408 := Call(__e, __defun__shen_4hdhd, V190)
 				reg1409 := PrimIsPair(reg1408)
 				var reg1412 Obj
 				if reg1409 == True {
@@ -1486,18 +1486,18 @@ func init() {
 			}
 			var reg1467 Obj
 			if reg1414 == True {
-				reg1415 := __e.Call(__defun__shen_4hdhd, V190)
-				reg1416 := __e.Call(__defun__shen_4hdtl, V190)
-				reg1417 := __e.Call(__defun__shen_4pair, reg1415, reg1416)
+				reg1415 := Call(__e, __defun__shen_4hdhd, V190)
+				reg1416 := Call(__e, __defun__shen_4hdtl, V190)
+				reg1417 := Call(__e, __defun__shen_4pair, reg1415, reg1416)
 				reg1418 := PrimHead(reg1417)
 				reg1419 := PrimIsPair(reg1418)
 				var reg1430 Obj
 				if reg1419 == True {
 					reg1420 := MakeSymbol("cons")
-					reg1421 := __e.Call(__defun__shen_4hdhd, V190)
-					reg1422 := __e.Call(__defun__shen_4hdtl, V190)
-					reg1423 := __e.Call(__defun__shen_4pair, reg1421, reg1422)
-					reg1424 := __e.Call(__defun__shen_4hdhd, reg1423)
+					reg1421 := Call(__e, __defun__shen_4hdhd, V190)
+					reg1422 := Call(__e, __defun__shen_4hdtl, V190)
+					reg1423 := Call(__e, __defun__shen_4pair, reg1421, reg1422)
+					reg1424 := Call(__e, __defun__shen_4hdhd, reg1423)
 					reg1425 := PrimEqual(reg1420, reg1424)
 					var reg1428 Obj
 					if reg1425 == True {
@@ -1514,75 +1514,75 @@ func init() {
 				}
 				var reg1465 Obj
 				if reg1430 == True {
-					reg1431 := __e.Call(__defun__shen_4hdhd, V190)
-					reg1432 := __e.Call(__defun__shen_4hdtl, V190)
-					reg1433 := __e.Call(__defun__shen_4pair, reg1431, reg1432)
-					reg1434 := __e.Call(__defun__shen_4tlhd, reg1433)
-					reg1435 := __e.Call(__defun__shen_4hdhd, V190)
-					reg1436 := __e.Call(__defun__shen_4hdtl, V190)
-					reg1437 := __e.Call(__defun__shen_4pair, reg1435, reg1436)
-					reg1438 := __e.Call(__defun__shen_4hdtl, reg1437)
-					reg1439 := __e.Call(__defun__shen_4pair, reg1434, reg1438)
+					reg1431 := Call(__e, __defun__shen_4hdhd, V190)
+					reg1432 := Call(__e, __defun__shen_4hdtl, V190)
+					reg1433 := Call(__e, __defun__shen_4pair, reg1431, reg1432)
+					reg1434 := Call(__e, __defun__shen_4tlhd, reg1433)
+					reg1435 := Call(__e, __defun__shen_4hdhd, V190)
+					reg1436 := Call(__e, __defun__shen_4hdtl, V190)
+					reg1437 := Call(__e, __defun__shen_4pair, reg1435, reg1436)
+					reg1438 := Call(__e, __defun__shen_4hdtl, reg1437)
+					reg1439 := Call(__e, __defun__shen_4pair, reg1434, reg1438)
 					NewStream181 := reg1439
 					_ = NewStream181
-					reg1440 := __e.Call(__defun__shen_4_5pattern1_6, NewStream181)
+					reg1440 := Call(__e, __defun__shen_4_5pattern1_6, NewStream181)
 					Parse__shen_4_5pattern1_6 := reg1440
 					_ = Parse__shen_4_5pattern1_6
-					reg1441 := __e.Call(__defun__fail)
+					reg1441 := Call(__e, __defun__fail)
 					reg1442 := PrimEqual(reg1441, Parse__shen_4_5pattern1_6)
 					reg1443 := PrimNot(reg1442)
 					var reg1463 Obj
 					if reg1443 == True {
-						reg1444 := __e.Call(__defun__shen_4_5pattern2_6, Parse__shen_4_5pattern1_6)
+						reg1444 := Call(__e, __defun__shen_4_5pattern2_6, Parse__shen_4_5pattern1_6)
 						Parse__shen_4_5pattern2_6 := reg1444
 						_ = Parse__shen_4_5pattern2_6
-						reg1445 := __e.Call(__defun__fail)
+						reg1445 := Call(__e, __defun__fail)
 						reg1446 := PrimEqual(reg1445, Parse__shen_4_5pattern2_6)
 						reg1447 := PrimNot(reg1446)
 						var reg1461 Obj
 						if reg1447 == True {
-							reg1448 := __e.Call(__defun__shen_4tlhd, V190)
-							reg1449 := __e.Call(__defun__shen_4hdtl, V190)
-							reg1450 := __e.Call(__defun__shen_4pair, reg1448, reg1449)
+							reg1448 := Call(__e, __defun__shen_4tlhd, V190)
+							reg1449 := Call(__e, __defun__shen_4hdtl, V190)
+							reg1450 := Call(__e, __defun__shen_4pair, reg1448, reg1449)
 							reg1451 := PrimHead(reg1450)
 							reg1452 := MakeSymbol("cons")
-							reg1453 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern1_6)
-							reg1454 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern2_6)
+							reg1453 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern1_6)
+							reg1454 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern2_6)
 							reg1455 := Nil
 							reg1456 := PrimCons(reg1454, reg1455)
 							reg1457 := PrimCons(reg1453, reg1456)
 							reg1458 := PrimCons(reg1452, reg1457)
-							reg1459 := __e.Call(__defun__shen_4pair, reg1451, reg1458)
+							reg1459 := Call(__e, __defun__shen_4pair, reg1451, reg1458)
 							reg1461 = reg1459
 						} else {
-							reg1460 := __e.Call(__defun__fail)
+							reg1460 := Call(__e, __defun__fail)
 							reg1461 = reg1460
 						}
 						reg1463 = reg1461
 					} else {
-						reg1462 := __e.Call(__defun__fail)
+						reg1462 := Call(__e, __defun__fail)
 						reg1463 = reg1462
 					}
 					reg1465 = reg1463
 				} else {
-					reg1464 := __e.Call(__defun__fail)
+					reg1464 := Call(__e, __defun__fail)
 					reg1465 = reg1464
 				}
 				reg1467 = reg1465
 			} else {
-				reg1466 := __e.Call(__defun__fail)
+				reg1466 := Call(__e, __defun__fail)
 				reg1467 = reg1466
 			}
 			YaccParse := reg1467
 			_ = YaccParse
-			reg1468 := __e.Call(__defun__fail)
+			reg1468 := Call(__e, __defun__fail)
 			reg1469 := PrimEqual(YaccParse, reg1468)
 			if reg1469 == True {
 				reg1470 := PrimHead(V190)
 				reg1471 := PrimIsPair(reg1470)
 				var reg1478 Obj
 				if reg1471 == True {
-					reg1472 := __e.Call(__defun__shen_4hdhd, V190)
+					reg1472 := Call(__e, __defun__shen_4hdhd, V190)
 					reg1473 := PrimIsPair(reg1472)
 					var reg1476 Obj
 					if reg1473 == True {
@@ -1599,18 +1599,18 @@ func init() {
 				}
 				var reg1531 Obj
 				if reg1478 == True {
-					reg1479 := __e.Call(__defun__shen_4hdhd, V190)
-					reg1480 := __e.Call(__defun__shen_4hdtl, V190)
-					reg1481 := __e.Call(__defun__shen_4pair, reg1479, reg1480)
+					reg1479 := Call(__e, __defun__shen_4hdhd, V190)
+					reg1480 := Call(__e, __defun__shen_4hdtl, V190)
+					reg1481 := Call(__e, __defun__shen_4pair, reg1479, reg1480)
 					reg1482 := PrimHead(reg1481)
 					reg1483 := PrimIsPair(reg1482)
 					var reg1494 Obj
 					if reg1483 == True {
 						reg1484 := MakeSymbol("@v")
-						reg1485 := __e.Call(__defun__shen_4hdhd, V190)
-						reg1486 := __e.Call(__defun__shen_4hdtl, V190)
-						reg1487 := __e.Call(__defun__shen_4pair, reg1485, reg1486)
-						reg1488 := __e.Call(__defun__shen_4hdhd, reg1487)
+						reg1485 := Call(__e, __defun__shen_4hdhd, V190)
+						reg1486 := Call(__e, __defun__shen_4hdtl, V190)
+						reg1487 := Call(__e, __defun__shen_4pair, reg1485, reg1486)
+						reg1488 := Call(__e, __defun__shen_4hdhd, reg1487)
 						reg1489 := PrimEqual(reg1484, reg1488)
 						var reg1492 Obj
 						if reg1489 == True {
@@ -1627,75 +1627,75 @@ func init() {
 					}
 					var reg1529 Obj
 					if reg1494 == True {
-						reg1495 := __e.Call(__defun__shen_4hdhd, V190)
-						reg1496 := __e.Call(__defun__shen_4hdtl, V190)
-						reg1497 := __e.Call(__defun__shen_4pair, reg1495, reg1496)
-						reg1498 := __e.Call(__defun__shen_4tlhd, reg1497)
-						reg1499 := __e.Call(__defun__shen_4hdhd, V190)
-						reg1500 := __e.Call(__defun__shen_4hdtl, V190)
-						reg1501 := __e.Call(__defun__shen_4pair, reg1499, reg1500)
-						reg1502 := __e.Call(__defun__shen_4hdtl, reg1501)
-						reg1503 := __e.Call(__defun__shen_4pair, reg1498, reg1502)
+						reg1495 := Call(__e, __defun__shen_4hdhd, V190)
+						reg1496 := Call(__e, __defun__shen_4hdtl, V190)
+						reg1497 := Call(__e, __defun__shen_4pair, reg1495, reg1496)
+						reg1498 := Call(__e, __defun__shen_4tlhd, reg1497)
+						reg1499 := Call(__e, __defun__shen_4hdhd, V190)
+						reg1500 := Call(__e, __defun__shen_4hdtl, V190)
+						reg1501 := Call(__e, __defun__shen_4pair, reg1499, reg1500)
+						reg1502 := Call(__e, __defun__shen_4hdtl, reg1501)
+						reg1503 := Call(__e, __defun__shen_4pair, reg1498, reg1502)
 						NewStream183 := reg1503
 						_ = NewStream183
-						reg1504 := __e.Call(__defun__shen_4_5pattern1_6, NewStream183)
+						reg1504 := Call(__e, __defun__shen_4_5pattern1_6, NewStream183)
 						Parse__shen_4_5pattern1_6 := reg1504
 						_ = Parse__shen_4_5pattern1_6
-						reg1505 := __e.Call(__defun__fail)
+						reg1505 := Call(__e, __defun__fail)
 						reg1506 := PrimEqual(reg1505, Parse__shen_4_5pattern1_6)
 						reg1507 := PrimNot(reg1506)
 						var reg1527 Obj
 						if reg1507 == True {
-							reg1508 := __e.Call(__defun__shen_4_5pattern2_6, Parse__shen_4_5pattern1_6)
+							reg1508 := Call(__e, __defun__shen_4_5pattern2_6, Parse__shen_4_5pattern1_6)
 							Parse__shen_4_5pattern2_6 := reg1508
 							_ = Parse__shen_4_5pattern2_6
-							reg1509 := __e.Call(__defun__fail)
+							reg1509 := Call(__e, __defun__fail)
 							reg1510 := PrimEqual(reg1509, Parse__shen_4_5pattern2_6)
 							reg1511 := PrimNot(reg1510)
 							var reg1525 Obj
 							if reg1511 == True {
-								reg1512 := __e.Call(__defun__shen_4tlhd, V190)
-								reg1513 := __e.Call(__defun__shen_4hdtl, V190)
-								reg1514 := __e.Call(__defun__shen_4pair, reg1512, reg1513)
+								reg1512 := Call(__e, __defun__shen_4tlhd, V190)
+								reg1513 := Call(__e, __defun__shen_4hdtl, V190)
+								reg1514 := Call(__e, __defun__shen_4pair, reg1512, reg1513)
 								reg1515 := PrimHead(reg1514)
 								reg1516 := MakeSymbol("@v")
-								reg1517 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern1_6)
-								reg1518 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern2_6)
+								reg1517 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern1_6)
+								reg1518 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern2_6)
 								reg1519 := Nil
 								reg1520 := PrimCons(reg1518, reg1519)
 								reg1521 := PrimCons(reg1517, reg1520)
 								reg1522 := PrimCons(reg1516, reg1521)
-								reg1523 := __e.Call(__defun__shen_4pair, reg1515, reg1522)
+								reg1523 := Call(__e, __defun__shen_4pair, reg1515, reg1522)
 								reg1525 = reg1523
 							} else {
-								reg1524 := __e.Call(__defun__fail)
+								reg1524 := Call(__e, __defun__fail)
 								reg1525 = reg1524
 							}
 							reg1527 = reg1525
 						} else {
-							reg1526 := __e.Call(__defun__fail)
+							reg1526 := Call(__e, __defun__fail)
 							reg1527 = reg1526
 						}
 						reg1529 = reg1527
 					} else {
-						reg1528 := __e.Call(__defun__fail)
+						reg1528 := Call(__e, __defun__fail)
 						reg1529 = reg1528
 					}
 					reg1531 = reg1529
 				} else {
-					reg1530 := __e.Call(__defun__fail)
+					reg1530 := Call(__e, __defun__fail)
 					reg1531 = reg1530
 				}
 				YaccParse := reg1531
 				_ = YaccParse
-				reg1532 := __e.Call(__defun__fail)
+				reg1532 := Call(__e, __defun__fail)
 				reg1533 := PrimEqual(YaccParse, reg1532)
 				if reg1533 == True {
 					reg1534 := PrimHead(V190)
 					reg1535 := PrimIsPair(reg1534)
 					var reg1542 Obj
 					if reg1535 == True {
-						reg1536 := __e.Call(__defun__shen_4hdhd, V190)
+						reg1536 := Call(__e, __defun__shen_4hdhd, V190)
 						reg1537 := PrimIsPair(reg1536)
 						var reg1540 Obj
 						if reg1537 == True {
@@ -1712,18 +1712,18 @@ func init() {
 					}
 					var reg1595 Obj
 					if reg1542 == True {
-						reg1543 := __e.Call(__defun__shen_4hdhd, V190)
-						reg1544 := __e.Call(__defun__shen_4hdtl, V190)
-						reg1545 := __e.Call(__defun__shen_4pair, reg1543, reg1544)
+						reg1543 := Call(__e, __defun__shen_4hdhd, V190)
+						reg1544 := Call(__e, __defun__shen_4hdtl, V190)
+						reg1545 := Call(__e, __defun__shen_4pair, reg1543, reg1544)
 						reg1546 := PrimHead(reg1545)
 						reg1547 := PrimIsPair(reg1546)
 						var reg1558 Obj
 						if reg1547 == True {
 							reg1548 := MakeSymbol("@s")
-							reg1549 := __e.Call(__defun__shen_4hdhd, V190)
-							reg1550 := __e.Call(__defun__shen_4hdtl, V190)
-							reg1551 := __e.Call(__defun__shen_4pair, reg1549, reg1550)
-							reg1552 := __e.Call(__defun__shen_4hdhd, reg1551)
+							reg1549 := Call(__e, __defun__shen_4hdhd, V190)
+							reg1550 := Call(__e, __defun__shen_4hdtl, V190)
+							reg1551 := Call(__e, __defun__shen_4pair, reg1549, reg1550)
+							reg1552 := Call(__e, __defun__shen_4hdhd, reg1551)
 							reg1553 := PrimEqual(reg1548, reg1552)
 							var reg1556 Obj
 							if reg1553 == True {
@@ -1740,75 +1740,75 @@ func init() {
 						}
 						var reg1593 Obj
 						if reg1558 == True {
-							reg1559 := __e.Call(__defun__shen_4hdhd, V190)
-							reg1560 := __e.Call(__defun__shen_4hdtl, V190)
-							reg1561 := __e.Call(__defun__shen_4pair, reg1559, reg1560)
-							reg1562 := __e.Call(__defun__shen_4tlhd, reg1561)
-							reg1563 := __e.Call(__defun__shen_4hdhd, V190)
-							reg1564 := __e.Call(__defun__shen_4hdtl, V190)
-							reg1565 := __e.Call(__defun__shen_4pair, reg1563, reg1564)
-							reg1566 := __e.Call(__defun__shen_4hdtl, reg1565)
-							reg1567 := __e.Call(__defun__shen_4pair, reg1562, reg1566)
+							reg1559 := Call(__e, __defun__shen_4hdhd, V190)
+							reg1560 := Call(__e, __defun__shen_4hdtl, V190)
+							reg1561 := Call(__e, __defun__shen_4pair, reg1559, reg1560)
+							reg1562 := Call(__e, __defun__shen_4tlhd, reg1561)
+							reg1563 := Call(__e, __defun__shen_4hdhd, V190)
+							reg1564 := Call(__e, __defun__shen_4hdtl, V190)
+							reg1565 := Call(__e, __defun__shen_4pair, reg1563, reg1564)
+							reg1566 := Call(__e, __defun__shen_4hdtl, reg1565)
+							reg1567 := Call(__e, __defun__shen_4pair, reg1562, reg1566)
 							NewStream185 := reg1567
 							_ = NewStream185
-							reg1568 := __e.Call(__defun__shen_4_5pattern1_6, NewStream185)
+							reg1568 := Call(__e, __defun__shen_4_5pattern1_6, NewStream185)
 							Parse__shen_4_5pattern1_6 := reg1568
 							_ = Parse__shen_4_5pattern1_6
-							reg1569 := __e.Call(__defun__fail)
+							reg1569 := Call(__e, __defun__fail)
 							reg1570 := PrimEqual(reg1569, Parse__shen_4_5pattern1_6)
 							reg1571 := PrimNot(reg1570)
 							var reg1591 Obj
 							if reg1571 == True {
-								reg1572 := __e.Call(__defun__shen_4_5pattern2_6, Parse__shen_4_5pattern1_6)
+								reg1572 := Call(__e, __defun__shen_4_5pattern2_6, Parse__shen_4_5pattern1_6)
 								Parse__shen_4_5pattern2_6 := reg1572
 								_ = Parse__shen_4_5pattern2_6
-								reg1573 := __e.Call(__defun__fail)
+								reg1573 := Call(__e, __defun__fail)
 								reg1574 := PrimEqual(reg1573, Parse__shen_4_5pattern2_6)
 								reg1575 := PrimNot(reg1574)
 								var reg1589 Obj
 								if reg1575 == True {
-									reg1576 := __e.Call(__defun__shen_4tlhd, V190)
-									reg1577 := __e.Call(__defun__shen_4hdtl, V190)
-									reg1578 := __e.Call(__defun__shen_4pair, reg1576, reg1577)
+									reg1576 := Call(__e, __defun__shen_4tlhd, V190)
+									reg1577 := Call(__e, __defun__shen_4hdtl, V190)
+									reg1578 := Call(__e, __defun__shen_4pair, reg1576, reg1577)
 									reg1579 := PrimHead(reg1578)
 									reg1580 := MakeSymbol("@s")
-									reg1581 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern1_6)
-									reg1582 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern2_6)
+									reg1581 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern1_6)
+									reg1582 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern2_6)
 									reg1583 := Nil
 									reg1584 := PrimCons(reg1582, reg1583)
 									reg1585 := PrimCons(reg1581, reg1584)
 									reg1586 := PrimCons(reg1580, reg1585)
-									reg1587 := __e.Call(__defun__shen_4pair, reg1579, reg1586)
+									reg1587 := Call(__e, __defun__shen_4pair, reg1579, reg1586)
 									reg1589 = reg1587
 								} else {
-									reg1588 := __e.Call(__defun__fail)
+									reg1588 := Call(__e, __defun__fail)
 									reg1589 = reg1588
 								}
 								reg1591 = reg1589
 							} else {
-								reg1590 := __e.Call(__defun__fail)
+								reg1590 := Call(__e, __defun__fail)
 								reg1591 = reg1590
 							}
 							reg1593 = reg1591
 						} else {
-							reg1592 := __e.Call(__defun__fail)
+							reg1592 := Call(__e, __defun__fail)
 							reg1593 = reg1592
 						}
 						reg1595 = reg1593
 					} else {
-						reg1594 := __e.Call(__defun__fail)
+						reg1594 := Call(__e, __defun__fail)
 						reg1595 = reg1594
 					}
 					YaccParse := reg1595
 					_ = YaccParse
-					reg1596 := __e.Call(__defun__fail)
+					reg1596 := Call(__e, __defun__fail)
 					reg1597 := PrimEqual(YaccParse, reg1596)
 					if reg1597 == True {
 						reg1598 := PrimHead(V190)
 						reg1599 := PrimIsPair(reg1598)
 						var reg1606 Obj
 						if reg1599 == True {
-							reg1600 := __e.Call(__defun__shen_4hdhd, V190)
+							reg1600 := Call(__e, __defun__shen_4hdhd, V190)
 							reg1601 := PrimIsPair(reg1600)
 							var reg1604 Obj
 							if reg1601 == True {
@@ -1825,18 +1825,18 @@ func init() {
 						}
 						var reg1660 Obj
 						if reg1606 == True {
-							reg1607 := __e.Call(__defun__shen_4hdhd, V190)
-							reg1608 := __e.Call(__defun__shen_4hdtl, V190)
-							reg1609 := __e.Call(__defun__shen_4pair, reg1607, reg1608)
+							reg1607 := Call(__e, __defun__shen_4hdhd, V190)
+							reg1608 := Call(__e, __defun__shen_4hdtl, V190)
+							reg1609 := Call(__e, __defun__shen_4pair, reg1607, reg1608)
 							reg1610 := PrimHead(reg1609)
 							reg1611 := PrimIsPair(reg1610)
 							var reg1622 Obj
 							if reg1611 == True {
 								reg1612 := MakeSymbol("vector")
-								reg1613 := __e.Call(__defun__shen_4hdhd, V190)
-								reg1614 := __e.Call(__defun__shen_4hdtl, V190)
-								reg1615 := __e.Call(__defun__shen_4pair, reg1613, reg1614)
-								reg1616 := __e.Call(__defun__shen_4hdhd, reg1615)
+								reg1613 := Call(__e, __defun__shen_4hdhd, V190)
+								reg1614 := Call(__e, __defun__shen_4hdtl, V190)
+								reg1615 := Call(__e, __defun__shen_4pair, reg1613, reg1614)
+								reg1616 := Call(__e, __defun__shen_4hdhd, reg1615)
 								reg1617 := PrimEqual(reg1612, reg1616)
 								var reg1620 Obj
 								if reg1617 == True {
@@ -1853,15 +1853,15 @@ func init() {
 							}
 							var reg1658 Obj
 							if reg1622 == True {
-								reg1623 := __e.Call(__defun__shen_4hdhd, V190)
-								reg1624 := __e.Call(__defun__shen_4hdtl, V190)
-								reg1625 := __e.Call(__defun__shen_4pair, reg1623, reg1624)
-								reg1626 := __e.Call(__defun__shen_4tlhd, reg1625)
-								reg1627 := __e.Call(__defun__shen_4hdhd, V190)
-								reg1628 := __e.Call(__defun__shen_4hdtl, V190)
-								reg1629 := __e.Call(__defun__shen_4pair, reg1627, reg1628)
-								reg1630 := __e.Call(__defun__shen_4hdtl, reg1629)
-								reg1631 := __e.Call(__defun__shen_4pair, reg1626, reg1630)
+								reg1623 := Call(__e, __defun__shen_4hdhd, V190)
+								reg1624 := Call(__e, __defun__shen_4hdtl, V190)
+								reg1625 := Call(__e, __defun__shen_4pair, reg1623, reg1624)
+								reg1626 := Call(__e, __defun__shen_4tlhd, reg1625)
+								reg1627 := Call(__e, __defun__shen_4hdhd, V190)
+								reg1628 := Call(__e, __defun__shen_4hdtl, V190)
+								reg1629 := Call(__e, __defun__shen_4pair, reg1627, reg1628)
+								reg1630 := Call(__e, __defun__shen_4hdtl, reg1629)
+								reg1631 := Call(__e, __defun__shen_4pair, reg1626, reg1630)
 								NewStream187 := reg1631
 								_ = NewStream187
 								reg1632 := PrimHead(NewStream187)
@@ -1869,7 +1869,7 @@ func init() {
 								var reg1641 Obj
 								if reg1633 == True {
 									reg1634 := MakeNumber(0)
-									reg1635 := __e.Call(__defun__shen_4hdhd, NewStream187)
+									reg1635 := Call(__e, __defun__shen_4hdhd, NewStream187)
 									reg1636 := PrimEqual(reg1634, reg1635)
 									var reg1639 Obj
 									if reg1636 == True {
@@ -1886,166 +1886,166 @@ func init() {
 								}
 								var reg1656 Obj
 								if reg1641 == True {
-									reg1642 := __e.Call(__defun__shen_4tlhd, NewStream187)
-									reg1643 := __e.Call(__defun__shen_4hdtl, NewStream187)
-									reg1644 := __e.Call(__defun__shen_4pair, reg1642, reg1643)
+									reg1642 := Call(__e, __defun__shen_4tlhd, NewStream187)
+									reg1643 := Call(__e, __defun__shen_4hdtl, NewStream187)
+									reg1644 := Call(__e, __defun__shen_4pair, reg1642, reg1643)
 									NewStream188 := reg1644
 									_ = NewStream188
-									reg1645 := __e.Call(__defun__shen_4tlhd, V190)
-									reg1646 := __e.Call(__defun__shen_4hdtl, V190)
-									reg1647 := __e.Call(__defun__shen_4pair, reg1645, reg1646)
+									reg1645 := Call(__e, __defun__shen_4tlhd, V190)
+									reg1646 := Call(__e, __defun__shen_4hdtl, V190)
+									reg1647 := Call(__e, __defun__shen_4pair, reg1645, reg1646)
 									reg1648 := PrimHead(reg1647)
 									reg1649 := MakeSymbol("vector")
 									reg1650 := MakeNumber(0)
 									reg1651 := Nil
 									reg1652 := PrimCons(reg1650, reg1651)
 									reg1653 := PrimCons(reg1649, reg1652)
-									reg1654 := __e.Call(__defun__shen_4pair, reg1648, reg1653)
+									reg1654 := Call(__e, __defun__shen_4pair, reg1648, reg1653)
 									reg1656 = reg1654
 								} else {
-									reg1655 := __e.Call(__defun__fail)
+									reg1655 := Call(__e, __defun__fail)
 									reg1656 = reg1655
 								}
 								reg1658 = reg1656
 							} else {
-								reg1657 := __e.Call(__defun__fail)
+								reg1657 := Call(__e, __defun__fail)
 								reg1658 = reg1657
 							}
 							reg1660 = reg1658
 						} else {
-							reg1659 := __e.Call(__defun__fail)
+							reg1659 := Call(__e, __defun__fail)
 							reg1660 = reg1659
 						}
 						YaccParse := reg1660
 						_ = YaccParse
-						reg1661 := __e.Call(__defun__fail)
+						reg1661 := Call(__e, __defun__fail)
 						reg1662 := PrimEqual(YaccParse, reg1661)
 						if reg1662 == True {
 							reg1663 := PrimHead(V190)
 							reg1664 := PrimIsPair(reg1663)
 							var reg1676 Obj
 							if reg1664 == True {
-								reg1665 := __e.Call(__defun__shen_4hdhd, V190)
+								reg1665 := Call(__e, __defun__shen_4hdhd, V190)
 								Parse__X := reg1665
 								_ = Parse__X
 								reg1666 := PrimIsPair(Parse__X)
 								var reg1674 Obj
 								if reg1666 == True {
-									reg1667 := __e.Call(__defun__shen_4tlhd, V190)
-									reg1668 := __e.Call(__defun__shen_4hdtl, V190)
-									reg1669 := __e.Call(__defun__shen_4pair, reg1667, reg1668)
+									reg1667 := Call(__e, __defun__shen_4tlhd, V190)
+									reg1668 := Call(__e, __defun__shen_4hdtl, V190)
+									reg1669 := Call(__e, __defun__shen_4pair, reg1667, reg1668)
 									reg1670 := PrimHead(reg1669)
-									reg1671 := __e.Call(__defun__shen_4constructor_1error, Parse__X)
-									reg1672 := __e.Call(__defun__shen_4pair, reg1670, reg1671)
+									reg1671 := Call(__e, __defun__shen_4constructor_1error, Parse__X)
+									reg1672 := Call(__e, __defun__shen_4pair, reg1670, reg1671)
 									reg1674 = reg1672
 								} else {
-									reg1673 := __e.Call(__defun__fail)
+									reg1673 := Call(__e, __defun__fail)
 									reg1674 = reg1673
 								}
 								reg1676 = reg1674
 							} else {
-								reg1675 := __e.Call(__defun__fail)
+								reg1675 := Call(__e, __defun__fail)
 								reg1676 = reg1675
 							}
 							YaccParse := reg1676
 							_ = YaccParse
-							reg1677 := __e.Call(__defun__fail)
+							reg1677 := Call(__e, __defun__fail)
 							reg1678 := PrimEqual(YaccParse, reg1677)
 							if reg1678 == True {
-								reg1679 := __e.Call(__defun__shen_4_5simple__pattern_6, V190)
+								reg1679 := Call(__e, __defun__shen_4_5simple__pattern_6, V190)
 								Parse__shen_4_5simple__pattern_6 := reg1679
 								_ = Parse__shen_4_5simple__pattern_6
-								reg1680 := __e.Call(__defun__fail)
+								reg1680 := Call(__e, __defun__fail)
 								reg1681 := PrimEqual(reg1680, Parse__shen_4_5simple__pattern_6)
 								reg1682 := PrimNot(reg1681)
 								if reg1682 == True {
 									reg1683 := PrimHead(Parse__shen_4_5simple__pattern_6)
-									reg1684 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5simple__pattern_6)
-									__ctx.TailApply(__defun__shen_4pair, reg1683, reg1684)
+									reg1684 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5simple__pattern_6)
+									__e.TailApply(__defun__shen_4pair, reg1683, reg1684)
 									return
 								} else {
-									__ctx.TailApply(__defun__fail)
+									__e.TailApply(__defun__fail)
 									return
 								}
 							} else {
-								__ctx.Return(YaccParse)
+								__e.Return(YaccParse)
 								return
 							}
 						} else {
-							__ctx.Return(YaccParse)
+							__e.Return(YaccParse)
 							return
 						}
 					} else {
-						__ctx.Return(YaccParse)
+						__e.Return(YaccParse)
 						return
 					}
 				} else {
-					__ctx.Return(YaccParse)
+					__e.Return(YaccParse)
 					return
 				}
 			} else {
-				__ctx.Return(YaccParse)
+				__e.Return(YaccParse)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<pattern>", value: __defun__shen_4_5pattern_6})
 
-	__defun__shen_4constructor_1error = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4constructor_1error = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V192 := __args[0]
 		_ = V192
 		reg1687 := MakeString(" is not a legitimate constructor\n")
 		reg1688 := MakeSymbol("shen.a")
-		reg1689 := __e.Call(__defun__shen_4app, V192, reg1687, reg1688)
+		reg1689 := Call(__e, __defun__shen_4app, V192, reg1687, reg1688)
 		reg1690 := PrimSimpleError(reg1689)
-		__ctx.Return(reg1690)
+		__e.Return(reg1690)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.constructor-error", value: __defun__shen_4constructor_1error})
 
-	__defun__shen_4_5simple__pattern_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5simple__pattern_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V194 := __args[0]
 		_ = V194
 		reg1691 := PrimHead(V194)
 		reg1692 := PrimIsPair(reg1691)
 		var reg1706 Obj
 		if reg1692 == True {
-			reg1693 := __e.Call(__defun__shen_4hdhd, V194)
+			reg1693 := Call(__e, __defun__shen_4hdhd, V194)
 			Parse__X := reg1693
 			_ = Parse__X
 			reg1694 := MakeSymbol("_")
 			reg1695 := PrimEqual(Parse__X, reg1694)
 			var reg1704 Obj
 			if reg1695 == True {
-				reg1696 := __e.Call(__defun__shen_4tlhd, V194)
-				reg1697 := __e.Call(__defun__shen_4hdtl, V194)
-				reg1698 := __e.Call(__defun__shen_4pair, reg1696, reg1697)
+				reg1696 := Call(__e, __defun__shen_4tlhd, V194)
+				reg1697 := Call(__e, __defun__shen_4hdtl, V194)
+				reg1698 := Call(__e, __defun__shen_4pair, reg1696, reg1697)
 				reg1699 := PrimHead(reg1698)
 				reg1700 := MakeSymbol("Parse_Y")
-				reg1701 := __e.Call(__defun__gensym, reg1700)
-				reg1702 := __e.Call(__defun__shen_4pair, reg1699, reg1701)
+				reg1701 := Call(__e, __defun__gensym, reg1700)
+				reg1702 := Call(__e, __defun__shen_4pair, reg1699, reg1701)
 				reg1704 = reg1702
 			} else {
-				reg1703 := __e.Call(__defun__fail)
+				reg1703 := Call(__e, __defun__fail)
 				reg1704 = reg1703
 			}
 			reg1706 = reg1704
 		} else {
-			reg1705 := __e.Call(__defun__fail)
+			reg1705 := Call(__e, __defun__fail)
 			reg1706 = reg1705
 		}
 		YaccParse := reg1706
 		_ = YaccParse
-		reg1707 := __e.Call(__defun__fail)
+		reg1707 := Call(__e, __defun__fail)
 		reg1708 := PrimEqual(YaccParse, reg1707)
 		if reg1708 == True {
 			reg1709 := PrimHead(V194)
 			reg1710 := PrimIsPair(reg1709)
 			if reg1710 == True {
-				reg1711 := __e.Call(__defun__shen_4hdhd, V194)
+				reg1711 := Call(__e, __defun__shen_4hdhd, V194)
 				Parse__X := reg1711
 				_ = Parse__X
 				reg1712 := MakeSymbol("->")
@@ -2053,136 +2053,136 @@ func init() {
 				reg1714 := Nil
 				reg1715 := PrimCons(reg1713, reg1714)
 				reg1716 := PrimCons(reg1712, reg1715)
-				reg1717 := __e.Call(__defun__element_2, Parse__X, reg1716)
+				reg1717 := Call(__e, __defun__element_2, Parse__X, reg1716)
 				reg1718 := PrimNot(reg1717)
 				if reg1718 == True {
-					reg1719 := __e.Call(__defun__shen_4tlhd, V194)
-					reg1720 := __e.Call(__defun__shen_4hdtl, V194)
-					reg1721 := __e.Call(__defun__shen_4pair, reg1719, reg1720)
+					reg1719 := Call(__e, __defun__shen_4tlhd, V194)
+					reg1720 := Call(__e, __defun__shen_4hdtl, V194)
+					reg1721 := Call(__e, __defun__shen_4pair, reg1719, reg1720)
 					reg1722 := PrimHead(reg1721)
-					__ctx.TailApply(__defun__shen_4pair, reg1722, Parse__X)
+					__e.TailApply(__defun__shen_4pair, reg1722, Parse__X)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<simple_pattern>", value: __defun__shen_4_5simple__pattern_6})
 
-	__defun__shen_4_5pattern1_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5pattern1_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V196 := __args[0]
 		_ = V196
-		reg1726 := __e.Call(__defun__shen_4_5pattern_6, V196)
+		reg1726 := Call(__e, __defun__shen_4_5pattern_6, V196)
 		Parse__shen_4_5pattern_6 := reg1726
 		_ = Parse__shen_4_5pattern_6
-		reg1727 := __e.Call(__defun__fail)
+		reg1727 := Call(__e, __defun__fail)
 		reg1728 := PrimEqual(reg1727, Parse__shen_4_5pattern_6)
 		reg1729 := PrimNot(reg1728)
 		if reg1729 == True {
 			reg1730 := PrimHead(Parse__shen_4_5pattern_6)
-			reg1731 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern_6)
-			__ctx.TailApply(__defun__shen_4pair, reg1730, reg1731)
+			reg1731 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern_6)
+			__e.TailApply(__defun__shen_4pair, reg1730, reg1731)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<pattern1>", value: __defun__shen_4_5pattern1_6})
 
-	__defun__shen_4_5pattern2_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5pattern2_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V198 := __args[0]
 		_ = V198
-		reg1734 := __e.Call(__defun__shen_4_5pattern_6, V198)
+		reg1734 := Call(__e, __defun__shen_4_5pattern_6, V198)
 		Parse__shen_4_5pattern_6 := reg1734
 		_ = Parse__shen_4_5pattern_6
-		reg1735 := __e.Call(__defun__fail)
+		reg1735 := Call(__e, __defun__fail)
 		reg1736 := PrimEqual(reg1735, Parse__shen_4_5pattern_6)
 		reg1737 := PrimNot(reg1736)
 		if reg1737 == True {
 			reg1738 := PrimHead(Parse__shen_4_5pattern_6)
-			reg1739 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5pattern_6)
-			__ctx.TailApply(__defun__shen_4pair, reg1738, reg1739)
+			reg1739 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5pattern_6)
+			__e.TailApply(__defun__shen_4pair, reg1738, reg1739)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<pattern2>", value: __defun__shen_4_5pattern2_6})
 
-	__defun__shen_4_5action_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5action_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V200 := __args[0]
 		_ = V200
 		reg1742 := PrimHead(V200)
 		reg1743 := PrimIsPair(reg1742)
 		if reg1743 == True {
-			reg1744 := __e.Call(__defun__shen_4hdhd, V200)
+			reg1744 := Call(__e, __defun__shen_4hdhd, V200)
 			Parse__X := reg1744
 			_ = Parse__X
-			reg1745 := __e.Call(__defun__shen_4tlhd, V200)
-			reg1746 := __e.Call(__defun__shen_4hdtl, V200)
-			reg1747 := __e.Call(__defun__shen_4pair, reg1745, reg1746)
+			reg1745 := Call(__e, __defun__shen_4tlhd, V200)
+			reg1746 := Call(__e, __defun__shen_4hdtl, V200)
+			reg1747 := Call(__e, __defun__shen_4pair, reg1745, reg1746)
 			reg1748 := PrimHead(reg1747)
-			__ctx.TailApply(__defun__shen_4pair, reg1748, Parse__X)
+			__e.TailApply(__defun__shen_4pair, reg1748, Parse__X)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<action>", value: __defun__shen_4_5action_6})
 
-	__defun__shen_4_5guard_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5guard_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V202 := __args[0]
 		_ = V202
 		reg1751 := PrimHead(V202)
 		reg1752 := PrimIsPair(reg1751)
 		if reg1752 == True {
-			reg1753 := __e.Call(__defun__shen_4hdhd, V202)
+			reg1753 := Call(__e, __defun__shen_4hdhd, V202)
 			Parse__X := reg1753
 			_ = Parse__X
-			reg1754 := __e.Call(__defun__shen_4tlhd, V202)
-			reg1755 := __e.Call(__defun__shen_4hdtl, V202)
-			reg1756 := __e.Call(__defun__shen_4pair, reg1754, reg1755)
+			reg1754 := Call(__e, __defun__shen_4tlhd, V202)
+			reg1755 := Call(__e, __defun__shen_4hdtl, V202)
+			reg1756 := Call(__e, __defun__shen_4pair, reg1754, reg1755)
 			reg1757 := PrimHead(reg1756)
-			__ctx.TailApply(__defun__shen_4pair, reg1757, Parse__X)
+			__e.TailApply(__defun__shen_4pair, reg1757, Parse__X)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<guard>", value: __defun__shen_4_5guard_6})
 
-	__defun__shen_4compile__to__machine__code = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4compile__to__machine__code = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V205 := __args[0]
 		_ = V205
 		V206 := __args[1]
 		_ = V206
-		reg1760 := __e.Call(__defun__shen_4compile__to__lambda_7, V205, V206)
+		reg1760 := Call(__e, __defun__shen_4compile__to__lambda_7, V205, V206)
 		Lambda_7 := reg1760
 		_ = Lambda_7
-		reg1761 := __e.Call(__defun__shen_4compile__to__kl, V205, Lambda_7)
+		reg1761 := Call(__e, __defun__shen_4compile__to__kl, V205, Lambda_7)
 		KL := reg1761
 		_ = KL
-		reg1762 := __e.Call(__defun__shen_4record_1source, V205, KL)
+		reg1762 := Call(__e, __defun__shen_4record_1source, V205, KL)
 		Record := reg1762
 		_ = Record
-		__ctx.Return(KL)
+		__e.Return(KL)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.compile_to_machine_code", value: __defun__shen_4compile__to__machine__code})
 
-	__defun__shen_4record_1source = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4record_1source = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V211 := __args[0]
 		_ = V211
 		V212 := __args[1]
@@ -2191,77 +2191,77 @@ func init() {
 		reg1764 := PrimValue(reg1763)
 		if reg1764 == True {
 			reg1765 := MakeSymbol("shen.skip")
-			__ctx.Return(reg1765)
+			__e.Return(reg1765)
 			return
 		} else {
 			reg1766 := MakeSymbol("shen.source")
 			reg1767 := MakeSymbol("*property-vector*")
 			reg1768 := PrimValue(reg1767)
-			__ctx.TailApply(__defun__put, V211, reg1766, V212, reg1768)
+			__e.TailApply(__defun__put, V211, reg1766, V212, reg1768)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.record-source", value: __defun__shen_4record_1source})
 
-	__defun__shen_4compile__to__lambda_7 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4compile__to__lambda_7 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V215 := __args[0]
 		_ = V215
 		V216 := __args[1]
 		_ = V216
-		reg1770 := __e.Call(__defun__shen_4aritycheck, V215, V216)
+		reg1770 := Call(__e, __defun__shen_4aritycheck, V215, V216)
 		Arity := reg1770
 		_ = Arity
-		reg1771 := __e.Call(__defun__shen_4update_1symbol_1table, V215, Arity)
+		reg1771 := Call(__e, __defun__shen_4update_1symbol_1table, V215, Arity)
 		UpDateSymbolTable := reg1771
 		_ = UpDateSymbolTable
-		reg1772 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg1772 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			Rule := __args[0]
 			_ = Rule
-			__ctx.TailApply(__defun__shen_4free__variable__check, V215, Rule)
+			__e.TailApply(__defun__shen_4free__variable__check, V215, Rule)
 			return
 		}, 1)
-		reg1774 := __e.Call(__defun__shen_4for_1each, reg1772, V216)
+		reg1774 := Call(__e, __defun__shen_4for_1each, reg1772, V216)
 		Free := reg1774
 		_ = Free
-		reg1775 := __e.Call(__defun__shen_4parameters, Arity)
+		reg1775 := Call(__e, __defun__shen_4parameters, Arity)
 		Variables := reg1775
 		_ = Variables
-		reg1776 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg1776 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4strip_1protect, X)
+			__e.TailApply(__defun__shen_4strip_1protect, X)
 			return
 		}, 1)
-		reg1778 := __e.Call(__defun__map, reg1776, V216)
+		reg1778 := Call(__e, __defun__map, reg1776, V216)
 		Strip := reg1778
 		_ = Strip
-		reg1779 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg1779 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4abstract__rule, X)
+			__e.TailApply(__defun__shen_4abstract__rule, X)
 			return
 		}, 1)
-		reg1781 := __e.Call(__defun__map, reg1779, Strip)
+		reg1781 := Call(__e, __defun__map, reg1779, Strip)
 		Abstractions := reg1781
 		_ = Abstractions
-		reg1782 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg1782 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4application__build, Variables, X)
+			__e.TailApply(__defun__shen_4application__build, Variables, X)
 			return
 		}, 1)
-		reg1784 := __e.Call(__defun__map, reg1782, Abstractions)
+		reg1784 := Call(__e, __defun__map, reg1782, Abstractions)
 		Applications := reg1784
 		_ = Applications
 		reg1785 := Nil
 		reg1786 := PrimCons(Applications, reg1785)
 		reg1787 := PrimCons(Variables, reg1786)
-		__ctx.Return(reg1787)
+		__e.Return(reg1787)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.compile_to_lambda+", value: __defun__shen_4compile__to__lambda_7})
 
-	__defun__shen_4update_1symbol_1table = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4update_1symbol_1table = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V219 := __args[0]
 		_ = V219
 		V220 := __args[1]
@@ -2270,21 +2270,21 @@ func init() {
 		reg1789 := PrimEqual(reg1788, V220)
 		if reg1789 == True {
 			reg1790 := MakeSymbol("shen.skip")
-			__ctx.Return(reg1790)
+			__e.Return(reg1790)
 			return
 		} else {
 			reg1791 := MakeSymbol("shen.lambda-form")
-			reg1792 := __e.Call(__defun__shen_4lambda_1form, V219, V220)
+			reg1792 := Call(__e, __defun__shen_4lambda_1form, V219, V220)
 			reg1793 := PrimEvalKL(__e, reg1792)
 			reg1794 := MakeSymbol("*property-vector*")
 			reg1795 := PrimValue(reg1794)
-			__ctx.TailApply(__defun__put, V219, reg1791, reg1793, reg1795)
+			__e.TailApply(__defun__put, V219, reg1791, reg1793, reg1795)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.update-symbol-table", value: __defun__shen_4update_1symbol_1table})
 
-	__defun__shen_4free__variable__check = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4free__variable__check = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V223 := __args[0]
 		_ = V223
 		V224 := __args[1]
@@ -2328,52 +2328,52 @@ func init() {
 		}
 		if reg1813 == True {
 			reg1814 := PrimHead(V224)
-			reg1815 := __e.Call(__defun__shen_4extract__vars, reg1814)
+			reg1815 := Call(__e, __defun__shen_4extract__vars, reg1814)
 			Bound := reg1815
 			_ = Bound
 			reg1816 := PrimTail(V224)
 			reg1817 := PrimHead(reg1816)
-			reg1818 := __e.Call(__defun__shen_4extract__free__vars, Bound, reg1817)
+			reg1818 := Call(__e, __defun__shen_4extract__free__vars, Bound, reg1817)
 			Free := reg1818
 			_ = Free
-			__ctx.TailApply(__defun__shen_4free__variable__warnings, V223, Free)
+			__e.TailApply(__defun__shen_4free__variable__warnings, V223, Free)
 			return
 		} else {
 			reg1820 := MakeSymbol("shen.free_variable_check")
-			__ctx.TailApply(__defun__shen_4f__error, reg1820)
+			__e.TailApply(__defun__shen_4f__error, reg1820)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.free_variable_check", value: __defun__shen_4free__variable__check})
 
-	__defun__shen_4extract__vars = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4extract__vars = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V226 := __args[0]
 		_ = V226
 		reg1822 := PrimIsVariable(V226)
 		if reg1822 == True {
 			reg1823 := Nil
 			reg1824 := PrimCons(V226, reg1823)
-			__ctx.Return(reg1824)
+			__e.Return(reg1824)
 			return
 		} else {
 			reg1825 := PrimIsPair(V226)
 			if reg1825 == True {
 				reg1826 := PrimHead(V226)
-				reg1827 := __e.Call(__defun__shen_4extract__vars, reg1826)
+				reg1827 := Call(__e, __defun__shen_4extract__vars, reg1826)
 				reg1828 := PrimTail(V226)
-				reg1829 := __e.Call(__defun__shen_4extract__vars, reg1828)
-				__ctx.TailApply(__defun__union, reg1827, reg1829)
+				reg1829 := Call(__e, __defun__shen_4extract__vars, reg1828)
+				__e.TailApply(__defun__union, reg1827, reg1829)
 				return
 			} else {
 				reg1831 := Nil
-				__ctx.Return(reg1831)
+				__e.Return(reg1831)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.extract_vars", value: __defun__shen_4extract__vars})
 
-	__defun__shen_4extract__free__vars = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4extract__free__vars = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V238 := __args[0]
 		_ = V238
 		V239 := __args[1]
@@ -2435,13 +2435,13 @@ func init() {
 		}
 		if reg1856 == True {
 			reg1857 := Nil
-			__ctx.Return(reg1857)
+			__e.Return(reg1857)
 			return
 		} else {
 			reg1858 := PrimIsVariable(V239)
 			var reg1865 Obj
 			if reg1858 == True {
-				reg1859 := __e.Call(__defun__element_2, V239, V238)
+				reg1859 := Call(__e, __defun__element_2, V239, V238)
 				reg1860 := PrimNot(reg1859)
 				var reg1863 Obj
 				if reg1860 == True {
@@ -2459,7 +2459,7 @@ func init() {
 			if reg1865 == True {
 				reg1866 := Nil
 				reg1867 := PrimCons(V239, reg1866)
-				__ctx.Return(reg1867)
+				__e.Return(reg1867)
 				return
 			} else {
 				reg1868 := PrimIsPair(V239)
@@ -2543,7 +2543,7 @@ func init() {
 					reg1905 := PrimTail(V239)
 					reg1906 := PrimTail(reg1905)
 					reg1907 := PrimHead(reg1906)
-					__ctx.TailApply(__defun__shen_4extract__free__vars, reg1904, reg1907)
+					__e.TailApply(__defun__shen_4extract__free__vars, reg1904, reg1907)
 					return
 				} else {
 					reg1909 := PrimIsPair(V239)
@@ -2644,7 +2644,7 @@ func init() {
 						reg1953 := PrimTail(V239)
 						reg1954 := PrimTail(reg1953)
 						reg1955 := PrimHead(reg1954)
-						reg1956 := __e.Call(__defun__shen_4extract__free__vars, V238, reg1955)
+						reg1956 := Call(__e, __defun__shen_4extract__free__vars, V238, reg1955)
 						reg1957 := PrimTail(V239)
 						reg1958 := PrimHead(reg1957)
 						reg1959 := PrimCons(reg1958, V238)
@@ -2652,21 +2652,21 @@ func init() {
 						reg1961 := PrimTail(reg1960)
 						reg1962 := PrimTail(reg1961)
 						reg1963 := PrimHead(reg1962)
-						reg1964 := __e.Call(__defun__shen_4extract__free__vars, reg1959, reg1963)
-						__ctx.TailApply(__defun__union, reg1956, reg1964)
+						reg1964 := Call(__e, __defun__shen_4extract__free__vars, reg1959, reg1963)
+						__e.TailApply(__defun__union, reg1956, reg1964)
 						return
 					} else {
 						reg1966 := PrimIsPair(V239)
 						if reg1966 == True {
 							reg1967 := PrimHead(V239)
-							reg1968 := __e.Call(__defun__shen_4extract__free__vars, V238, reg1967)
+							reg1968 := Call(__e, __defun__shen_4extract__free__vars, V238, reg1967)
 							reg1969 := PrimTail(V239)
-							reg1970 := __e.Call(__defun__shen_4extract__free__vars, V238, reg1969)
-							__ctx.TailApply(__defun__union, reg1968, reg1970)
+							reg1970 := Call(__e, __defun__shen_4extract__free__vars, V238, reg1969)
+							__e.TailApply(__defun__union, reg1968, reg1970)
 							return
 						} else {
 							reg1972 := Nil
-							__ctx.Return(reg1972)
+							__e.Return(reg1972)
 							return
 						}
 					}
@@ -2676,7 +2676,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.extract_free_vars", value: __defun__shen_4extract__free__vars})
 
-	__defun__shen_4free__variable__warnings = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4free__variable__warnings = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V244 := __args[0]
 		_ = V244
 		V245 := __args[1]
@@ -2685,27 +2685,27 @@ func init() {
 		reg1974 := PrimEqual(reg1973, V245)
 		if reg1974 == True {
 			reg1975 := MakeSymbol("_")
-			__ctx.Return(reg1975)
+			__e.Return(reg1975)
 			return
 		} else {
 			reg1976 := MakeString("error: the following variables are free in ")
 			reg1977 := MakeString(": ")
-			reg1978 := __e.Call(__defun__shen_4list__variables, V245)
+			reg1978 := Call(__e, __defun__shen_4list__variables, V245)
 			reg1979 := MakeString("")
 			reg1980 := MakeSymbol("shen.a")
-			reg1981 := __e.Call(__defun__shen_4app, reg1978, reg1979, reg1980)
+			reg1981 := Call(__e, __defun__shen_4app, reg1978, reg1979, reg1980)
 			reg1982 := PrimStringConcat(reg1977, reg1981)
 			reg1983 := MakeSymbol("shen.a")
-			reg1984 := __e.Call(__defun__shen_4app, V244, reg1982, reg1983)
+			reg1984 := Call(__e, __defun__shen_4app, V244, reg1982, reg1983)
 			reg1985 := PrimStringConcat(reg1976, reg1984)
 			reg1986 := PrimSimpleError(reg1985)
-			__ctx.Return(reg1986)
+			__e.Return(reg1986)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.free_variable_warnings", value: __defun__shen_4free__variable__warnings})
 
-	__defun__shen_4list__variables = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4list__variables = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V247 := __args[0]
 		_ = V247
 		reg1987 := PrimIsPair(V247)
@@ -2732,7 +2732,7 @@ func init() {
 			reg1997 := PrimStr(reg1996)
 			reg1998 := MakeString(".")
 			reg1999 := PrimStringConcat(reg1997, reg1998)
-			__ctx.Return(reg1999)
+			__e.Return(reg1999)
 			return
 		} else {
 			reg2000 := PrimIsPair(V247)
@@ -2741,21 +2741,21 @@ func init() {
 				reg2002 := PrimStr(reg2001)
 				reg2003 := MakeString(", ")
 				reg2004 := PrimTail(V247)
-				reg2005 := __e.Call(__defun__shen_4list__variables, reg2004)
+				reg2005 := Call(__e, __defun__shen_4list__variables, reg2004)
 				reg2006 := PrimStringConcat(reg2003, reg2005)
 				reg2007 := PrimStringConcat(reg2002, reg2006)
-				__ctx.Return(reg2007)
+				__e.Return(reg2007)
 				return
 			} else {
 				reg2008 := MakeSymbol("shen.list_variables")
-				__ctx.TailApply(__defun__shen_4f__error, reg2008)
+				__e.TailApply(__defun__shen_4f__error, reg2008)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.list_variables", value: __defun__shen_4list__variables})
 
-	__defun__shen_4strip_1protect = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4strip_1protect = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V249 := __args[0]
 		_ = V249
 		reg2010 := PrimIsPair(V249)
@@ -2816,28 +2816,28 @@ func init() {
 		if reg2034 == True {
 			reg2035 := PrimTail(V249)
 			reg2036 := PrimHead(reg2035)
-			__ctx.TailApply(__defun__shen_4strip_1protect, reg2036)
+			__e.TailApply(__defun__shen_4strip_1protect, reg2036)
 			return
 		} else {
 			reg2038 := PrimIsPair(V249)
 			if reg2038 == True {
-				reg2039 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg2039 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					Z := __args[0]
 					_ = Z
-					__ctx.TailApply(__defun__shen_4strip_1protect, Z)
+					__e.TailApply(__defun__shen_4strip_1protect, Z)
 					return
 				}, 1)
-				__ctx.TailApply(__defun__map, reg2039, V249)
+				__e.TailApply(__defun__map, reg2039, V249)
 				return
 			} else {
-				__ctx.Return(V249)
+				__e.Return(V249)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.strip-protect", value: __defun__shen_4strip_1protect})
 
-	__defun__shen_4linearise = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4linearise = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V251 := __args[0]
 		_ = V251
 		reg2042 := PrimIsPair(V251)
@@ -2879,49 +2879,49 @@ func init() {
 		}
 		if reg2058 == True {
 			reg2059 := PrimHead(V251)
-			reg2060 := __e.Call(__defun__shen_4flatten, reg2059)
+			reg2060 := Call(__e, __defun__shen_4flatten, reg2059)
 			reg2061 := PrimHead(V251)
 			reg2062 := PrimTail(V251)
 			reg2063 := PrimHead(reg2062)
-			__ctx.TailApply(__defun__shen_4linearise__help, reg2060, reg2061, reg2063)
+			__e.TailApply(__defun__shen_4linearise__help, reg2060, reg2061, reg2063)
 			return
 		} else {
 			reg2065 := MakeSymbol("shen.linearise")
-			__ctx.TailApply(__defun__shen_4f__error, reg2065)
+			__e.TailApply(__defun__shen_4f__error, reg2065)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.linearise", value: __defun__shen_4linearise})
 
-	__defun__shen_4flatten = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4flatten = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V253 := __args[0]
 		_ = V253
 		reg2067 := Nil
 		reg2068 := PrimEqual(reg2067, V253)
 		if reg2068 == True {
 			reg2069 := Nil
-			__ctx.Return(reg2069)
+			__e.Return(reg2069)
 			return
 		} else {
 			reg2070 := PrimIsPair(V253)
 			if reg2070 == True {
 				reg2071 := PrimHead(V253)
-				reg2072 := __e.Call(__defun__shen_4flatten, reg2071)
+				reg2072 := Call(__e, __defun__shen_4flatten, reg2071)
 				reg2073 := PrimTail(V253)
-				reg2074 := __e.Call(__defun__shen_4flatten, reg2073)
-				__ctx.TailApply(__defun__append, reg2072, reg2074)
+				reg2074 := Call(__e, __defun__shen_4flatten, reg2073)
+				__e.TailApply(__defun__append, reg2072, reg2074)
 				return
 			} else {
 				reg2076 := Nil
 				reg2077 := PrimCons(V253, reg2076)
-				__ctx.Return(reg2077)
+				__e.Return(reg2077)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.flatten", value: __defun__shen_4flatten})
 
-	__defun__shen_4linearise__help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4linearise__help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V257 := __args[0]
 		_ = V257
 		V258 := __args[1]
@@ -2934,7 +2934,7 @@ func init() {
 			reg2080 := Nil
 			reg2081 := PrimCons(V259, reg2080)
 			reg2082 := PrimCons(V258, reg2081)
-			__ctx.Return(reg2082)
+			__e.Return(reg2082)
 			return
 		} else {
 			reg2083 := PrimIsPair(V257)
@@ -2945,7 +2945,7 @@ func init() {
 				if reg2085 == True {
 					reg2086 := PrimHead(V257)
 					reg2087 := PrimTail(V257)
-					reg2088 := __e.Call(__defun__element_2, reg2086, reg2087)
+					reg2088 := Call(__e, __defun__element_2, reg2086, reg2087)
 					var reg2091 Obj
 					if reg2088 == True {
 						reg2089 := True
@@ -2961,7 +2961,7 @@ func init() {
 				}
 				if reg2093 == True {
 					reg2094 := PrimHead(V257)
-					reg2095 := __e.Call(__defun__gensym, reg2094)
+					reg2095 := Call(__e, __defun__gensym, reg2094)
 					Var := reg2095
 					_ = Var
 					reg2096 := MakeSymbol("where")
@@ -2978,27 +2978,27 @@ func init() {
 					NewAction := reg2106
 					_ = NewAction
 					reg2107 := PrimHead(V257)
-					reg2108 := __e.Call(__defun__shen_4linearise__X, reg2107, Var, V258)
+					reg2108 := Call(__e, __defun__shen_4linearise__X, reg2107, Var, V258)
 					NewPatts := reg2108
 					_ = NewPatts
 					reg2109 := PrimTail(V257)
-					__ctx.TailApply(__defun__shen_4linearise__help, reg2109, NewPatts, NewAction)
+					__e.TailApply(__defun__shen_4linearise__help, reg2109, NewPatts, NewAction)
 					return
 				} else {
 					reg2111 := PrimTail(V257)
-					__ctx.TailApply(__defun__shen_4linearise__help, reg2111, V258, V259)
+					__e.TailApply(__defun__shen_4linearise__help, reg2111, V258, V259)
 					return
 				}
 			} else {
 				reg2113 := MakeSymbol("shen.linearise_help")
-				__ctx.TailApply(__defun__shen_4f__error, reg2113)
+				__e.TailApply(__defun__shen_4f__error, reg2113)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.linearise_help", value: __defun__shen_4linearise__help})
 
-	__defun__shen_4linearise__X = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4linearise__X = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V272 := __args[0]
 		_ = V272
 		V273 := __args[1]
@@ -3007,13 +3007,13 @@ func init() {
 		_ = V274
 		reg2115 := PrimEqual(V274, V272)
 		if reg2115 == True {
-			__ctx.Return(V273)
+			__e.Return(V273)
 			return
 		} else {
 			reg2116 := PrimIsPair(V274)
 			if reg2116 == True {
 				reg2117 := PrimHead(V274)
-				reg2118 := __e.Call(__defun__shen_4linearise__X, V272, V273, reg2117)
+				reg2118 := Call(__e, __defun__shen_4linearise__X, V272, V273, reg2117)
 				L := reg2118
 				_ = L
 				reg2119 := PrimHead(V274)
@@ -3021,25 +3021,25 @@ func init() {
 				if reg2120 == True {
 					reg2121 := PrimHead(V274)
 					reg2122 := PrimTail(V274)
-					reg2123 := __e.Call(__defun__shen_4linearise__X, V272, V273, reg2122)
+					reg2123 := Call(__e, __defun__shen_4linearise__X, V272, V273, reg2122)
 					reg2124 := PrimCons(reg2121, reg2123)
-					__ctx.Return(reg2124)
+					__e.Return(reg2124)
 					return
 				} else {
 					reg2125 := PrimTail(V274)
 					reg2126 := PrimCons(L, reg2125)
-					__ctx.Return(reg2126)
+					__e.Return(reg2126)
 					return
 				}
 			} else {
-				__ctx.Return(V274)
+				__e.Return(V274)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.linearise_X", value: __defun__shen_4linearise__X})
 
-	__defun__shen_4aritycheck = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4aritycheck = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V277 := __args[0]
 		_ = V277
 		V278 := __args[1]
@@ -3122,13 +3122,13 @@ func init() {
 			reg2161 := PrimHead(V278)
 			reg2162 := PrimTail(reg2161)
 			reg2163 := PrimHead(reg2162)
-			reg2164 := __e.Call(__defun__shen_4aritycheck_1action, reg2163)
+			reg2164 := Call(__e, __defun__shen_4aritycheck_1action, reg2163)
 			_ = reg2164
-			reg2165 := __e.Call(__defun__arity, V277)
+			reg2165 := Call(__e, __defun__arity, V277)
 			reg2166 := PrimHead(V278)
 			reg2167 := PrimHead(reg2166)
-			reg2168 := __e.Call(__defun__length, reg2167)
-			__ctx.TailApply(__defun__shen_4aritycheck_1name, V277, reg2165, reg2168)
+			reg2168 := Call(__e, __defun__length, reg2167)
+			__e.TailApply(__defun__shen_4aritycheck_1name, V277, reg2165, reg2168)
 			return
 		} else {
 			reg2170 := PrimIsPair(V278)
@@ -3265,41 +3265,41 @@ func init() {
 			if reg2230 == True {
 				reg2231 := PrimHead(V278)
 				reg2232 := PrimHead(reg2231)
-				reg2233 := __e.Call(__defun__length, reg2232)
+				reg2233 := Call(__e, __defun__length, reg2232)
 				reg2234 := PrimTail(V278)
 				reg2235 := PrimHead(reg2234)
 				reg2236 := PrimHead(reg2235)
-				reg2237 := __e.Call(__defun__length, reg2236)
+				reg2237 := Call(__e, __defun__length, reg2236)
 				reg2238 := PrimEqual(reg2233, reg2237)
 				if reg2238 == True {
 					reg2239 := PrimHead(V278)
 					reg2240 := PrimTail(reg2239)
 					reg2241 := PrimHead(reg2240)
-					reg2242 := __e.Call(__defun__shen_4aritycheck_1action, reg2241)
+					reg2242 := Call(__e, __defun__shen_4aritycheck_1action, reg2241)
 					_ = reg2242
 					reg2243 := PrimTail(V278)
-					__ctx.TailApply(__defun__shen_4aritycheck, V277, reg2243)
+					__e.TailApply(__defun__shen_4aritycheck, V277, reg2243)
 					return
 				} else {
 					reg2245 := MakeString("arity error in ")
 					reg2246 := MakeString("\n")
 					reg2247 := MakeSymbol("shen.a")
-					reg2248 := __e.Call(__defun__shen_4app, V277, reg2246, reg2247)
+					reg2248 := Call(__e, __defun__shen_4app, V277, reg2246, reg2247)
 					reg2249 := PrimStringConcat(reg2245, reg2248)
 					reg2250 := PrimSimpleError(reg2249)
-					__ctx.Return(reg2250)
+					__e.Return(reg2250)
 					return
 				}
 			} else {
 				reg2251 := MakeSymbol("shen.aritycheck")
-				__ctx.TailApply(__defun__shen_4f__error, reg2251)
+				__e.TailApply(__defun__shen_4f__error, reg2251)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.aritycheck", value: __defun__shen_4aritycheck})
 
-	__defun__shen_4aritycheck_1name = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4aritycheck_1name = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V291 := __args[0]
 		_ = V291
 		V292 := __args[1]
@@ -3309,63 +3309,63 @@ func init() {
 		reg2253 := MakeNumber(-1)
 		reg2254 := PrimEqual(reg2253, V292)
 		if reg2254 == True {
-			__ctx.Return(V293)
+			__e.Return(V293)
 			return
 		} else {
 			reg2255 := PrimEqual(V293, V292)
 			if reg2255 == True {
-				__ctx.Return(V293)
+				__e.Return(V293)
 				return
 			} else {
 				reg2256 := MakeString("\nwarning: changing the arity of ")
 				reg2257 := MakeString(" can cause errors.\n")
 				reg2258 := MakeSymbol("shen.a")
-				reg2259 := __e.Call(__defun__shen_4app, V291, reg2257, reg2258)
+				reg2259 := Call(__e, __defun__shen_4app, V291, reg2257, reg2258)
 				reg2260 := PrimStringConcat(reg2256, reg2259)
-				reg2261 := __e.Call(__defun__stoutput)
-				reg2262 := __e.Call(__defun__shen_4prhush, reg2260, reg2261)
+				reg2261 := Call(__e, __defun__stoutput)
+				reg2262 := Call(__e, __defun__shen_4prhush, reg2260, reg2261)
 				_ = reg2262
-				__ctx.Return(V293)
+				__e.Return(V293)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.aritycheck-name", value: __defun__shen_4aritycheck_1name})
 
-	__defun__shen_4aritycheck_1action = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4aritycheck_1action = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V299 := __args[0]
 		_ = V299
 		reg2263 := PrimIsPair(V299)
 		if reg2263 == True {
 			reg2264 := PrimHead(V299)
 			reg2265 := PrimTail(V299)
-			reg2266 := __e.Call(__defun__shen_4aah, reg2264, reg2265)
+			reg2266 := Call(__e, __defun__shen_4aah, reg2264, reg2265)
 			_ = reg2266
-			reg2267 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg2267 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Y := __args[0]
 				_ = Y
-				__ctx.TailApply(__defun__shen_4aritycheck_1action, Y)
+				__e.TailApply(__defun__shen_4aritycheck_1action, Y)
 				return
 			}, 1)
-			__ctx.TailApply(__defun__shen_4for_1each, reg2267, V299)
+			__e.TailApply(__defun__shen_4for_1each, reg2267, V299)
 			return
 		} else {
 			reg2270 := MakeSymbol("shen.skip")
-			__ctx.Return(reg2270)
+			__e.Return(reg2270)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.aritycheck-action", value: __defun__shen_4aritycheck_1action})
 
-	__defun__shen_4aah = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4aah = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V302 := __args[0]
 		_ = V302
 		V303 := __args[1]
 		_ = V303
-		reg2271 := __e.Call(__defun__arity, V302)
+		reg2271 := Call(__e, __defun__arity, V302)
 		Arity := reg2271
 		_ = Arity
-		reg2272 := __e.Call(__defun__length, V303)
+		reg2272 := Call(__e, __defun__length, V303)
 		Len := reg2272
 		_ = Len
 		reg2273 := MakeNumber(-1)
@@ -3402,26 +3402,26 @@ func init() {
 			}
 			reg2289 := MakeString(".\n")
 			reg2290 := MakeSymbol("shen.a")
-			reg2291 := __e.Call(__defun__shen_4app, reg2288, reg2289, reg2290)
+			reg2291 := Call(__e, __defun__shen_4app, reg2288, reg2289, reg2290)
 			reg2292 := PrimStringConcat(reg2283, reg2291)
 			reg2293 := MakeSymbol("shen.a")
-			reg2294 := __e.Call(__defun__shen_4app, Len, reg2292, reg2293)
+			reg2294 := Call(__e, __defun__shen_4app, Len, reg2292, reg2293)
 			reg2295 := PrimStringConcat(reg2282, reg2294)
 			reg2296 := MakeSymbol("shen.a")
-			reg2297 := __e.Call(__defun__shen_4app, V302, reg2295, reg2296)
+			reg2297 := Call(__e, __defun__shen_4app, V302, reg2295, reg2296)
 			reg2298 := PrimStringConcat(reg2281, reg2297)
-			reg2299 := __e.Call(__defun__stoutput)
-			__ctx.TailApply(__defun__shen_4prhush, reg2298, reg2299)
+			reg2299 := Call(__e, __defun__stoutput)
+			__e.TailApply(__defun__shen_4prhush, reg2298, reg2299)
 			return
 		} else {
 			reg2301 := MakeSymbol("shen.skip")
-			__ctx.Return(reg2301)
+			__e.Return(reg2301)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.aah", value: __defun__shen_4aah})
 
-	__defun__shen_4abstract__rule = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4abstract__rule = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V305 := __args[0]
 		_ = V305
 		reg2302 := PrimIsPair(V305)
@@ -3465,17 +3465,17 @@ func init() {
 			reg2319 := PrimHead(V305)
 			reg2320 := PrimTail(V305)
 			reg2321 := PrimHead(reg2320)
-			__ctx.TailApply(__defun__shen_4abstraction__build, reg2319, reg2321)
+			__e.TailApply(__defun__shen_4abstraction__build, reg2319, reg2321)
 			return
 		} else {
 			reg2323 := MakeSymbol("shen.abstract_rule")
-			__ctx.TailApply(__defun__shen_4f__error, reg2323)
+			__e.TailApply(__defun__shen_4f__error, reg2323)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.abstract_rule", value: __defun__shen_4abstract__rule})
 
-	__defun__shen_4abstraction__build = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4abstraction__build = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V308 := __args[0]
 		_ = V308
 		V309 := __args[1]
@@ -3483,7 +3483,7 @@ func init() {
 		reg2325 := Nil
 		reg2326 := PrimEqual(reg2325, V308)
 		if reg2326 == True {
-			__ctx.Return(V309)
+			__e.Return(V309)
 			return
 		} else {
 			reg2327 := PrimIsPair(V308)
@@ -3491,45 +3491,45 @@ func init() {
 				reg2328 := MakeSymbol("/.")
 				reg2329 := PrimHead(V308)
 				reg2330 := PrimTail(V308)
-				reg2331 := __e.Call(__defun__shen_4abstraction__build, reg2330, V309)
+				reg2331 := Call(__e, __defun__shen_4abstraction__build, reg2330, V309)
 				reg2332 := Nil
 				reg2333 := PrimCons(reg2331, reg2332)
 				reg2334 := PrimCons(reg2329, reg2333)
 				reg2335 := PrimCons(reg2328, reg2334)
-				__ctx.Return(reg2335)
+				__e.Return(reg2335)
 				return
 			} else {
 				reg2336 := MakeSymbol("shen.abstraction_build")
-				__ctx.TailApply(__defun__shen_4f__error, reg2336)
+				__e.TailApply(__defun__shen_4f__error, reg2336)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.abstraction_build", value: __defun__shen_4abstraction__build})
 
-	__defun__shen_4parameters = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4parameters = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V311 := __args[0]
 		_ = V311
 		reg2338 := MakeNumber(0)
 		reg2339 := PrimEqual(reg2338, V311)
 		if reg2339 == True {
 			reg2340 := Nil
-			__ctx.Return(reg2340)
+			__e.Return(reg2340)
 			return
 		} else {
 			reg2341 := MakeSymbol("V")
-			reg2342 := __e.Call(__defun__gensym, reg2341)
+			reg2342 := Call(__e, __defun__gensym, reg2341)
 			reg2343 := MakeNumber(1)
 			reg2344 := PrimNumberSubtract(V311, reg2343)
-			reg2345 := __e.Call(__defun__shen_4parameters, reg2344)
+			reg2345 := Call(__e, __defun__shen_4parameters, reg2344)
 			reg2346 := PrimCons(reg2342, reg2345)
-			__ctx.Return(reg2346)
+			__e.Return(reg2346)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.parameters", value: __defun__shen_4parameters})
 
-	__defun__shen_4application__build = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4application__build = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V314 := __args[0]
 		_ = V314
 		V315 := __args[1]
@@ -3537,7 +3537,7 @@ func init() {
 		reg2347 := Nil
 		reg2348 := PrimEqual(reg2347, V314)
 		if reg2348 == True {
-			__ctx.Return(V315)
+			__e.Return(V315)
 			return
 		} else {
 			reg2349 := PrimIsPair(V314)
@@ -3547,18 +3547,18 @@ func init() {
 				reg2352 := Nil
 				reg2353 := PrimCons(reg2351, reg2352)
 				reg2354 := PrimCons(V315, reg2353)
-				__ctx.TailApply(__defun__shen_4application__build, reg2350, reg2354)
+				__e.TailApply(__defun__shen_4application__build, reg2350, reg2354)
 				return
 			} else {
 				reg2356 := MakeSymbol("shen.application_build")
-				__ctx.TailApply(__defun__shen_4f__error, reg2356)
+				__e.TailApply(__defun__shen_4f__error, reg2356)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.application_build", value: __defun__shen_4application__build})
 
-	__defun__shen_4compile__to__kl = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4compile__to__kl = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V318 := __args[0]
 		_ = V318
 		V319 := __args[1]
@@ -3602,32 +3602,32 @@ func init() {
 		}
 		if reg2374 == True {
 			reg2375 := PrimHead(V319)
-			reg2376 := __e.Call(__defun__length, reg2375)
-			reg2377 := __e.Call(__defun__shen_4store_1arity, V318, reg2376)
+			reg2376 := Call(__e, __defun__length, reg2375)
+			reg2377 := Call(__e, __defun__shen_4store_1arity, V318, reg2376)
 			Arity := reg2377
 			_ = Arity
-			reg2378 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg2378 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				__ctx.TailApply(__defun__shen_4reduce, X)
+				__e.TailApply(__defun__shen_4reduce, X)
 				return
 			}, 1)
 			reg2380 := PrimTail(V319)
 			reg2381 := PrimHead(reg2380)
-			reg2382 := __e.Call(__defun__map, reg2378, reg2381)
+			reg2382 := Call(__e, __defun__map, reg2378, reg2381)
 			Reduce := reg2382
 			_ = Reduce
 			reg2383 := PrimHead(V319)
-			reg2384 := __e.Call(__defun__shen_4cond_1expression, V318, reg2383, Reduce)
+			reg2384 := Call(__e, __defun__shen_4cond_1expression, V318, reg2383, Reduce)
 			CondExpression := reg2384
 			_ = CondExpression
 			reg2385 := MakeSymbol("shen.*optimise*")
 			reg2386 := PrimValue(reg2385)
 			var reg2391 Obj
 			if reg2386 == True {
-				reg2387 := __e.Call(__defun__shen_4get_1type, V318)
+				reg2387 := Call(__e, __defun__shen_4get_1type, V318)
 				reg2388 := PrimHead(V319)
-				reg2389 := __e.Call(__defun__shen_4typextable, reg2387, reg2388)
+				reg2389 := Call(__e, __defun__shen_4typextable, reg2387, reg2388)
 				reg2391 = reg2389
 			} else {
 				reg2390 := MakeSymbol("shen.skip")
@@ -3640,7 +3640,7 @@ func init() {
 			var reg2396 Obj
 			if reg2393 == True {
 				reg2394 := PrimHead(V319)
-				reg2395 := __e.Call(__defun__shen_4assign_1types, reg2394, TypeTable, CondExpression)
+				reg2395 := Call(__e, __defun__shen_4assign_1types, reg2394, TypeTable, CondExpression)
 				reg2396 = reg2395
 			} else {
 				reg2396 = CondExpression
@@ -3654,45 +3654,45 @@ func init() {
 			reg2401 := PrimCons(reg2398, reg2400)
 			reg2402 := PrimCons(V318, reg2401)
 			reg2403 := PrimCons(reg2397, reg2402)
-			__ctx.Return(reg2403)
+			__e.Return(reg2403)
 			return
 		} else {
 			reg2404 := MakeSymbol("shen.compile_to_kl")
-			__ctx.TailApply(__defun__shen_4f__error, reg2404)
+			__e.TailApply(__defun__shen_4f__error, reg2404)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.compile_to_kl", value: __defun__shen_4compile__to__kl})
 
-	__defun__shen_4get_1type = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4get_1type = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V325 := __args[0]
 		_ = V325
 		reg2406 := PrimIsPair(V325)
 		if reg2406 == True {
 			reg2407 := MakeSymbol("shen.skip")
-			__ctx.Return(reg2407)
+			__e.Return(reg2407)
 			return
 		} else {
 			reg2408 := MakeSymbol("shen.*signedfuncs*")
 			reg2409 := PrimValue(reg2408)
-			reg2410 := __e.Call(__defun__assoc, V325, reg2409)
+			reg2410 := Call(__e, __defun__assoc, V325, reg2409)
 			FType := reg2410
 			_ = FType
-			reg2411 := __e.Call(__defun__empty_2, FType)
+			reg2411 := Call(__e, __defun__empty_2, FType)
 			if reg2411 == True {
 				reg2412 := MakeSymbol("shen.skip")
-				__ctx.Return(reg2412)
+				__e.Return(reg2412)
 				return
 			} else {
 				reg2413 := PrimTail(FType)
-				__ctx.Return(reg2413)
+				__e.Return(reg2413)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.get-type", value: __defun__shen_4get_1type})
 
-	__defun__shen_4typextable = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4typextable = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V336 := __args[0]
 		_ = V336
 		V337 := __args[1]
@@ -3796,7 +3796,7 @@ func init() {
 				reg2458 := PrimTail(reg2457)
 				reg2459 := PrimHead(reg2458)
 				reg2460 := PrimTail(V337)
-				__ctx.TailApply(__defun__shen_4typextable, reg2459, reg2460)
+				__e.TailApply(__defun__shen_4typextable, reg2459, reg2460)
 				return
 			} else {
 				reg2462 := PrimHead(V337)
@@ -3806,20 +3806,20 @@ func init() {
 				reg2466 := PrimTail(reg2465)
 				reg2467 := PrimHead(reg2466)
 				reg2468 := PrimTail(V337)
-				reg2469 := __e.Call(__defun__shen_4typextable, reg2467, reg2468)
+				reg2469 := Call(__e, __defun__shen_4typextable, reg2467, reg2468)
 				reg2470 := PrimCons(reg2464, reg2469)
-				__ctx.Return(reg2470)
+				__e.Return(reg2470)
 				return
 			}
 		} else {
 			reg2471 := Nil
-			__ctx.Return(reg2471)
+			__e.Return(reg2471)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.typextable", value: __defun__shen_4typextable})
 
-	__defun__shen_4assign_1types = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4assign_1types = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V341 := __args[0]
 		_ = V341
 		V342 := __args[1]
@@ -3927,7 +3927,7 @@ func init() {
 			reg2519 := PrimTail(V343)
 			reg2520 := PrimTail(reg2519)
 			reg2521 := PrimHead(reg2520)
-			reg2522 := __e.Call(__defun__shen_4assign_1types, V341, V342, reg2521)
+			reg2522 := Call(__e, __defun__shen_4assign_1types, V341, V342, reg2521)
 			reg2523 := PrimTail(V343)
 			reg2524 := PrimHead(reg2523)
 			reg2525 := PrimCons(reg2524, V341)
@@ -3935,13 +3935,13 @@ func init() {
 			reg2527 := PrimTail(reg2526)
 			reg2528 := PrimTail(reg2527)
 			reg2529 := PrimHead(reg2528)
-			reg2530 := __e.Call(__defun__shen_4assign_1types, reg2525, V342, reg2529)
+			reg2530 := Call(__e, __defun__shen_4assign_1types, reg2525, V342, reg2529)
 			reg2531 := Nil
 			reg2532 := PrimCons(reg2530, reg2531)
 			reg2533 := PrimCons(reg2522, reg2532)
 			reg2534 := PrimCons(reg2518, reg2533)
 			reg2535 := PrimCons(reg2516, reg2534)
-			__ctx.Return(reg2535)
+			__e.Return(reg2535)
 			return
 		} else {
 			reg2536 := PrimIsPair(V343)
@@ -4028,12 +4028,12 @@ func init() {
 				reg2576 := PrimTail(V343)
 				reg2577 := PrimTail(reg2576)
 				reg2578 := PrimHead(reg2577)
-				reg2579 := __e.Call(__defun__shen_4assign_1types, reg2575, V342, reg2578)
+				reg2579 := Call(__e, __defun__shen_4assign_1types, reg2575, V342, reg2578)
 				reg2580 := Nil
 				reg2581 := PrimCons(reg2579, reg2580)
 				reg2582 := PrimCons(reg2572, reg2581)
 				reg2583 := PrimCons(reg2570, reg2582)
-				__ctx.Return(reg2583)
+				__e.Return(reg2583)
 				return
 			} else {
 				reg2584 := PrimIsPair(V343)
@@ -4057,49 +4057,49 @@ func init() {
 				}
 				if reg2592 == True {
 					reg2593 := MakeSymbol("cond")
-					reg2594 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg2594 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						Y := __args[0]
 						_ = Y
 						reg2595 := PrimHead(Y)
-						reg2596 := __e.Call(__defun__shen_4assign_1types, V341, V342, reg2595)
+						reg2596 := Call(__e, __defun__shen_4assign_1types, V341, V342, reg2595)
 						reg2597 := PrimTail(Y)
 						reg2598 := PrimHead(reg2597)
-						reg2599 := __e.Call(__defun__shen_4assign_1types, V341, V342, reg2598)
+						reg2599 := Call(__e, __defun__shen_4assign_1types, V341, V342, reg2598)
 						reg2600 := Nil
 						reg2601 := PrimCons(reg2599, reg2600)
 						reg2602 := PrimCons(reg2596, reg2601)
-						__ctx.Return(reg2602)
+						__e.Return(reg2602)
 						return
 					}, 1)
 					reg2603 := PrimTail(V343)
-					reg2604 := __e.Call(__defun__map, reg2594, reg2603)
+					reg2604 := Call(__e, __defun__map, reg2594, reg2603)
 					reg2605 := PrimCons(reg2593, reg2604)
-					__ctx.Return(reg2605)
+					__e.Return(reg2605)
 					return
 				} else {
 					reg2606 := PrimIsPair(V343)
 					if reg2606 == True {
 						reg2607 := PrimHead(V343)
-						reg2608 := __e.Call(__defun__shen_4get_1type, reg2607)
+						reg2608 := Call(__e, __defun__shen_4get_1type, reg2607)
 						reg2609 := PrimTail(V343)
-						reg2610 := __e.Call(__defun__shen_4typextable, reg2608, reg2609)
+						reg2610 := Call(__e, __defun__shen_4typextable, reg2608, reg2609)
 						NewTable := reg2610
 						_ = NewTable
 						reg2611 := PrimHead(V343)
-						reg2612 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+						reg2612 := MakeNative(func(__e Evaluator, __args ...Obj) {
 							Y := __args[0]
 							_ = Y
-							reg2613 := __e.Call(__defun__append, V342, NewTable)
-							__ctx.TailApply(__defun__shen_4assign_1types, V341, reg2613, Y)
+							reg2613 := Call(__e, __defun__append, V342, NewTable)
+							__e.TailApply(__defun__shen_4assign_1types, V341, reg2613, Y)
 							return
 						}, 1)
 						reg2615 := PrimTail(V343)
-						reg2616 := __e.Call(__defun__map, reg2612, reg2615)
+						reg2616 := Call(__e, __defun__map, reg2612, reg2615)
 						reg2617 := PrimCons(reg2611, reg2616)
-						__ctx.Return(reg2617)
+						__e.Return(reg2617)
 						return
 					} else {
-						reg2618 := __e.Call(__defun__assoc, V343, V342)
+						reg2618 := Call(__e, __defun__assoc, V343, V342)
 						AtomType := reg2618
 						_ = AtomType
 						reg2619 := PrimIsPair(AtomType)
@@ -4110,15 +4110,15 @@ func init() {
 							reg2623 := PrimCons(reg2621, reg2622)
 							reg2624 := PrimCons(V343, reg2623)
 							reg2625 := PrimCons(reg2620, reg2624)
-							__ctx.Return(reg2625)
+							__e.Return(reg2625)
 							return
 						} else {
-							reg2626 := __e.Call(__defun__element_2, V343, V341)
+							reg2626 := Call(__e, __defun__element_2, V343, V341)
 							if reg2626 == True {
-								__ctx.Return(V343)
+								__e.Return(V343)
 								return
 							} else {
-								__ctx.TailApply(__defun__shen_4atom_1type, V343)
+								__e.TailApply(__defun__shen_4atom_1type, V343)
 								return
 							}
 						}
@@ -4129,7 +4129,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.assign-types", value: __defun__shen_4assign_1types})
 
-	__defun__shen_4atom_1type = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4atom_1type = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V345 := __args[0]
 		_ = V345
 		reg2628 := PrimIsString(V345)
@@ -4140,7 +4140,7 @@ func init() {
 			reg2632 := PrimCons(reg2630, reg2631)
 			reg2633 := PrimCons(V345, reg2632)
 			reg2634 := PrimCons(reg2629, reg2633)
-			__ctx.Return(reg2634)
+			__e.Return(reg2634)
 			return
 		} else {
 			reg2635 := PrimIsNumber(V345)
@@ -4151,10 +4151,10 @@ func init() {
 				reg2639 := PrimCons(reg2637, reg2638)
 				reg2640 := PrimCons(V345, reg2639)
 				reg2641 := PrimCons(reg2636, reg2640)
-				__ctx.Return(reg2641)
+				__e.Return(reg2641)
 				return
 			} else {
-				reg2642 := __e.Call(__defun__boolean_2, V345)
+				reg2642 := Call(__e, __defun__boolean_2, V345)
 				if reg2642 == True {
 					reg2643 := MakeSymbol("type")
 					reg2644 := MakeSymbol("boolean")
@@ -4162,7 +4162,7 @@ func init() {
 					reg2646 := PrimCons(reg2644, reg2645)
 					reg2647 := PrimCons(V345, reg2646)
 					reg2648 := PrimCons(reg2643, reg2647)
-					__ctx.Return(reg2648)
+					__e.Return(reg2648)
 					return
 				} else {
 					reg2649 := PrimIsSymbol(V345)
@@ -4173,10 +4173,10 @@ func init() {
 						reg2653 := PrimCons(reg2651, reg2652)
 						reg2654 := PrimCons(V345, reg2653)
 						reg2655 := PrimCons(reg2650, reg2654)
-						__ctx.Return(reg2655)
+						__e.Return(reg2655)
 						return
 					} else {
-						__ctx.Return(V345)
+						__e.Return(V345)
 						return
 					}
 				}
@@ -4185,7 +4185,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.atom-type", value: __defun__shen_4atom_1type})
 
-	__defun__shen_4store_1arity = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4store_1arity = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V350 := __args[0]
 		_ = V350
 		V351 := __args[1]
@@ -4194,44 +4194,44 @@ func init() {
 		reg2657 := PrimValue(reg2656)
 		if reg2657 == True {
 			reg2658 := MakeSymbol("shen.skip")
-			__ctx.Return(reg2658)
+			__e.Return(reg2658)
 			return
 		} else {
 			reg2659 := MakeSymbol("arity")
 			reg2660 := MakeSymbol("*property-vector*")
 			reg2661 := PrimValue(reg2660)
-			__ctx.TailApply(__defun__put, V350, reg2659, V351, reg2661)
+			__e.TailApply(__defun__put, V350, reg2659, V351, reg2661)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.store-arity", value: __defun__shen_4store_1arity})
 
-	__defun__shen_4reduce = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4reduce = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V353 := __args[0]
 		_ = V353
 		reg2663 := MakeSymbol("shen.*teststack*")
 		reg2664 := Nil
 		reg2665 := PrimSet(reg2663, reg2664)
 		_ = reg2665
-		reg2666 := __e.Call(__defun__shen_4reduce__help, V353)
+		reg2666 := Call(__e, __defun__shen_4reduce__help, V353)
 		Result := reg2666
 		_ = Result
 		reg2667 := MakeSymbol(":")
 		reg2668 := MakeSymbol("shen.tests")
 		reg2669 := MakeSymbol("shen.*teststack*")
 		reg2670 := PrimValue(reg2669)
-		reg2671 := __e.Call(__defun__reverse, reg2670)
+		reg2671 := Call(__e, __defun__reverse, reg2670)
 		reg2672 := PrimCons(reg2668, reg2671)
 		reg2673 := PrimCons(reg2667, reg2672)
 		reg2674 := Nil
 		reg2675 := PrimCons(Result, reg2674)
 		reg2676 := PrimCons(reg2673, reg2675)
-		__ctx.Return(reg2676)
+		__e.Return(reg2676)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.reduce", value: __defun__shen_4reduce})
 
-	__defun__shen_4reduce__help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4reduce__help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V355 := __args[0]
 		_ = V355
 		reg2677 := PrimIsPair(V355)
@@ -4473,7 +4473,7 @@ func init() {
 			reg2792 := MakeSymbol("cons?")
 			reg2793 := PrimTail(V355)
 			reg2794 := PrimCons(reg2792, reg2793)
-			reg2795 := __e.Call(__defun__shen_4add__test, reg2794)
+			reg2795 := Call(__e, __defun__shen_4add__test, reg2794)
 			_ = reg2795
 			reg2796 := MakeSymbol("/.")
 			reg2797 := PrimHead(V355)
@@ -4497,7 +4497,7 @@ func init() {
 			reg2815 := PrimTail(reg2814)
 			reg2816 := PrimTail(reg2815)
 			reg2817 := PrimHead(reg2816)
-			reg2818 := __e.Call(__defun__shen_4ebr, reg2810, reg2813, reg2817)
+			reg2818 := Call(__e, __defun__shen_4ebr, reg2810, reg2813, reg2817)
 			reg2819 := Nil
 			reg2820 := PrimCons(reg2818, reg2819)
 			reg2821 := PrimCons(reg2808, reg2820)
@@ -4522,7 +4522,7 @@ func init() {
 			reg2838 := PrimCons(reg2832, reg2837)
 			Application := reg2838
 			_ = Application
-			__ctx.TailApply(__defun__shen_4reduce__help, Application)
+			__e.TailApply(__defun__shen_4reduce__help, Application)
 			return
 		} else {
 			reg2840 := PrimIsPair(V355)
@@ -4764,7 +4764,7 @@ func init() {
 				reg2955 := MakeSymbol("tuple?")
 				reg2956 := PrimTail(V355)
 				reg2957 := PrimCons(reg2955, reg2956)
-				reg2958 := __e.Call(__defun__shen_4add__test, reg2957)
+				reg2958 := Call(__e, __defun__shen_4add__test, reg2957)
 				_ = reg2958
 				reg2959 := MakeSymbol("/.")
 				reg2960 := PrimHead(V355)
@@ -4788,7 +4788,7 @@ func init() {
 				reg2978 := PrimTail(reg2977)
 				reg2979 := PrimTail(reg2978)
 				reg2980 := PrimHead(reg2979)
-				reg2981 := __e.Call(__defun__shen_4ebr, reg2973, reg2976, reg2980)
+				reg2981 := Call(__e, __defun__shen_4ebr, reg2973, reg2976, reg2980)
 				reg2982 := Nil
 				reg2983 := PrimCons(reg2981, reg2982)
 				reg2984 := PrimCons(reg2971, reg2983)
@@ -4813,7 +4813,7 @@ func init() {
 				reg3001 := PrimCons(reg2995, reg3000)
 				Application := reg3001
 				_ = Application
-				__ctx.TailApply(__defun__shen_4reduce__help, Application)
+				__e.TailApply(__defun__shen_4reduce__help, Application)
 				return
 			} else {
 				reg3003 := PrimIsPair(V355)
@@ -5055,7 +5055,7 @@ func init() {
 					reg3118 := MakeSymbol("shen.+vector?")
 					reg3119 := PrimTail(V355)
 					reg3120 := PrimCons(reg3118, reg3119)
-					reg3121 := __e.Call(__defun__shen_4add__test, reg3120)
+					reg3121 := Call(__e, __defun__shen_4add__test, reg3120)
 					_ = reg3121
 					reg3122 := MakeSymbol("/.")
 					reg3123 := PrimHead(V355)
@@ -5079,7 +5079,7 @@ func init() {
 					reg3141 := PrimTail(reg3140)
 					reg3142 := PrimTail(reg3141)
 					reg3143 := PrimHead(reg3142)
-					reg3144 := __e.Call(__defun__shen_4ebr, reg3136, reg3139, reg3143)
+					reg3144 := Call(__e, __defun__shen_4ebr, reg3136, reg3139, reg3143)
 					reg3145 := Nil
 					reg3146 := PrimCons(reg3144, reg3145)
 					reg3147 := PrimCons(reg3134, reg3146)
@@ -5104,7 +5104,7 @@ func init() {
 					reg3164 := PrimCons(reg3158, reg3163)
 					Application := reg3164
 					_ = Application
-					__ctx.TailApply(__defun__shen_4reduce__help, Application)
+					__e.TailApply(__defun__shen_4reduce__help, Application)
 					return
 				} else {
 					reg3166 := PrimIsPair(V355)
@@ -5346,7 +5346,7 @@ func init() {
 						reg3281 := MakeSymbol("shen.+string?")
 						reg3282 := PrimTail(V355)
 						reg3283 := PrimCons(reg3281, reg3282)
-						reg3284 := __e.Call(__defun__shen_4add__test, reg3283)
+						reg3284 := Call(__e, __defun__shen_4add__test, reg3283)
 						_ = reg3284
 						reg3285 := MakeSymbol("/.")
 						reg3286 := PrimHead(V355)
@@ -5370,7 +5370,7 @@ func init() {
 						reg3304 := PrimTail(reg3303)
 						reg3305 := PrimTail(reg3304)
 						reg3306 := PrimHead(reg3305)
-						reg3307 := __e.Call(__defun__shen_4ebr, reg3299, reg3302, reg3306)
+						reg3307 := Call(__e, __defun__shen_4ebr, reg3299, reg3302, reg3306)
 						reg3308 := Nil
 						reg3309 := PrimCons(reg3307, reg3308)
 						reg3310 := PrimCons(reg3297, reg3309)
@@ -5400,7 +5400,7 @@ func init() {
 						reg3332 := PrimCons(reg3326, reg3331)
 						Application := reg3332
 						_ = Application
-						__ctx.TailApply(__defun__shen_4reduce__help, Application)
+						__e.TailApply(__defun__shen_4reduce__help, Application)
 						return
 					} else {
 						reg3334 := PrimIsPair(V355)
@@ -5562,13 +5562,13 @@ func init() {
 							reg3409 := PrimTail(V355)
 							reg3410 := PrimCons(reg3408, reg3409)
 							reg3411 := PrimCons(reg3405, reg3410)
-							reg3412 := __e.Call(__defun__shen_4add__test, reg3411)
+							reg3412 := Call(__e, __defun__shen_4add__test, reg3411)
 							_ = reg3412
 							reg3413 := PrimHead(V355)
 							reg3414 := PrimTail(reg3413)
 							reg3415 := PrimTail(reg3414)
 							reg3416 := PrimHead(reg3415)
-							__ctx.TailApply(__defun__shen_4reduce__help, reg3416)
+							__e.TailApply(__defun__shen_4reduce__help, reg3416)
 							return
 						} else {
 							reg3418 := PrimIsPair(V355)
@@ -5712,8 +5712,8 @@ func init() {
 								reg3485 := PrimTail(reg3484)
 								reg3486 := PrimTail(reg3485)
 								reg3487 := PrimHead(reg3486)
-								reg3488 := __e.Call(__defun__shen_4ebr, reg3480, reg3483, reg3487)
-								__ctx.TailApply(__defun__shen_4reduce__help, reg3488)
+								reg3488 := Call(__e, __defun__shen_4ebr, reg3480, reg3483, reg3487)
+								__e.TailApply(__defun__shen_4reduce__help, reg3488)
 								return
 							} else {
 								reg3490 := PrimIsPair(V355)
@@ -5793,12 +5793,12 @@ func init() {
 								if reg3523 == True {
 									reg3524 := PrimTail(V355)
 									reg3525 := PrimHead(reg3524)
-									reg3526 := __e.Call(__defun__shen_4add__test, reg3525)
+									reg3526 := Call(__e, __defun__shen_4add__test, reg3525)
 									_ = reg3526
 									reg3527 := PrimTail(V355)
 									reg3528 := PrimTail(reg3527)
 									reg3529 := PrimHead(reg3528)
-									__ctx.TailApply(__defun__shen_4reduce__help, reg3529)
+									__e.TailApply(__defun__shen_4reduce__help, reg3529)
 									return
 								} else {
 									reg3531 := PrimIsPair(V355)
@@ -5840,22 +5840,22 @@ func init() {
 									}
 									if reg3547 == True {
 										reg3548 := PrimHead(V355)
-										reg3549 := __e.Call(__defun__shen_4reduce__help, reg3548)
+										reg3549 := Call(__e, __defun__shen_4reduce__help, reg3548)
 										Z := reg3549
 										_ = Z
 										reg3550 := PrimHead(V355)
 										reg3551 := PrimEqual(reg3550, Z)
 										if reg3551 == True {
-											__ctx.Return(V355)
+											__e.Return(V355)
 											return
 										} else {
 											reg3552 := PrimTail(V355)
 											reg3553 := PrimCons(Z, reg3552)
-											__ctx.TailApply(__defun__shen_4reduce__help, reg3553)
+											__e.TailApply(__defun__shen_4reduce__help, reg3553)
 											return
 										}
 									} else {
-										__ctx.Return(V355)
+										__e.Return(V355)
 										return
 									}
 								}
@@ -5868,24 +5868,24 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.reduce_help", value: __defun__shen_4reduce__help})
 
-	__defun__shen_4_7string_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_7string_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V357 := __args[0]
 		_ = V357
 		reg3555 := MakeString("")
 		reg3556 := PrimEqual(reg3555, V357)
 		if reg3556 == True {
 			reg3557 := False
-			__ctx.Return(reg3557)
+			__e.Return(reg3557)
 			return
 		} else {
 			reg3558 := PrimIsString(V357)
-			__ctx.Return(reg3558)
+			__e.Return(reg3558)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.+string?", value: __defun__shen_4_7string_2})
 
-	__defun__shen_4_7vector_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_7vector_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V359 := __args[0]
 		_ = V359
 		reg3559 := PrimIsVector(V359)
@@ -5896,22 +5896,22 @@ func init() {
 			reg3563 := PrimGreatThan(reg3561, reg3562)
 			if reg3563 == True {
 				reg3564 := True
-				__ctx.Return(reg3564)
+				__e.Return(reg3564)
 				return
 			} else {
 				reg3565 := False
-				__ctx.Return(reg3565)
+				__e.Return(reg3565)
 				return
 			}
 		} else {
 			reg3566 := False
-			__ctx.Return(reg3566)
+			__e.Return(reg3566)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.+vector?", value: __defun__shen_4_7vector_2})
 
-	__defun__shen_4ebr = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4ebr = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V372 := __args[0]
 		_ = V372
 		V373 := __args[1]
@@ -5920,7 +5920,7 @@ func init() {
 		_ = V374
 		reg3567 := PrimEqual(V374, V373)
 		if reg3567 == True {
-			__ctx.Return(V372)
+			__e.Return(V372)
 			return
 		} else {
 			reg3568 := PrimIsPair(V374)
@@ -5949,7 +5949,7 @@ func init() {
 							if reg3581 == True {
 								reg3582 := PrimTail(V374)
 								reg3583 := PrimHead(reg3582)
-								reg3584 := __e.Call(__defun__shen_4clash_2, reg3583, V373)
+								reg3584 := Call(__e, __defun__shen_4clash_2, reg3583, V373)
 								var reg3587 Obj
 								if reg3584 == True {
 									reg3585 := True
@@ -6016,7 +6016,7 @@ func init() {
 				reg3609 = reg3608
 			}
 			if reg3609 == True {
-				__ctx.Return(V374)
+				__e.Return(V374)
 				return
 			} else {
 				reg3610 := PrimIsPair(V374)
@@ -6052,7 +6052,7 @@ func init() {
 									if reg3628 == True {
 										reg3629 := PrimTail(V374)
 										reg3630 := PrimHead(reg3629)
-										reg3631 := __e.Call(__defun__shen_4clash_2, reg3630, V373)
+										reg3631 := Call(__e, __defun__shen_4clash_2, reg3630, V373)
 										var reg3634 Obj
 										if reg3631 == True {
 											reg3632 := True
@@ -6138,27 +6138,27 @@ func init() {
 					reg3665 := PrimTail(V374)
 					reg3666 := PrimTail(reg3665)
 					reg3667 := PrimHead(reg3666)
-					reg3668 := __e.Call(__defun__shen_4ebr, V372, V373, reg3667)
+					reg3668 := Call(__e, __defun__shen_4ebr, V372, V373, reg3667)
 					reg3669 := PrimTail(V374)
 					reg3670 := PrimTail(reg3669)
 					reg3671 := PrimTail(reg3670)
 					reg3672 := PrimCons(reg3668, reg3671)
 					reg3673 := PrimCons(reg3664, reg3672)
 					reg3674 := PrimCons(reg3662, reg3673)
-					__ctx.Return(reg3674)
+					__e.Return(reg3674)
 					return
 				} else {
 					reg3675 := PrimIsPair(V374)
 					if reg3675 == True {
 						reg3676 := PrimHead(V374)
-						reg3677 := __e.Call(__defun__shen_4ebr, V372, V373, reg3676)
+						reg3677 := Call(__e, __defun__shen_4ebr, V372, V373, reg3676)
 						reg3678 := PrimTail(V374)
-						reg3679 := __e.Call(__defun__shen_4ebr, V372, V373, reg3678)
+						reg3679 := Call(__e, __defun__shen_4ebr, V372, V373, reg3678)
 						reg3680 := PrimCons(reg3677, reg3679)
-						__ctx.Return(reg3680)
+						__e.Return(reg3680)
 						return
 					} else {
-						__ctx.Return(V374)
+						__e.Return(V374)
 						return
 					}
 				}
@@ -6167,7 +6167,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.ebr", value: __defun__shen_4ebr})
 
-	__defun__shen_4clash_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4clash_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V386 := __args[0]
 		_ = V386
 		V387 := __args[1]
@@ -6175,40 +6175,40 @@ func init() {
 		reg3681 := PrimEqual(V387, V386)
 		if reg3681 == True {
 			reg3682 := True
-			__ctx.Return(reg3682)
+			__e.Return(reg3682)
 			return
 		} else {
 			reg3683 := PrimIsPair(V387)
 			if reg3683 == True {
 				reg3684 := PrimHead(V387)
-				reg3685 := __e.Call(__defun__shen_4clash_2, V386, reg3684)
+				reg3685 := Call(__e, __defun__shen_4clash_2, V386, reg3684)
 				if reg3685 == True {
 					reg3686 := True
-					__ctx.Return(reg3686)
+					__e.Return(reg3686)
 					return
 				} else {
 					reg3687 := PrimTail(V387)
-					reg3688 := __e.Call(__defun__shen_4clash_2, V386, reg3687)
+					reg3688 := Call(__e, __defun__shen_4clash_2, V386, reg3687)
 					if reg3688 == True {
 						reg3689 := True
-						__ctx.Return(reg3689)
+						__e.Return(reg3689)
 						return
 					} else {
 						reg3690 := False
-						__ctx.Return(reg3690)
+						__e.Return(reg3690)
 						return
 					}
 				}
 			} else {
 				reg3691 := False
-				__ctx.Return(reg3691)
+				__e.Return(reg3691)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.clash?", value: __defun__shen_4clash_2})
 
-	__defun__shen_4add__test = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4add__test = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V389 := __args[0]
 		_ = V389
 		reg3692 := MakeSymbol("shen.*teststack*")
@@ -6216,33 +6216,33 @@ func init() {
 		reg3694 := PrimValue(reg3693)
 		reg3695 := PrimCons(V389, reg3694)
 		reg3696 := PrimSet(reg3692, reg3695)
-		__ctx.Return(reg3696)
+		__e.Return(reg3696)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.add_test", value: __defun__shen_4add__test})
 
-	__defun__shen_4cond_1expression = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4cond_1expression = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V393 := __args[0]
 		_ = V393
 		V394 := __args[1]
 		_ = V394
 		V395 := __args[2]
 		_ = V395
-		reg3697 := __e.Call(__defun__shen_4err_1condition, V393)
+		reg3697 := Call(__e, __defun__shen_4err_1condition, V393)
 		Err := reg3697
 		_ = Err
-		reg3698 := __e.Call(__defun__shen_4case_1form, V395, Err)
+		reg3698 := Call(__e, __defun__shen_4case_1form, V395, Err)
 		Cases := reg3698
 		_ = Cases
-		reg3699 := __e.Call(__defun__shen_4encode_1choices, Cases, V393)
+		reg3699 := Call(__e, __defun__shen_4encode_1choices, Cases, V393)
 		EncodeChoices := reg3699
 		_ = EncodeChoices
-		__ctx.TailApply(__defun__shen_4cond_1form, EncodeChoices)
+		__e.TailApply(__defun__shen_4cond_1form, EncodeChoices)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.cond-expression", value: __defun__shen_4cond_1expression})
 
-	__defun__shen_4cond_1form = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4cond_1form = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V399 := __args[0]
 		_ = V399
 		reg3701 := PrimIsPair(V399)
@@ -6324,18 +6324,18 @@ func init() {
 			reg3736 := PrimHead(V399)
 			reg3737 := PrimTail(reg3736)
 			reg3738 := PrimHead(reg3737)
-			__ctx.Return(reg3738)
+			__e.Return(reg3738)
 			return
 		} else {
 			reg3739 := MakeSymbol("cond")
 			reg3740 := PrimCons(reg3739, V399)
-			__ctx.Return(reg3740)
+			__e.Return(reg3740)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.cond-form", value: __defun__shen_4cond_1form})
 
-	__defun__shen_4encode_1choices = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4encode_1choices = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V404 := __args[0]
 		_ = V404
 		V405 := __args[1]
@@ -6344,7 +6344,7 @@ func init() {
 		reg3742 := PrimEqual(reg3741, V404)
 		if reg3742 == True {
 			reg3743 := Nil
-			__ctx.Return(reg3743)
+			__e.Return(reg3743)
 			return
 		} else {
 			reg3744 := PrimIsPair(V404)
@@ -6573,7 +6573,7 @@ func init() {
 				reg3871 := PrimCons(reg3829, reg3870)
 				reg3872 := Nil
 				reg3873 := PrimCons(reg3871, reg3872)
-				__ctx.Return(reg3873)
+				__e.Return(reg3873)
 				return
 			} else {
 				reg3874 := PrimIsPair(V404)
@@ -6753,8 +6753,8 @@ func init() {
 					reg3967 := PrimCons(reg3961, reg3966)
 					reg3968 := PrimCons(reg3960, reg3967)
 					reg3969 := PrimTail(V404)
-					reg3970 := __e.Call(__defun__shen_4encode_1choices, reg3969, V405)
-					reg3971 := __e.Call(__defun__shen_4cond_1form, reg3970)
+					reg3970 := Call(__e, __defun__shen_4encode_1choices, reg3969, V405)
+					reg3971 := Call(__e, __defun__shen_4cond_1form, reg3970)
 					reg3972 := MakeSymbol("Result")
 					reg3973 := Nil
 					reg3974 := PrimCons(reg3972, reg3973)
@@ -6771,7 +6771,7 @@ func init() {
 					reg3985 := PrimCons(reg3951, reg3984)
 					reg3986 := Nil
 					reg3987 := PrimCons(reg3985, reg3986)
-					__ctx.Return(reg3987)
+					__e.Return(reg3987)
 					return
 				} else {
 					reg3988 := PrimIsPair(V404)
@@ -6918,8 +6918,8 @@ func init() {
 						reg4058 := MakeSymbol("Freeze")
 						reg4059 := MakeSymbol("freeze")
 						reg4060 := PrimTail(V404)
-						reg4061 := __e.Call(__defun__shen_4encode_1choices, reg4060, V405)
-						reg4062 := __e.Call(__defun__shen_4cond_1form, reg4061)
+						reg4061 := Call(__e, __defun__shen_4encode_1choices, reg4060, V405)
+						reg4062 := Call(__e, __defun__shen_4cond_1form, reg4061)
 						reg4063 := Nil
 						reg4064 := PrimCons(reg4062, reg4063)
 						reg4065 := PrimCons(reg4059, reg4064)
@@ -6979,7 +6979,7 @@ func init() {
 						reg4119 := PrimCons(reg4056, reg4118)
 						reg4120 := Nil
 						reg4121 := PrimCons(reg4119, reg4120)
-						__ctx.Return(reg4121)
+						__e.Return(reg4121)
 						return
 					} else {
 						reg4122 := PrimIsPair(V404)
@@ -7041,13 +7041,13 @@ func init() {
 						if reg4147 == True {
 							reg4148 := PrimHead(V404)
 							reg4149 := PrimTail(V404)
-							reg4150 := __e.Call(__defun__shen_4encode_1choices, reg4149, V405)
+							reg4150 := Call(__e, __defun__shen_4encode_1choices, reg4149, V405)
 							reg4151 := PrimCons(reg4148, reg4150)
-							__ctx.Return(reg4151)
+							__e.Return(reg4151)
 							return
 						} else {
 							reg4152 := MakeSymbol("shen.encode-choices")
-							__ctx.TailApply(__defun__shen_4f__error, reg4152)
+							__e.TailApply(__defun__shen_4f__error, reg4152)
 							return
 						}
 					}
@@ -7057,7 +7057,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.encode-choices", value: __defun__shen_4encode_1choices})
 
-	__defun__shen_4case_1form = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4case_1form = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V412 := __args[0]
 		_ = V412
 		V413 := __args[1]
@@ -7067,7 +7067,7 @@ func init() {
 		if reg4155 == True {
 			reg4156 := Nil
 			reg4157 := PrimCons(V413, reg4156)
-			__ctx.Return(reg4157)
+			__e.Return(reg4157)
 			return
 		} else {
 			reg4158 := PrimIsPair(V412)
@@ -7313,9 +7313,9 @@ func init() {
 				reg4277 := PrimTail(reg4276)
 				reg4278 := PrimCons(reg4275, reg4277)
 				reg4279 := PrimTail(V412)
-				reg4280 := __e.Call(__defun__shen_4case_1form, reg4279, V413)
+				reg4280 := Call(__e, __defun__shen_4case_1form, reg4279, V413)
 				reg4281 := PrimCons(reg4278, reg4280)
-				__ctx.Return(reg4281)
+				__e.Return(reg4281)
 				return
 			} else {
 				reg4282 := PrimIsPair(V412)
@@ -7480,7 +7480,7 @@ func init() {
 					reg4360 := PrimCons(reg4357, reg4359)
 					reg4361 := Nil
 					reg4362 := PrimCons(reg4360, reg4361)
-					__ctx.Return(reg4362)
+					__e.Return(reg4362)
 					return
 				} else {
 					reg4363 := PrimIsPair(V412)
@@ -7622,18 +7622,18 @@ func init() {
 						reg4428 := PrimHead(reg4427)
 						reg4429 := PrimTail(reg4428)
 						reg4430 := PrimTail(reg4429)
-						reg4431 := __e.Call(__defun__shen_4embed_1and, reg4430)
+						reg4431 := Call(__e, __defun__shen_4embed_1and, reg4430)
 						reg4432 := PrimHead(V412)
 						reg4433 := PrimTail(reg4432)
 						reg4434 := PrimCons(reg4431, reg4433)
 						reg4435 := PrimTail(V412)
-						reg4436 := __e.Call(__defun__shen_4case_1form, reg4435, V413)
+						reg4436 := Call(__e, __defun__shen_4case_1form, reg4435, V413)
 						reg4437 := PrimCons(reg4434, reg4436)
-						__ctx.Return(reg4437)
+						__e.Return(reg4437)
 						return
 					} else {
 						reg4438 := MakeSymbol("shen.case-form")
-						__ctx.TailApply(__defun__shen_4f__error, reg4438)
+						__e.TailApply(__defun__shen_4f__error, reg4438)
 						return
 					}
 				}
@@ -7642,7 +7642,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.case-form", value: __defun__shen_4case_1form})
 
-	__defun__shen_4embed_1and = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4embed_1and = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V415 := __args[0]
 		_ = V415
 		reg4440 := PrimIsPair(V415)
@@ -7666,7 +7666,7 @@ func init() {
 		}
 		if reg4448 == True {
 			reg4449 := PrimHead(V415)
-			__ctx.Return(reg4449)
+			__e.Return(reg4449)
 			return
 		} else {
 			reg4450 := PrimIsPair(V415)
@@ -7674,23 +7674,23 @@ func init() {
 				reg4451 := MakeSymbol("and")
 				reg4452 := PrimHead(V415)
 				reg4453 := PrimTail(V415)
-				reg4454 := __e.Call(__defun__shen_4embed_1and, reg4453)
+				reg4454 := Call(__e, __defun__shen_4embed_1and, reg4453)
 				reg4455 := Nil
 				reg4456 := PrimCons(reg4454, reg4455)
 				reg4457 := PrimCons(reg4452, reg4456)
 				reg4458 := PrimCons(reg4451, reg4457)
-				__ctx.Return(reg4458)
+				__e.Return(reg4458)
 				return
 			} else {
 				reg4459 := MakeSymbol("shen.embed-and")
-				__ctx.TailApply(__defun__shen_4f__error, reg4459)
+				__e.TailApply(__defun__shen_4f__error, reg4459)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.embed-and", value: __defun__shen_4embed_1and})
 
-	__defun__shen_4err_1condition = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4err_1condition = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V417 := __args[0]
 		_ = V417
 		reg4461 := True
@@ -7701,21 +7701,21 @@ func init() {
 		reg4466 := Nil
 		reg4467 := PrimCons(reg4465, reg4466)
 		reg4468 := PrimCons(reg4461, reg4467)
-		__ctx.Return(reg4468)
+		__e.Return(reg4468)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.err-condition", value: __defun__shen_4err_1condition})
 
-	__defun__shen_4sys_1error = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4sys_1error = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V419 := __args[0]
 		_ = V419
 		reg4469 := MakeString("system function ")
 		reg4470 := MakeString(": unexpected argument\n")
 		reg4471 := MakeSymbol("shen.a")
-		reg4472 := __e.Call(__defun__shen_4app, V419, reg4470, reg4471)
+		reg4472 := Call(__e, __defun__shen_4app, V419, reg4470, reg4471)
 		reg4473 := PrimStringConcat(reg4469, reg4472)
 		reg4474 := PrimSimpleError(reg4473)
-		__ctx.Return(reg4474)
+		__e.Return(reg4474)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.sys-error", value: __defun__shen_4sys_1error})

--- a/cmd/shen/declarations.go
+++ b/cmd/shen/declarations.go
@@ -14,19 +14,19 @@ var __defun__specialise Obj                     // specialise
 var __defun__unspecialise Obj                   // unspecialise
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg19088 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg19088)
+		__e.Return(reg19088)
 		return
 	}, 0))
-	__defun__shen_4initialise__arity__table = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4initialise__arity__table = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V421 := __args[0]
 		_ = V421
 		reg19089 := Nil
 		reg19090 := PrimEqual(reg19089, V421)
 		if reg19090 == True {
 			reg19091 := Nil
-			__ctx.Return(reg19091)
+			__e.Return(reg19091)
 			return
 		} else {
 			reg19092 := PrimIsPair(V421)
@@ -54,46 +54,46 @@ func init() {
 				reg19103 := PrimHead(reg19102)
 				reg19104 := MakeSymbol("*property-vector*")
 				reg19105 := PrimValue(reg19104)
-				reg19106 := __e.Call(__defun__put, reg19100, reg19101, reg19103, reg19105)
+				reg19106 := Call(__e, __defun__put, reg19100, reg19101, reg19103, reg19105)
 				DecArity := reg19106
 				_ = DecArity
 				reg19107 := PrimTail(V421)
 				reg19108 := PrimTail(reg19107)
-				__ctx.TailApply(__defun__shen_4initialise__arity__table, reg19108)
+				__e.TailApply(__defun__shen_4initialise__arity__table, reg19108)
 				return
 			} else {
 				reg19110 := MakeSymbol("shen.initialise_arity_table")
-				__ctx.TailApply(__defun__shen_4f__error, reg19110)
+				__e.TailApply(__defun__shen_4f__error, reg19110)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.initialise_arity_table", value: __defun__shen_4initialise__arity__table})
 
-	__defun__arity = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__arity = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V423 := __args[0]
 		_ = V423
-		reg19112 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg19112 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg19113 := MakeSymbol("arity")
 			reg19114 := MakeSymbol("*property-vector*")
 			reg19115 := PrimValue(reg19114)
-			__ctx.TailApply(__defun__get, V423, reg19113, reg19115)
+			__e.TailApply(__defun__get, V423, reg19113, reg19115)
 			return
 		}, 0)
-		reg19117 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg19117 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg19118 := MakeNumber(-1)
-			__ctx.Return(reg19118)
+			__e.Return(reg19118)
 			return
 		}, 1)
-		reg19119 := __e.Try(reg19112).Catch(reg19117)
-		__ctx.Return(reg19119)
+		reg19119 := Try(__e, reg19112).Catch(reg19117)
+		__e.Return(reg19119)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "arity", value: __defun__arity})
 
-	__defun__systemf = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__systemf = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V425 := __args[0]
 		_ = V425
 		reg19120 := MakeString("shen")
@@ -103,78 +103,78 @@ func init() {
 		reg19122 := MakeSymbol("shen.external-symbols")
 		reg19123 := MakeSymbol("*property-vector*")
 		reg19124 := PrimValue(reg19123)
-		reg19125 := __e.Call(__defun__get, Shen, reg19122, reg19124)
+		reg19125 := Call(__e, __defun__get, Shen, reg19122, reg19124)
 		External := reg19125
 		_ = External
 		reg19126 := MakeSymbol("shen.external-symbols")
-		reg19127 := __e.Call(__defun__adjoin, V425, External)
+		reg19127 := Call(__e, __defun__adjoin, V425, External)
 		reg19128 := MakeSymbol("*property-vector*")
 		reg19129 := PrimValue(reg19128)
-		reg19130 := __e.Call(__defun__put, Shen, reg19126, reg19127, reg19129)
+		reg19130 := Call(__e, __defun__put, Shen, reg19126, reg19127, reg19129)
 		Place := reg19130
 		_ = Place
-		__ctx.Return(V425)
+		__e.Return(V425)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "systemf", value: __defun__systemf})
 
-	__defun__adjoin = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__adjoin = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V428 := __args[0]
 		_ = V428
 		V429 := __args[1]
 		_ = V429
-		reg19131 := __e.Call(__defun__element_2, V428, V429)
+		reg19131 := Call(__e, __defun__element_2, V428, V429)
 		if reg19131 == True {
-			__ctx.Return(V429)
+			__e.Return(V429)
 			return
 		} else {
 			reg19132 := PrimCons(V428, V429)
-			__ctx.Return(reg19132)
+			__e.Return(reg19132)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "adjoin", value: __defun__adjoin})
 
-	__defun__shen_4lambda_1form_1entry = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lambda_1form_1entry = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V431 := __args[0]
 		_ = V431
 		reg19133 := MakeSymbol("package")
 		reg19134 := PrimEqual(reg19133, V431)
 		if reg19134 == True {
 			reg19135 := Nil
-			__ctx.Return(reg19135)
+			__e.Return(reg19135)
 			return
 		} else {
 			reg19136 := MakeSymbol("receive")
 			reg19137 := PrimEqual(reg19136, V431)
 			if reg19137 == True {
 				reg19138 := Nil
-				__ctx.Return(reg19138)
+				__e.Return(reg19138)
 				return
 			} else {
-				reg19139 := __e.Call(__defun__arity, V431)
+				reg19139 := Call(__e, __defun__arity, V431)
 				ArityF := reg19139
 				_ = ArityF
 				reg19140 := MakeNumber(-1)
 				reg19141 := PrimEqual(ArityF, reg19140)
 				if reg19141 == True {
 					reg19142 := Nil
-					__ctx.Return(reg19142)
+					__e.Return(reg19142)
 					return
 				} else {
 					reg19143 := MakeNumber(0)
 					reg19144 := PrimEqual(ArityF, reg19143)
 					if reg19144 == True {
 						reg19145 := Nil
-						__ctx.Return(reg19145)
+						__e.Return(reg19145)
 						return
 					} else {
-						reg19146 := __e.Call(__defun__shen_4lambda_1form, V431, ArityF)
+						reg19146 := Call(__e, __defun__shen_4lambda_1form, V431, ArityF)
 						reg19147 := PrimEvalKL(__e, reg19146)
 						reg19148 := PrimCons(V431, reg19147)
 						reg19149 := Nil
 						reg19150 := PrimCons(reg19148, reg19149)
-						__ctx.Return(reg19150)
+						__e.Return(reg19150)
 						return
 					}
 				}
@@ -183,7 +183,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.lambda-form-entry", value: __defun__shen_4lambda_1form_1entry})
 
-	__defun__shen_4lambda_1form = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lambda_1form = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V434 := __args[0]
 		_ = V434
 		V435 := __args[1]
@@ -191,29 +191,29 @@ func init() {
 		reg19151 := MakeNumber(0)
 		reg19152 := PrimEqual(reg19151, V435)
 		if reg19152 == True {
-			__ctx.Return(V434)
+			__e.Return(V434)
 			return
 		} else {
 			reg19153 := MakeSymbol("V")
-			reg19154 := __e.Call(__defun__gensym, reg19153)
+			reg19154 := Call(__e, __defun__gensym, reg19153)
 			X := reg19154
 			_ = X
 			reg19155 := MakeSymbol("lambda")
-			reg19156 := __e.Call(__defun__shen_4add_1end, V434, X)
+			reg19156 := Call(__e, __defun__shen_4add_1end, V434, X)
 			reg19157 := MakeNumber(1)
 			reg19158 := PrimNumberSubtract(V435, reg19157)
-			reg19159 := __e.Call(__defun__shen_4lambda_1form, reg19156, reg19158)
+			reg19159 := Call(__e, __defun__shen_4lambda_1form, reg19156, reg19158)
 			reg19160 := Nil
 			reg19161 := PrimCons(reg19159, reg19160)
 			reg19162 := PrimCons(X, reg19161)
 			reg19163 := PrimCons(reg19155, reg19162)
-			__ctx.Return(reg19163)
+			__e.Return(reg19163)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.lambda-form", value: __defun__shen_4lambda_1form})
 
-	__defun__shen_4add_1end = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4add_1end = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V438 := __args[0]
 		_ = V438
 		V439 := __args[1]
@@ -222,19 +222,19 @@ func init() {
 		if reg19164 == True {
 			reg19165 := Nil
 			reg19166 := PrimCons(V439, reg19165)
-			__ctx.TailApply(__defun__append, V438, reg19166)
+			__e.TailApply(__defun__append, V438, reg19166)
 			return
 		} else {
 			reg19168 := Nil
 			reg19169 := PrimCons(V439, reg19168)
 			reg19170 := PrimCons(V438, reg19169)
-			__ctx.Return(reg19170)
+			__e.Return(reg19170)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.add-end", value: __defun__shen_4add_1end})
 
-	__defun__shen_4set_1lambda_1form_1entry = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4set_1lambda_1form_1entry = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V441 := __args[0]
 		_ = V441
 		reg19171 := PrimIsPair(V441)
@@ -244,17 +244,17 @@ func init() {
 			reg19174 := PrimTail(V441)
 			reg19175 := MakeSymbol("*property-vector*")
 			reg19176 := PrimValue(reg19175)
-			__ctx.TailApply(__defun__put, reg19172, reg19173, reg19174, reg19176)
+			__e.TailApply(__defun__put, reg19172, reg19173, reg19174, reg19176)
 			return
 		} else {
 			reg19178 := MakeSymbol("shen.set-lambda-form-entry")
-			__ctx.TailApply(__defun__shen_4f__error, reg19178)
+			__e.TailApply(__defun__shen_4f__error, reg19178)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.set-lambda-form-entry", value: __defun__shen_4set_1lambda_1form_1entry})
 
-	__defun__specialise = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__specialise = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V443 := __args[0]
 		_ = V443
 		reg19180 := MakeSymbol("shen.*special*")
@@ -263,21 +263,21 @@ func init() {
 		reg19183 := PrimCons(V443, reg19182)
 		reg19184 := PrimSet(reg19180, reg19183)
 		_ = reg19184
-		__ctx.Return(V443)
+		__e.Return(V443)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "specialise", value: __defun__specialise})
 
-	__defun__unspecialise = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__unspecialise = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V445 := __args[0]
 		_ = V445
 		reg19185 := MakeSymbol("shen.*special*")
 		reg19186 := MakeSymbol("shen.*special*")
 		reg19187 := PrimValue(reg19186)
-		reg19188 := __e.Call(__defun__remove, V445, reg19187)
+		reg19188 := Call(__e, __defun__remove, V445, reg19187)
 		reg19189 := PrimSet(reg19185, reg19188)
 		_ = reg19189
-		__ctx.Return(V445)
+		__e.Return(V445)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "unspecialise", value: __defun__unspecialise})

--- a/cmd/shen/dict.go
+++ b/cmd/shen/dict.go
@@ -20,12 +20,12 @@ var __defun__shen_4dict_1keys Obj          // shen.dict-keys
 var __defun__shen_4dict_1values Obj        // shen.dict-values
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5830 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg5830)
+		__e.Return(reg5830)
 		return
 	}, 0))
-	__defun__shen_4dict = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2312 := __args[0]
 		_ = V2312
 		reg5831 := MakeNumber(1)
@@ -34,10 +34,10 @@ func init() {
 			reg5833 := MakeString("invalid initial dict size: ")
 			reg5834 := MakeString("")
 			reg5835 := MakeSymbol("shen.s")
-			reg5836 := __e.Call(__defun__shen_4app, V2312, reg5834, reg5835)
+			reg5836 := Call(__e, __defun__shen_4app, V2312, reg5834, reg5835)
 			reg5837 := PrimStringConcat(reg5833, reg5836)
 			reg5838 := PrimSimpleError(reg5837)
-			__ctx.Return(reg5838)
+			__e.Return(reg5838)
 			return
 		} else {
 			reg5839 := MakeNumber(3)
@@ -63,86 +63,86 @@ func init() {
 			reg5851 := MakeNumber(2)
 			reg5852 := PrimNumberAdd(reg5851, V2312)
 			reg5853 := Nil
-			reg5854 := __e.Call(__defun__shen_4fillvector, D, reg5850, reg5852, reg5853)
+			reg5854 := Call(__e, __defun__shen_4fillvector, D, reg5850, reg5852, reg5853)
 			Fill := reg5854
 			_ = Fill
-			__ctx.Return(D)
+			__e.Return(D)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.dict", value: __defun__shen_4dict})
 
-	__defun__shen_4dict_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2314 := __args[0]
 		_ = V2314
 		reg5855 := PrimIsVector(V2314)
 		if reg5855 == True {
-			reg5856 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5856 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg5857 := MakeNumber(0)
 				reg5858 := PrimVectorGet(V2314, reg5857)
-				__ctx.Return(reg5858)
+				__e.Return(reg5858)
 				return
 			}, 0)
-			reg5859 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5859 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg5860 := MakeSymbol("shen.not-dictionary")
-				__ctx.Return(reg5860)
+				__e.Return(reg5860)
 				return
 			}, 1)
-			reg5861 := __e.Try(reg5856).Catch(reg5859)
+			reg5861 := Try(__e, reg5856).Catch(reg5859)
 			reg5862 := MakeSymbol("shen.dictionary")
 			reg5863 := PrimEqual(reg5861, reg5862)
 			if reg5863 == True {
 				reg5864 := True
-				__ctx.Return(reg5864)
+				__e.Return(reg5864)
 				return
 			} else {
 				reg5865 := False
-				__ctx.Return(reg5865)
+				__e.Return(reg5865)
 				return
 			}
 		} else {
 			reg5866 := False
-			__ctx.Return(reg5866)
+			__e.Return(reg5866)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.dict?", value: __defun__shen_4dict_2})
 
-	__defun__shen_4dict_1capacity = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1capacity = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2316 := __args[0]
 		_ = V2316
 		reg5867 := MakeNumber(1)
 		reg5868 := PrimVectorGet(V2316, reg5867)
-		__ctx.Return(reg5868)
+		__e.Return(reg5868)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-capacity", value: __defun__shen_4dict_1capacity})
 
-	__defun__shen_4dict_1count = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1count = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2318 := __args[0]
 		_ = V2318
 		reg5869 := MakeNumber(2)
 		reg5870 := PrimVectorGet(V2318, reg5869)
-		__ctx.Return(reg5870)
+		__e.Return(reg5870)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-count", value: __defun__shen_4dict_1count})
 
-	__defun__shen_4dict_1count_1_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1count_1_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2321 := __args[0]
 		_ = V2321
 		V2322 := __args[1]
 		_ = V2322
 		reg5871 := MakeNumber(2)
 		reg5872 := PrimVectorSet(V2321, reg5871, V2322)
-		__ctx.Return(reg5872)
+		__e.Return(reg5872)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-count->", value: __defun__shen_4dict_1count_1_6})
 
-	__defun__shen_4_5_1dict_1bucket = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5_1dict_1bucket = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2325 := __args[0]
 		_ = V2325
 		V2326 := __args[1]
@@ -150,12 +150,12 @@ func init() {
 		reg5873 := MakeNumber(3)
 		reg5874 := PrimNumberAdd(reg5873, V2326)
 		reg5875 := PrimVectorGet(V2325, reg5874)
-		__ctx.Return(reg5875)
+		__e.Return(reg5875)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.<-dict-bucket", value: __defun__shen_4_5_1dict_1bucket})
 
-	__defun__shen_4dict_1bucket_1_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1bucket_1_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2330 := __args[0]
 		_ = V2330
 		V2331 := __args[1]
@@ -165,134 +165,134 @@ func init() {
 		reg5876 := MakeNumber(3)
 		reg5877 := PrimNumberAdd(reg5876, V2331)
 		reg5878 := PrimVectorSet(V2330, reg5877, V2332)
-		__ctx.Return(reg5878)
+		__e.Return(reg5878)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-bucket->", value: __defun__shen_4dict_1bucket_1_6})
 
-	__defun__shen_4dict_1update_1count = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1update_1count = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2336 := __args[0]
 		_ = V2336
 		V2337 := __args[1]
 		_ = V2337
 		V2338 := __args[2]
 		_ = V2338
-		reg5879 := __e.Call(__defun__length, V2338)
-		reg5880 := __e.Call(__defun__length, V2337)
+		reg5879 := Call(__e, __defun__length, V2338)
+		reg5880 := Call(__e, __defun__length, V2337)
 		reg5881 := PrimNumberSubtract(reg5879, reg5880)
 		Diff := reg5881
 		_ = Diff
-		reg5882 := __e.Call(__defun__shen_4dict_1count, V2336)
+		reg5882 := Call(__e, __defun__shen_4dict_1count, V2336)
 		reg5883 := PrimNumberAdd(Diff, reg5882)
-		__ctx.TailApply(__defun__shen_4dict_1count_1_6, V2336, reg5883)
+		__e.TailApply(__defun__shen_4dict_1count_1_6, V2336, reg5883)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-update-count", value: __defun__shen_4dict_1update_1count})
 
-	__defun__shen_4dict_1_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2342 := __args[0]
 		_ = V2342
 		V2343 := __args[1]
 		_ = V2343
 		V2344 := __args[2]
 		_ = V2344
-		reg5885 := __e.Call(__defun__shen_4dict_1capacity, V2342)
-		reg5886 := __e.Call(__defun__hash, V2343, reg5885)
+		reg5885 := Call(__e, __defun__shen_4dict_1capacity, V2342)
+		reg5886 := Call(__e, __defun__hash, V2343, reg5885)
 		N := reg5886
 		_ = N
-		reg5887 := __e.Call(__defun__shen_4_5_1dict_1bucket, V2342, N)
+		reg5887 := Call(__e, __defun__shen_4_5_1dict_1bucket, V2342, N)
 		Bucket := reg5887
 		_ = Bucket
-		reg5888 := __e.Call(__defun__shen_4assoc_1set, V2343, V2344, Bucket)
+		reg5888 := Call(__e, __defun__shen_4assoc_1set, V2343, V2344, Bucket)
 		NewBucket := reg5888
 		_ = NewBucket
-		reg5889 := __e.Call(__defun__shen_4dict_1bucket_1_6, V2342, N, NewBucket)
+		reg5889 := Call(__e, __defun__shen_4dict_1bucket_1_6, V2342, N, NewBucket)
 		Change := reg5889
 		_ = Change
-		reg5890 := __e.Call(__defun__shen_4dict_1update_1count, V2342, Bucket, NewBucket)
+		reg5890 := Call(__e, __defun__shen_4dict_1update_1count, V2342, Bucket, NewBucket)
 		Count := reg5890
 		_ = Count
-		__ctx.Return(V2344)
+		__e.Return(V2344)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.dict->", value: __defun__shen_4dict_1_6})
 
-	__defun__shen_4_5_1dict = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5_1dict = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2347 := __args[0]
 		_ = V2347
 		V2348 := __args[1]
 		_ = V2348
-		reg5891 := __e.Call(__defun__shen_4dict_1capacity, V2347)
-		reg5892 := __e.Call(__defun__hash, V2348, reg5891)
+		reg5891 := Call(__e, __defun__shen_4dict_1capacity, V2347)
+		reg5892 := Call(__e, __defun__hash, V2348, reg5891)
 		N := reg5892
 		_ = N
-		reg5893 := __e.Call(__defun__shen_4_5_1dict_1bucket, V2347, N)
+		reg5893 := Call(__e, __defun__shen_4_5_1dict_1bucket, V2347, N)
 		Bucket := reg5893
 		_ = Bucket
-		reg5894 := __e.Call(__defun__assoc, V2348, Bucket)
+		reg5894 := Call(__e, __defun__assoc, V2348, Bucket)
 		Result := reg5894
 		_ = Result
-		reg5895 := __e.Call(__defun__empty_2, Result)
+		reg5895 := Call(__e, __defun__empty_2, Result)
 		if reg5895 == True {
 			reg5896 := MakeString("value ")
 			reg5897 := MakeString(" not found in dict\n")
 			reg5898 := MakeSymbol("shen.a")
-			reg5899 := __e.Call(__defun__shen_4app, V2348, reg5897, reg5898)
+			reg5899 := Call(__e, __defun__shen_4app, V2348, reg5897, reg5898)
 			reg5900 := PrimStringConcat(reg5896, reg5899)
 			reg5901 := PrimSimpleError(reg5900)
-			__ctx.Return(reg5901)
+			__e.Return(reg5901)
 			return
 		} else {
 			reg5902 := PrimTail(Result)
-			__ctx.Return(reg5902)
+			__e.Return(reg5902)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.<-dict", value: __defun__shen_4_5_1dict})
 
-	__defun__shen_4dict_1rm = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1rm = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2351 := __args[0]
 		_ = V2351
 		V2352 := __args[1]
 		_ = V2352
-		reg5903 := __e.Call(__defun__shen_4dict_1capacity, V2351)
-		reg5904 := __e.Call(__defun__hash, V2352, reg5903)
+		reg5903 := Call(__e, __defun__shen_4dict_1capacity, V2351)
+		reg5904 := Call(__e, __defun__hash, V2352, reg5903)
 		N := reg5904
 		_ = N
-		reg5905 := __e.Call(__defun__shen_4_5_1dict_1bucket, V2351, N)
+		reg5905 := Call(__e, __defun__shen_4_5_1dict_1bucket, V2351, N)
 		Bucket := reg5905
 		_ = Bucket
-		reg5906 := __e.Call(__defun__shen_4assoc_1rm, V2352, Bucket)
+		reg5906 := Call(__e, __defun__shen_4assoc_1rm, V2352, Bucket)
 		NewBucket := reg5906
 		_ = NewBucket
-		reg5907 := __e.Call(__defun__shen_4dict_1bucket_1_6, V2351, N, NewBucket)
+		reg5907 := Call(__e, __defun__shen_4dict_1bucket_1_6, V2351, N, NewBucket)
 		Change := reg5907
 		_ = Change
-		reg5908 := __e.Call(__defun__shen_4dict_1update_1count, V2351, Bucket, NewBucket)
+		reg5908 := Call(__e, __defun__shen_4dict_1update_1count, V2351, Bucket, NewBucket)
 		Count := reg5908
 		_ = Count
-		__ctx.Return(V2352)
+		__e.Return(V2352)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-rm", value: __defun__shen_4dict_1rm})
 
-	__defun__shen_4dict_1fold = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1fold = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2356 := __args[0]
 		_ = V2356
 		V2357 := __args[1]
 		_ = V2357
 		V2358 := __args[2]
 		_ = V2358
-		reg5909 := __e.Call(__defun__shen_4dict_1capacity, V2357)
+		reg5909 := Call(__e, __defun__shen_4dict_1capacity, V2357)
 		Limit := reg5909
 		_ = Limit
 		reg5910 := MakeNumber(0)
-		__ctx.TailApply(__defun__shen_4dict_1fold_1h, V2356, V2357, V2358, reg5910, Limit)
+		__e.TailApply(__defun__shen_4dict_1fold_1h, V2356, V2357, V2358, reg5910, Limit)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-fold", value: __defun__shen_4dict_1fold})
 
-	__defun__shen_4dict_1fold_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1fold_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2365 := __args[0]
 		_ = V2365
 		V2366 := __args[1]
@@ -305,24 +305,24 @@ func init() {
 		_ = V2369
 		reg5912 := PrimEqual(V2369, V2368)
 		if reg5912 == True {
-			__ctx.Return(V2367)
+			__e.Return(V2367)
 			return
 		} else {
-			reg5913 := __e.Call(__defun__shen_4_5_1dict_1bucket, V2366, V2368)
+			reg5913 := Call(__e, __defun__shen_4_5_1dict_1bucket, V2366, V2368)
 			B := reg5913
 			_ = B
-			reg5914 := __e.Call(__defun__shen_4bucket_1fold, V2365, B, V2367)
+			reg5914 := Call(__e, __defun__shen_4bucket_1fold, V2365, B, V2367)
 			Acc := reg5914
 			_ = Acc
 			reg5915 := MakeNumber(1)
 			reg5916 := PrimNumberAdd(reg5915, V2368)
-			__ctx.TailApply(__defun__shen_4dict_1fold_1h, V2365, V2366, Acc, reg5916, V2369)
+			__e.TailApply(__defun__shen_4dict_1fold_1h, V2365, V2366, Acc, reg5916, V2369)
 			return
 		}
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-fold-h", value: __defun__shen_4dict_1fold_1h})
 
-	__defun__shen_4bucket_1fold = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4bucket_1fold = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2373 := __args[0]
 		_ = V2373
 		V2374 := __args[1]
@@ -332,7 +332,7 @@ func init() {
 		reg5918 := Nil
 		reg5919 := PrimEqual(reg5918, V2374)
 		if reg5919 == True {
-			__ctx.Return(V2375)
+			__e.Return(V2375)
 			return
 		} else {
 			reg5920 := PrimIsPair(V2374)
@@ -359,70 +359,70 @@ func init() {
 				reg5930 := PrimHead(V2374)
 				reg5931 := PrimTail(reg5930)
 				reg5932 := PrimTail(V2374)
-				reg5933 := __e.Call(__defun__shen_4bucket_1fold, V2373, reg5932, V2375)
-				__ctx.TailApply(V2373, reg5929, reg5931, reg5933)
+				reg5933 := Call(__e, __defun__shen_4bucket_1fold, V2373, reg5932, V2375)
+				__e.TailApply(V2373, reg5929, reg5931, reg5933)
 				return
 			} else {
 				reg5935 := MakeSymbol("shen.bucket-fold")
-				__ctx.TailApply(__defun__shen_4f__error, reg5935)
+				__e.TailApply(__defun__shen_4f__error, reg5935)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.bucket-fold", value: __defun__shen_4bucket_1fold})
 
-	__defun__shen_4dict_1keys = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1keys = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2377 := __args[0]
 		_ = V2377
-		reg5937 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5937 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			K := __args[0]
 			_ = K
-			reg5938 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5938 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				__ := __args[0]
 				_ = __
-				reg5939 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg5939 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					Acc := __args[0]
 					_ = Acc
 					reg5940 := PrimCons(K, Acc)
-					__ctx.Return(reg5940)
+					__e.Return(reg5940)
 					return
 				}, 1)
-				__ctx.Return(reg5939)
+				__e.Return(reg5939)
 				return
 			}, 1)
-			__ctx.Return(reg5938)
+			__e.Return(reg5938)
 			return
 		}, 1)
 		reg5941 := Nil
-		__ctx.TailApply(__defun__shen_4dict_1fold, reg5937, V2377, reg5941)
+		__e.TailApply(__defun__shen_4dict_1fold, reg5937, V2377, reg5941)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-keys", value: __defun__shen_4dict_1keys})
 
-	__defun__shen_4dict_1values = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dict_1values = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2379 := __args[0]
 		_ = V2379
-		reg5943 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5943 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			__ := __args[0]
 			_ = __
-			reg5944 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5944 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V := __args[0]
 				_ = V
-				reg5945 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg5945 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					Acc := __args[0]
 					_ = Acc
 					reg5946 := PrimCons(V, Acc)
-					__ctx.Return(reg5946)
+					__e.Return(reg5946)
 					return
 				}, 1)
-				__ctx.Return(reg5945)
+				__e.Return(reg5945)
 				return
 			}, 1)
-			__ctx.Return(reg5944)
+			__e.Return(reg5944)
 			return
 		}, 1)
 		reg5947 := Nil
-		__ctx.TailApply(__defun__shen_4dict_1fold, reg5943, V2379, reg5947)
+		__e.TailApply(__defun__shen_4dict_1fold, reg5943, V2379, reg5947)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.dict-values", value: __defun__shen_4dict_1values})

--- a/cmd/shen/init.go
+++ b/cmd/shen/init.go
@@ -9,12 +9,12 @@ var __defun__shen_4initialise_1lambda_1forms Obj             // shen.initialise-
 var __defun__shen_4initialise Obj                            // shen.initialise
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg31663 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg31663)
+		__e.Return(reg31663)
 		return
 	}, 0))
-	__defun__shen_4initialise_1environment = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4initialise_1environment = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg31664 := MakeSymbol("shen.*installing-kl*")
 		reg31665 := False
 		reg31666 := PrimSet(reg31664, reg31665)
@@ -29,7 +29,7 @@ func init() {
 		_ = reg31672
 		reg31673 := MakeSymbol("*property-vector*")
 		reg31674 := MakeNumber(20000)
-		reg31675 := __e.Call(__defun__shen_4dict, reg31674)
+		reg31675 := Call(__e, __defun__shen_4dict, reg31674)
 		reg31676 := PrimSet(reg31673, reg31675)
 		_ = reg31676
 		reg31677 := MakeSymbol("shen.*process-counter*")
@@ -38,19 +38,19 @@ func init() {
 		_ = reg31679
 		reg31680 := MakeSymbol("shen.*varcounter*")
 		reg31681 := MakeNumber(10000)
-		reg31682 := __e.Call(__defun__vector, reg31681)
+		reg31682 := Call(__e, __defun__vector, reg31681)
 		reg31683 := PrimSet(reg31680, reg31682)
 		_ = reg31683
 		reg31684 := MakeSymbol("shen.*prologvectors*")
 		reg31685 := MakeNumber(10000)
-		reg31686 := __e.Call(__defun__vector, reg31685)
+		reg31686 := Call(__e, __defun__vector, reg31685)
 		reg31687 := PrimSet(reg31684, reg31686)
 		_ = reg31687
 		reg31688 := MakeSymbol("shen.*demodulation-function*")
-		reg31689 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31689 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.Return(X)
+			__e.Return(X)
 			return
 		}, 1)
 		reg31690 := PrimSet(reg31688, reg31689)
@@ -96,112 +96,112 @@ func init() {
 		reg31729 := PrimSet(reg31691, reg31728)
 		_ = reg31729
 		reg31730 := MakeSymbol("*macros*")
-		reg31731 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31731 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4timer_1macro, X)
+			__e.TailApply(__defun__shen_4timer_1macro, X)
 			return
 		}, 1)
-		reg31733 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31733 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4cases_1macro, X)
+			__e.TailApply(__defun__shen_4cases_1macro, X)
 			return
 		}, 1)
-		reg31735 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31735 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4abs_1macro, X)
+			__e.TailApply(__defun__shen_4abs_1macro, X)
 			return
 		}, 1)
-		reg31737 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31737 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4put_cget_1macro, X)
+			__e.TailApply(__defun__shen_4put_cget_1macro, X)
 			return
 		}, 1)
-		reg31739 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31739 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4compile_1macro, X)
+			__e.TailApply(__defun__shen_4compile_1macro, X)
 			return
 		}, 1)
-		reg31741 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31741 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4datatype_1macro, X)
+			__e.TailApply(__defun__shen_4datatype_1macro, X)
 			return
 		}, 1)
-		reg31743 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31743 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4let_1macro, X)
+			__e.TailApply(__defun__shen_4let_1macro, X)
 			return
 		}, 1)
-		reg31745 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31745 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4assoc_1macro, X)
+			__e.TailApply(__defun__shen_4assoc_1macro, X)
 			return
 		}, 1)
-		reg31747 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31747 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4make_1string_1macro, X)
+			__e.TailApply(__defun__shen_4make_1string_1macro, X)
 			return
 		}, 1)
-		reg31749 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31749 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4output_1macro, X)
+			__e.TailApply(__defun__shen_4output_1macro, X)
 			return
 		}, 1)
-		reg31751 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31751 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4input_1macro, X)
+			__e.TailApply(__defun__shen_4input_1macro, X)
 			return
 		}, 1)
-		reg31753 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31753 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4error_1macro, X)
+			__e.TailApply(__defun__shen_4error_1macro, X)
 			return
 		}, 1)
-		reg31755 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31755 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4prolog_1macro, X)
+			__e.TailApply(__defun__shen_4prolog_1macro, X)
 			return
 		}, 1)
-		reg31757 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31757 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4synonyms_1macro, X)
+			__e.TailApply(__defun__shen_4synonyms_1macro, X)
 			return
 		}, 1)
-		reg31759 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31759 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4nl_1macro, X)
+			__e.TailApply(__defun__shen_4nl_1macro, X)
 			return
 		}, 1)
-		reg31761 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31761 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4_8s_1macro, X)
+			__e.TailApply(__defun__shen_4_8s_1macro, X)
 			return
 		}, 1)
-		reg31763 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31763 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4defprolog_1macro, X)
+			__e.TailApply(__defun__shen_4defprolog_1macro, X)
 			return
 		}, 1)
-		reg31765 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg31765 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4function_1macro, X)
+			__e.TailApply(__defun__shen_4function_1macro, X)
 			return
 		}, 1)
 		reg31767 := Nil
@@ -392,7 +392,7 @@ func init() {
 		reg31931 := PrimSet(reg31929, reg31930)
 		_ = reg31931
 		reg31932 := MakeSymbol("*home-directory*")
-		reg31933 := __e.Call(__defun__bound_2, reg31932)
+		reg31933 := Call(__e, __defun__bound_2, reg31932)
 		reg31934 := PrimNot(reg31933)
 		var reg31939 Obj
 		if reg31934 == True {
@@ -406,7 +406,7 @@ func init() {
 		}
 		_ = reg31939
 		reg31940 := MakeSymbol("*sterror*")
-		reg31941 := __e.Call(__defun__bound_2, reg31940)
+		reg31941 := Call(__e, __defun__bound_2, reg31940)
 		reg31942 := PrimNot(reg31941)
 		var reg31948 Obj
 		if reg31942 == True {
@@ -1113,7 +1113,7 @@ func init() {
 		reg32639 := PrimCons(reg31951, reg32638)
 		reg32640 := PrimCons(reg31950, reg32639)
 		reg32641 := PrimCons(reg31949, reg32640)
-		reg32642 := __e.Call(__defun__shen_4initialise__arity__table, reg32641)
+		reg32642 := Call(__e, __defun__shen_4initialise__arity__table, reg32641)
 		_ = reg32642
 		reg32643 := MakeString("shen")
 		reg32644 := PrimIntern(reg32643)
@@ -1611,7 +1611,7 @@ func init() {
 		reg33136 := PrimCons(reg32646, reg33135)
 		reg33137 := MakeSymbol("*property-vector*")
 		reg33138 := PrimValue(reg33137)
-		reg33139 := __e.Call(__defun__put, reg32644, reg32645, reg33136, reg33138)
+		reg33139 := Call(__e, __defun__put, reg32644, reg32645, reg33136, reg33138)
 		_ = reg33139
 		reg33140 := MakeSymbol("shen.*history*")
 		reg33141 := Nil
@@ -1625,12 +1625,12 @@ func init() {
 		reg33147 := MakeNumber(0)
 		reg33148 := PrimAbsvector(reg33147)
 		reg33149 := PrimSet(reg33146, reg33148)
-		__ctx.Return(reg33149)
+		__e.Return(reg33149)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.initialise-environment", value: __defun__shen_4initialise_1environment})
 
-	__defun__shen_4initialise_1signedfuncs = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4initialise_1signedfuncs = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg33150 := MakeSymbol("shen.*signedfuncs*")
 		reg33151 := Nil
 		reg33152 := PrimSet(reg33150, reg33151)
@@ -4316,5071 +4316,5071 @@ func init() {
 		reg35696 := PrimValue(reg35695)
 		reg35697 := PrimCons(reg35694, reg35696)
 		reg35698 := PrimSet(reg35679, reg35697)
-		__ctx.Return(reg35698)
+		__e.Return(reg35698)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.initialise-signedfuncs", value: __defun__shen_4initialise_1signedfuncs})
 
-	__defun__shen_4initialise_1signedfunc_1lambda_1forms = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4initialise_1signedfunc_1lambda_1forms = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg35699 := MakeSymbol("shen.type-signature-of-absvector?")
-		reg35700 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35700 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4559 := __args[0]
 			_ = V4559
-			reg35701 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35701 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4560 := __args[0]
 				_ = V4560
-				reg35702 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35702 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4561 := __args[0]
 					_ = V4561
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1absvector_2, V4559, V4560, V4561)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1absvector_2, V4559, V4560, V4561)
 					return
 				}, 1)
-				__ctx.Return(reg35702)
+				__e.Return(reg35702)
 				return
 			}, 1)
-			__ctx.Return(reg35701)
+			__e.Return(reg35701)
 			return
 		}, 1)
 		reg35704 := PrimCons(reg35699, reg35700)
-		reg35705 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35704)
+		reg35705 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35704)
 		_ = reg35705
 		reg35706 := MakeSymbol("shen.type-signature-of-adjoin")
-		reg35707 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35707 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4549 := __args[0]
 			_ = V4549
-			reg35708 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35708 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4550 := __args[0]
 				_ = V4550
-				reg35709 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35709 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4551 := __args[0]
 					_ = V4551
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1adjoin, V4549, V4550, V4551)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1adjoin, V4549, V4550, V4551)
 					return
 				}, 1)
-				__ctx.Return(reg35709)
+				__e.Return(reg35709)
 				return
 			}, 1)
-			__ctx.Return(reg35708)
+			__e.Return(reg35708)
 			return
 		}, 1)
 		reg35711 := PrimCons(reg35706, reg35707)
-		reg35712 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35711)
+		reg35712 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35711)
 		_ = reg35712
 		reg35713 := MakeSymbol("shen.type-signature-of-and")
-		reg35714 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35714 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4539 := __args[0]
 			_ = V4539
-			reg35715 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35715 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4540 := __args[0]
 				_ = V4540
-				reg35716 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35716 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4541 := __args[0]
 					_ = V4541
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1and, V4539, V4540, V4541)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1and, V4539, V4540, V4541)
 					return
 				}, 1)
-				__ctx.Return(reg35716)
+				__e.Return(reg35716)
 				return
 			}, 1)
-			__ctx.Return(reg35715)
+			__e.Return(reg35715)
 			return
 		}, 1)
 		reg35718 := PrimCons(reg35713, reg35714)
-		reg35719 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35718)
+		reg35719 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35718)
 		_ = reg35719
 		reg35720 := MakeSymbol("shen.type-signature-of-shen.app")
-		reg35721 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35721 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4529 := __args[0]
 			_ = V4529
-			reg35722 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35722 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4530 := __args[0]
 				_ = V4530
-				reg35723 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35723 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4531 := __args[0]
 					_ = V4531
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1shen_4app, V4529, V4530, V4531)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1shen_4app, V4529, V4530, V4531)
 					return
 				}, 1)
-				__ctx.Return(reg35723)
+				__e.Return(reg35723)
 				return
 			}, 1)
-			__ctx.Return(reg35722)
+			__e.Return(reg35722)
 			return
 		}, 1)
 		reg35725 := PrimCons(reg35720, reg35721)
-		reg35726 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35725)
+		reg35726 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35725)
 		_ = reg35726
 		reg35727 := MakeSymbol("shen.type-signature-of-append")
-		reg35728 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35728 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4519 := __args[0]
 			_ = V4519
-			reg35729 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35729 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4520 := __args[0]
 				_ = V4520
-				reg35730 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35730 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4521 := __args[0]
 					_ = V4521
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1append, V4519, V4520, V4521)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1append, V4519, V4520, V4521)
 					return
 				}, 1)
-				__ctx.Return(reg35730)
+				__e.Return(reg35730)
 				return
 			}, 1)
-			__ctx.Return(reg35729)
+			__e.Return(reg35729)
 			return
 		}, 1)
 		reg35732 := PrimCons(reg35727, reg35728)
-		reg35733 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35732)
+		reg35733 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35732)
 		_ = reg35733
 		reg35734 := MakeSymbol("shen.type-signature-of-arity")
-		reg35735 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35735 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4509 := __args[0]
 			_ = V4509
-			reg35736 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35736 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4510 := __args[0]
 				_ = V4510
-				reg35737 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35737 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4511 := __args[0]
 					_ = V4511
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1arity, V4509, V4510, V4511)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1arity, V4509, V4510, V4511)
 					return
 				}, 1)
-				__ctx.Return(reg35737)
+				__e.Return(reg35737)
 				return
 			}, 1)
-			__ctx.Return(reg35736)
+			__e.Return(reg35736)
 			return
 		}, 1)
 		reg35739 := PrimCons(reg35734, reg35735)
-		reg35740 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35739)
+		reg35740 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35739)
 		_ = reg35740
 		reg35741 := MakeSymbol("shen.type-signature-of-assoc")
-		reg35742 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35742 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4499 := __args[0]
 			_ = V4499
-			reg35743 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35743 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4500 := __args[0]
 				_ = V4500
-				reg35744 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35744 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4501 := __args[0]
 					_ = V4501
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1assoc, V4499, V4500, V4501)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1assoc, V4499, V4500, V4501)
 					return
 				}, 1)
-				__ctx.Return(reg35744)
+				__e.Return(reg35744)
 				return
 			}, 1)
-			__ctx.Return(reg35743)
+			__e.Return(reg35743)
 			return
 		}, 1)
 		reg35746 := PrimCons(reg35741, reg35742)
-		reg35747 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35746)
+		reg35747 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35746)
 		_ = reg35747
 		reg35748 := MakeSymbol("shen.type-signature-of-boolean?")
-		reg35749 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35749 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4489 := __args[0]
 			_ = V4489
-			reg35750 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35750 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4490 := __args[0]
 				_ = V4490
-				reg35751 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35751 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4491 := __args[0]
 					_ = V4491
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1boolean_2, V4489, V4490, V4491)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1boolean_2, V4489, V4490, V4491)
 					return
 				}, 1)
-				__ctx.Return(reg35751)
+				__e.Return(reg35751)
 				return
 			}, 1)
-			__ctx.Return(reg35750)
+			__e.Return(reg35750)
 			return
 		}, 1)
 		reg35753 := PrimCons(reg35748, reg35749)
-		reg35754 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35753)
+		reg35754 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35753)
 		_ = reg35754
 		reg35755 := MakeSymbol("shen.type-signature-of-bound?")
-		reg35756 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35756 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4479 := __args[0]
 			_ = V4479
-			reg35757 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35757 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4480 := __args[0]
 				_ = V4480
-				reg35758 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35758 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4481 := __args[0]
 					_ = V4481
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1bound_2, V4479, V4480, V4481)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1bound_2, V4479, V4480, V4481)
 					return
 				}, 1)
-				__ctx.Return(reg35758)
+				__e.Return(reg35758)
 				return
 			}, 1)
-			__ctx.Return(reg35757)
+			__e.Return(reg35757)
 			return
 		}, 1)
 		reg35760 := PrimCons(reg35755, reg35756)
-		reg35761 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35760)
+		reg35761 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35760)
 		_ = reg35761
 		reg35762 := MakeSymbol("shen.type-signature-of-cd")
-		reg35763 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35763 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4469 := __args[0]
 			_ = V4469
-			reg35764 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35764 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4470 := __args[0]
 				_ = V4470
-				reg35765 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35765 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4471 := __args[0]
 					_ = V4471
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1cd, V4469, V4470, V4471)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1cd, V4469, V4470, V4471)
 					return
 				}, 1)
-				__ctx.Return(reg35765)
+				__e.Return(reg35765)
 				return
 			}, 1)
-			__ctx.Return(reg35764)
+			__e.Return(reg35764)
 			return
 		}, 1)
 		reg35767 := PrimCons(reg35762, reg35763)
-		reg35768 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35767)
+		reg35768 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35767)
 		_ = reg35768
 		reg35769 := MakeSymbol("shen.type-signature-of-close")
-		reg35770 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35770 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4459 := __args[0]
 			_ = V4459
-			reg35771 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35771 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4460 := __args[0]
 				_ = V4460
-				reg35772 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35772 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4461 := __args[0]
 					_ = V4461
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1close, V4459, V4460, V4461)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1close, V4459, V4460, V4461)
 					return
 				}, 1)
-				__ctx.Return(reg35772)
+				__e.Return(reg35772)
 				return
 			}, 1)
-			__ctx.Return(reg35771)
+			__e.Return(reg35771)
 			return
 		}, 1)
 		reg35774 := PrimCons(reg35769, reg35770)
-		reg35775 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35774)
+		reg35775 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35774)
 		_ = reg35775
 		reg35776 := MakeSymbol("shen.type-signature-of-cn")
-		reg35777 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35777 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4449 := __args[0]
 			_ = V4449
-			reg35778 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35778 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4450 := __args[0]
 				_ = V4450
-				reg35779 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35779 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4451 := __args[0]
 					_ = V4451
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1cn, V4449, V4450, V4451)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1cn, V4449, V4450, V4451)
 					return
 				}, 1)
-				__ctx.Return(reg35779)
+				__e.Return(reg35779)
 				return
 			}, 1)
-			__ctx.Return(reg35778)
+			__e.Return(reg35778)
 			return
 		}, 1)
 		reg35781 := PrimCons(reg35776, reg35777)
-		reg35782 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35781)
+		reg35782 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35781)
 		_ = reg35782
 		reg35783 := MakeSymbol("shen.type-signature-of-compile")
-		reg35784 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35784 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4439 := __args[0]
 			_ = V4439
-			reg35785 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35785 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4440 := __args[0]
 				_ = V4440
-				reg35786 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35786 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4441 := __args[0]
 					_ = V4441
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1compile, V4439, V4440, V4441)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1compile, V4439, V4440, V4441)
 					return
 				}, 1)
-				__ctx.Return(reg35786)
+				__e.Return(reg35786)
 				return
 			}, 1)
-			__ctx.Return(reg35785)
+			__e.Return(reg35785)
 			return
 		}, 1)
 		reg35788 := PrimCons(reg35783, reg35784)
-		reg35789 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35788)
+		reg35789 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35788)
 		_ = reg35789
 		reg35790 := MakeSymbol("shen.type-signature-of-cons?")
-		reg35791 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35791 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4429 := __args[0]
 			_ = V4429
-			reg35792 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35792 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4430 := __args[0]
 				_ = V4430
-				reg35793 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35793 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4431 := __args[0]
 					_ = V4431
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1cons_2, V4429, V4430, V4431)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1cons_2, V4429, V4430, V4431)
 					return
 				}, 1)
-				__ctx.Return(reg35793)
+				__e.Return(reg35793)
 				return
 			}, 1)
-			__ctx.Return(reg35792)
+			__e.Return(reg35792)
 			return
 		}, 1)
 		reg35795 := PrimCons(reg35790, reg35791)
-		reg35796 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35795)
+		reg35796 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35795)
 		_ = reg35796
 		reg35797 := MakeSymbol("shen.type-signature-of-destroy")
-		reg35798 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35798 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4419 := __args[0]
 			_ = V4419
-			reg35799 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35799 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4420 := __args[0]
 				_ = V4420
-				reg35800 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35800 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4421 := __args[0]
 					_ = V4421
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1destroy, V4419, V4420, V4421)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1destroy, V4419, V4420, V4421)
 					return
 				}, 1)
-				__ctx.Return(reg35800)
+				__e.Return(reg35800)
 				return
 			}, 1)
-			__ctx.Return(reg35799)
+			__e.Return(reg35799)
 			return
 		}, 1)
 		reg35802 := PrimCons(reg35797, reg35798)
-		reg35803 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35802)
+		reg35803 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35802)
 		_ = reg35803
 		reg35804 := MakeSymbol("shen.type-signature-of-difference")
-		reg35805 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35805 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4409 := __args[0]
 			_ = V4409
-			reg35806 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35806 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4410 := __args[0]
 				_ = V4410
-				reg35807 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35807 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4411 := __args[0]
 					_ = V4411
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1difference, V4409, V4410, V4411)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1difference, V4409, V4410, V4411)
 					return
 				}, 1)
-				__ctx.Return(reg35807)
+				__e.Return(reg35807)
 				return
 			}, 1)
-			__ctx.Return(reg35806)
+			__e.Return(reg35806)
 			return
 		}, 1)
 		reg35809 := PrimCons(reg35804, reg35805)
-		reg35810 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35809)
+		reg35810 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35809)
 		_ = reg35810
 		reg35811 := MakeSymbol("shen.type-signature-of-do")
-		reg35812 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35812 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4399 := __args[0]
 			_ = V4399
-			reg35813 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35813 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4400 := __args[0]
 				_ = V4400
-				reg35814 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35814 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4401 := __args[0]
 					_ = V4401
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1do, V4399, V4400, V4401)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1do, V4399, V4400, V4401)
 					return
 				}, 1)
-				__ctx.Return(reg35814)
+				__e.Return(reg35814)
 				return
 			}, 1)
-			__ctx.Return(reg35813)
+			__e.Return(reg35813)
 			return
 		}, 1)
 		reg35816 := PrimCons(reg35811, reg35812)
-		reg35817 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35816)
+		reg35817 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35816)
 		_ = reg35817
 		reg35818 := MakeSymbol("shen.type-signature-of-<e>")
-		reg35819 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35819 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4389 := __args[0]
 			_ = V4389
-			reg35820 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35820 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4390 := __args[0]
 				_ = V4390
-				reg35821 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35821 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4391 := __args[0]
 					_ = V4391
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_5e_6, V4389, V4390, V4391)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_5e_6, V4389, V4390, V4391)
 					return
 				}, 1)
-				__ctx.Return(reg35821)
+				__e.Return(reg35821)
 				return
 			}, 1)
-			__ctx.Return(reg35820)
+			__e.Return(reg35820)
 			return
 		}, 1)
 		reg35823 := PrimCons(reg35818, reg35819)
-		reg35824 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35823)
+		reg35824 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35823)
 		_ = reg35824
 		reg35825 := MakeSymbol("shen.type-signature-of-<!>")
-		reg35826 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35826 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4379 := __args[0]
 			_ = V4379
-			reg35827 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35827 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4380 := __args[0]
 				_ = V4380
-				reg35828 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35828 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4381 := __args[0]
 					_ = V4381
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_5_b_6, V4379, V4380, V4381)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_5_b_6, V4379, V4380, V4381)
 					return
 				}, 1)
-				__ctx.Return(reg35828)
+				__e.Return(reg35828)
 				return
 			}, 1)
-			__ctx.Return(reg35827)
+			__e.Return(reg35827)
 			return
 		}, 1)
 		reg35830 := PrimCons(reg35825, reg35826)
-		reg35831 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35830)
+		reg35831 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35830)
 		_ = reg35831
 		reg35832 := MakeSymbol("shen.type-signature-of-element?")
-		reg35833 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35833 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4369 := __args[0]
 			_ = V4369
-			reg35834 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35834 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4370 := __args[0]
 				_ = V4370
-				reg35835 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35835 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4371 := __args[0]
 					_ = V4371
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1element_2, V4369, V4370, V4371)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1element_2, V4369, V4370, V4371)
 					return
 				}, 1)
-				__ctx.Return(reg35835)
+				__e.Return(reg35835)
 				return
 			}, 1)
-			__ctx.Return(reg35834)
+			__e.Return(reg35834)
 			return
 		}, 1)
 		reg35837 := PrimCons(reg35832, reg35833)
-		reg35838 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35837)
+		reg35838 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35837)
 		_ = reg35838
 		reg35839 := MakeSymbol("shen.type-signature-of-empty?")
-		reg35840 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35840 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4359 := __args[0]
 			_ = V4359
-			reg35841 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35841 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4360 := __args[0]
 				_ = V4360
-				reg35842 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35842 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4361 := __args[0]
 					_ = V4361
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1empty_2, V4359, V4360, V4361)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1empty_2, V4359, V4360, V4361)
 					return
 				}, 1)
-				__ctx.Return(reg35842)
+				__e.Return(reg35842)
 				return
 			}, 1)
-			__ctx.Return(reg35841)
+			__e.Return(reg35841)
 			return
 		}, 1)
 		reg35844 := PrimCons(reg35839, reg35840)
-		reg35845 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35844)
+		reg35845 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35844)
 		_ = reg35845
 		reg35846 := MakeSymbol("shen.type-signature-of-enable-type-theory")
-		reg35847 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35847 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4349 := __args[0]
 			_ = V4349
-			reg35848 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35848 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4350 := __args[0]
 				_ = V4350
-				reg35849 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35849 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4351 := __args[0]
 					_ = V4351
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1enable_1type_1theory, V4349, V4350, V4351)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1enable_1type_1theory, V4349, V4350, V4351)
 					return
 				}, 1)
-				__ctx.Return(reg35849)
+				__e.Return(reg35849)
 				return
 			}, 1)
-			__ctx.Return(reg35848)
+			__e.Return(reg35848)
 			return
 		}, 1)
 		reg35851 := PrimCons(reg35846, reg35847)
-		reg35852 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35851)
+		reg35852 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35851)
 		_ = reg35852
 		reg35853 := MakeSymbol("shen.type-signature-of-external")
-		reg35854 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35854 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4339 := __args[0]
 			_ = V4339
-			reg35855 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35855 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4340 := __args[0]
 				_ = V4340
-				reg35856 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35856 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4341 := __args[0]
 					_ = V4341
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1external, V4339, V4340, V4341)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1external, V4339, V4340, V4341)
 					return
 				}, 1)
-				__ctx.Return(reg35856)
+				__e.Return(reg35856)
 				return
 			}, 1)
-			__ctx.Return(reg35855)
+			__e.Return(reg35855)
 			return
 		}, 1)
 		reg35858 := PrimCons(reg35853, reg35854)
-		reg35859 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35858)
+		reg35859 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35858)
 		_ = reg35859
 		reg35860 := MakeSymbol("shen.type-signature-of-error-to-string")
-		reg35861 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35861 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4329 := __args[0]
 			_ = V4329
-			reg35862 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35862 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4330 := __args[0]
 				_ = V4330
-				reg35863 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35863 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4331 := __args[0]
 					_ = V4331
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1error_1to_1string, V4329, V4330, V4331)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1error_1to_1string, V4329, V4330, V4331)
 					return
 				}, 1)
-				__ctx.Return(reg35863)
+				__e.Return(reg35863)
 				return
 			}, 1)
-			__ctx.Return(reg35862)
+			__e.Return(reg35862)
 			return
 		}, 1)
 		reg35865 := PrimCons(reg35860, reg35861)
-		reg35866 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35865)
+		reg35866 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35865)
 		_ = reg35866
 		reg35867 := MakeSymbol("shen.type-signature-of-explode")
-		reg35868 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35868 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4319 := __args[0]
 			_ = V4319
-			reg35869 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35869 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4320 := __args[0]
 				_ = V4320
-				reg35870 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35870 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4321 := __args[0]
 					_ = V4321
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1explode, V4319, V4320, V4321)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1explode, V4319, V4320, V4321)
 					return
 				}, 1)
-				__ctx.Return(reg35870)
+				__e.Return(reg35870)
 				return
 			}, 1)
-			__ctx.Return(reg35869)
+			__e.Return(reg35869)
 			return
 		}, 1)
 		reg35872 := PrimCons(reg35867, reg35868)
-		reg35873 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35872)
+		reg35873 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35872)
 		_ = reg35873
 		reg35874 := MakeSymbol("shen.type-signature-of-fail")
-		reg35875 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35875 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4309 := __args[0]
 			_ = V4309
-			reg35876 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35876 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4310 := __args[0]
 				_ = V4310
-				reg35877 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35877 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4311 := __args[0]
 					_ = V4311
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1fail, V4309, V4310, V4311)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1fail, V4309, V4310, V4311)
 					return
 				}, 1)
-				__ctx.Return(reg35877)
+				__e.Return(reg35877)
 				return
 			}, 1)
-			__ctx.Return(reg35876)
+			__e.Return(reg35876)
 			return
 		}, 1)
 		reg35879 := PrimCons(reg35874, reg35875)
-		reg35880 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35879)
+		reg35880 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35879)
 		_ = reg35880
 		reg35881 := MakeSymbol("shen.type-signature-of-fail-if")
-		reg35882 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35882 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4299 := __args[0]
 			_ = V4299
-			reg35883 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35883 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4300 := __args[0]
 				_ = V4300
-				reg35884 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35884 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4301 := __args[0]
 					_ = V4301
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1fail_1if, V4299, V4300, V4301)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1fail_1if, V4299, V4300, V4301)
 					return
 				}, 1)
-				__ctx.Return(reg35884)
+				__e.Return(reg35884)
 				return
 			}, 1)
-			__ctx.Return(reg35883)
+			__e.Return(reg35883)
 			return
 		}, 1)
 		reg35886 := PrimCons(reg35881, reg35882)
-		reg35887 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35886)
+		reg35887 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35886)
 		_ = reg35887
 		reg35888 := MakeSymbol("shen.type-signature-of-fix")
-		reg35889 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35889 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4289 := __args[0]
 			_ = V4289
-			reg35890 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35890 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4290 := __args[0]
 				_ = V4290
-				reg35891 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35891 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4291 := __args[0]
 					_ = V4291
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1fix, V4289, V4290, V4291)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1fix, V4289, V4290, V4291)
 					return
 				}, 1)
-				__ctx.Return(reg35891)
+				__e.Return(reg35891)
 				return
 			}, 1)
-			__ctx.Return(reg35890)
+			__e.Return(reg35890)
 			return
 		}, 1)
 		reg35893 := PrimCons(reg35888, reg35889)
-		reg35894 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35893)
+		reg35894 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35893)
 		_ = reg35894
 		reg35895 := MakeSymbol("shen.type-signature-of-freeze")
-		reg35896 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35896 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4279 := __args[0]
 			_ = V4279
-			reg35897 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35897 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4280 := __args[0]
 				_ = V4280
-				reg35898 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35898 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4281 := __args[0]
 					_ = V4281
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1freeze, V4279, V4280, V4281)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1freeze, V4279, V4280, V4281)
 					return
 				}, 1)
-				__ctx.Return(reg35898)
+				__e.Return(reg35898)
 				return
 			}, 1)
-			__ctx.Return(reg35897)
+			__e.Return(reg35897)
 			return
 		}, 1)
 		reg35900 := PrimCons(reg35895, reg35896)
-		reg35901 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35900)
+		reg35901 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35900)
 		_ = reg35901
 		reg35902 := MakeSymbol("shen.type-signature-of-fst")
-		reg35903 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35903 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4269 := __args[0]
 			_ = V4269
-			reg35904 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35904 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4270 := __args[0]
 				_ = V4270
-				reg35905 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35905 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4271 := __args[0]
 					_ = V4271
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1fst, V4269, V4270, V4271)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1fst, V4269, V4270, V4271)
 					return
 				}, 1)
-				__ctx.Return(reg35905)
+				__e.Return(reg35905)
 				return
 			}, 1)
-			__ctx.Return(reg35904)
+			__e.Return(reg35904)
 			return
 		}, 1)
 		reg35907 := PrimCons(reg35902, reg35903)
-		reg35908 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35907)
+		reg35908 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35907)
 		_ = reg35908
 		reg35909 := MakeSymbol("shen.type-signature-of-function")
-		reg35910 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35910 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4259 := __args[0]
 			_ = V4259
-			reg35911 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35911 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4260 := __args[0]
 				_ = V4260
-				reg35912 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35912 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4261 := __args[0]
 					_ = V4261
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1function, V4259, V4260, V4261)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1function, V4259, V4260, V4261)
 					return
 				}, 1)
-				__ctx.Return(reg35912)
+				__e.Return(reg35912)
 				return
 			}, 1)
-			__ctx.Return(reg35911)
+			__e.Return(reg35911)
 			return
 		}, 1)
 		reg35914 := PrimCons(reg35909, reg35910)
-		reg35915 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35914)
+		reg35915 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35914)
 		_ = reg35915
 		reg35916 := MakeSymbol("shen.type-signature-of-gensym")
-		reg35917 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35917 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4249 := __args[0]
 			_ = V4249
-			reg35918 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35918 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4250 := __args[0]
 				_ = V4250
-				reg35919 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35919 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4251 := __args[0]
 					_ = V4251
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1gensym, V4249, V4250, V4251)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1gensym, V4249, V4250, V4251)
 					return
 				}, 1)
-				__ctx.Return(reg35919)
+				__e.Return(reg35919)
 				return
 			}, 1)
-			__ctx.Return(reg35918)
+			__e.Return(reg35918)
 			return
 		}, 1)
 		reg35921 := PrimCons(reg35916, reg35917)
-		reg35922 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35921)
+		reg35922 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35921)
 		_ = reg35922
 		reg35923 := MakeSymbol("shen.type-signature-of-<-vector")
-		reg35924 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35924 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4239 := __args[0]
 			_ = V4239
-			reg35925 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35925 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4240 := __args[0]
 				_ = V4240
-				reg35926 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35926 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4241 := __args[0]
 					_ = V4241
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_5_1vector, V4239, V4240, V4241)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_5_1vector, V4239, V4240, V4241)
 					return
 				}, 1)
-				__ctx.Return(reg35926)
+				__e.Return(reg35926)
 				return
 			}, 1)
-			__ctx.Return(reg35925)
+			__e.Return(reg35925)
 			return
 		}, 1)
 		reg35928 := PrimCons(reg35923, reg35924)
-		reg35929 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35928)
+		reg35929 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35928)
 		_ = reg35929
 		reg35930 := MakeSymbol("shen.type-signature-of-vector->")
-		reg35931 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35931 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4229 := __args[0]
 			_ = V4229
-			reg35932 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35932 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4230 := __args[0]
 				_ = V4230
-				reg35933 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35933 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4231 := __args[0]
 					_ = V4231
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1vector_1_6, V4229, V4230, V4231)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1vector_1_6, V4229, V4230, V4231)
 					return
 				}, 1)
-				__ctx.Return(reg35933)
+				__e.Return(reg35933)
 				return
 			}, 1)
-			__ctx.Return(reg35932)
+			__e.Return(reg35932)
 			return
 		}, 1)
 		reg35935 := PrimCons(reg35930, reg35931)
-		reg35936 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35935)
+		reg35936 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35935)
 		_ = reg35936
 		reg35937 := MakeSymbol("shen.type-signature-of-vector")
-		reg35938 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35938 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4219 := __args[0]
 			_ = V4219
-			reg35939 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35939 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4220 := __args[0]
 				_ = V4220
-				reg35940 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35940 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4221 := __args[0]
 					_ = V4221
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1vector, V4219, V4220, V4221)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1vector, V4219, V4220, V4221)
 					return
 				}, 1)
-				__ctx.Return(reg35940)
+				__e.Return(reg35940)
 				return
 			}, 1)
-			__ctx.Return(reg35939)
+			__e.Return(reg35939)
 			return
 		}, 1)
 		reg35942 := PrimCons(reg35937, reg35938)
-		reg35943 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35942)
+		reg35943 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35942)
 		_ = reg35943
 		reg35944 := MakeSymbol("shen.type-signature-of-get-time")
-		reg35945 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35945 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4209 := __args[0]
 			_ = V4209
-			reg35946 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35946 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4210 := __args[0]
 				_ = V4210
-				reg35947 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35947 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4211 := __args[0]
 					_ = V4211
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1get_1time, V4209, V4210, V4211)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1get_1time, V4209, V4210, V4211)
 					return
 				}, 1)
-				__ctx.Return(reg35947)
+				__e.Return(reg35947)
 				return
 			}, 1)
-			__ctx.Return(reg35946)
+			__e.Return(reg35946)
 			return
 		}, 1)
 		reg35949 := PrimCons(reg35944, reg35945)
-		reg35950 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35949)
+		reg35950 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35949)
 		_ = reg35950
 		reg35951 := MakeSymbol("shen.type-signature-of-hash")
-		reg35952 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35952 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4199 := __args[0]
 			_ = V4199
-			reg35953 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35953 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4200 := __args[0]
 				_ = V4200
-				reg35954 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35954 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4201 := __args[0]
 					_ = V4201
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1hash, V4199, V4200, V4201)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1hash, V4199, V4200, V4201)
 					return
 				}, 1)
-				__ctx.Return(reg35954)
+				__e.Return(reg35954)
 				return
 			}, 1)
-			__ctx.Return(reg35953)
+			__e.Return(reg35953)
 			return
 		}, 1)
 		reg35956 := PrimCons(reg35951, reg35952)
-		reg35957 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35956)
+		reg35957 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35956)
 		_ = reg35957
 		reg35958 := MakeSymbol("shen.type-signature-of-head")
-		reg35959 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35959 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4189 := __args[0]
 			_ = V4189
-			reg35960 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35960 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4190 := __args[0]
 				_ = V4190
-				reg35961 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35961 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4191 := __args[0]
 					_ = V4191
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1head, V4189, V4190, V4191)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1head, V4189, V4190, V4191)
 					return
 				}, 1)
-				__ctx.Return(reg35961)
+				__e.Return(reg35961)
 				return
 			}, 1)
-			__ctx.Return(reg35960)
+			__e.Return(reg35960)
 			return
 		}, 1)
 		reg35963 := PrimCons(reg35958, reg35959)
-		reg35964 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35963)
+		reg35964 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35963)
 		_ = reg35964
 		reg35965 := MakeSymbol("shen.type-signature-of-hdv")
-		reg35966 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35966 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4179 := __args[0]
 			_ = V4179
-			reg35967 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35967 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4180 := __args[0]
 				_ = V4180
-				reg35968 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35968 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4181 := __args[0]
 					_ = V4181
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1hdv, V4179, V4180, V4181)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1hdv, V4179, V4180, V4181)
 					return
 				}, 1)
-				__ctx.Return(reg35968)
+				__e.Return(reg35968)
 				return
 			}, 1)
-			__ctx.Return(reg35967)
+			__e.Return(reg35967)
 			return
 		}, 1)
 		reg35970 := PrimCons(reg35965, reg35966)
-		reg35971 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35970)
+		reg35971 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35970)
 		_ = reg35971
 		reg35972 := MakeSymbol("shen.type-signature-of-hdstr")
-		reg35973 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35973 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4169 := __args[0]
 			_ = V4169
-			reg35974 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35974 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4170 := __args[0]
 				_ = V4170
-				reg35975 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35975 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4171 := __args[0]
 					_ = V4171
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1hdstr, V4169, V4170, V4171)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1hdstr, V4169, V4170, V4171)
 					return
 				}, 1)
-				__ctx.Return(reg35975)
+				__e.Return(reg35975)
 				return
 			}, 1)
-			__ctx.Return(reg35974)
+			__e.Return(reg35974)
 			return
 		}, 1)
 		reg35977 := PrimCons(reg35972, reg35973)
-		reg35978 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35977)
+		reg35978 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35977)
 		_ = reg35978
 		reg35979 := MakeSymbol("shen.type-signature-of-if")
-		reg35980 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35980 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4159 := __args[0]
 			_ = V4159
-			reg35981 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35981 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4160 := __args[0]
 				_ = V4160
-				reg35982 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35982 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4161 := __args[0]
 					_ = V4161
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1if, V4159, V4160, V4161)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1if, V4159, V4160, V4161)
 					return
 				}, 1)
-				__ctx.Return(reg35982)
+				__e.Return(reg35982)
 				return
 			}, 1)
-			__ctx.Return(reg35981)
+			__e.Return(reg35981)
 			return
 		}, 1)
 		reg35984 := PrimCons(reg35979, reg35980)
-		reg35985 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35984)
+		reg35985 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35984)
 		_ = reg35985
 		reg35986 := MakeSymbol("shen.type-signature-of-it")
-		reg35987 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35987 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4149 := __args[0]
 			_ = V4149
-			reg35988 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35988 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4150 := __args[0]
 				_ = V4150
-				reg35989 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35989 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4151 := __args[0]
 					_ = V4151
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1it, V4149, V4150, V4151)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1it, V4149, V4150, V4151)
 					return
 				}, 1)
-				__ctx.Return(reg35989)
+				__e.Return(reg35989)
 				return
 			}, 1)
-			__ctx.Return(reg35988)
+			__e.Return(reg35988)
 			return
 		}, 1)
 		reg35991 := PrimCons(reg35986, reg35987)
-		reg35992 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35991)
+		reg35992 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35991)
 		_ = reg35992
 		reg35993 := MakeSymbol("shen.type-signature-of-implementation")
-		reg35994 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg35994 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4139 := __args[0]
 			_ = V4139
-			reg35995 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg35995 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4140 := __args[0]
 				_ = V4140
-				reg35996 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg35996 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4141 := __args[0]
 					_ = V4141
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1implementation, V4139, V4140, V4141)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1implementation, V4139, V4140, V4141)
 					return
 				}, 1)
-				__ctx.Return(reg35996)
+				__e.Return(reg35996)
 				return
 			}, 1)
-			__ctx.Return(reg35995)
+			__e.Return(reg35995)
 			return
 		}, 1)
 		reg35998 := PrimCons(reg35993, reg35994)
-		reg35999 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg35998)
+		reg35999 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg35998)
 		_ = reg35999
 		reg36000 := MakeSymbol("shen.type-signature-of-include")
-		reg36001 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36001 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4129 := __args[0]
 			_ = V4129
-			reg36002 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36002 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4130 := __args[0]
 				_ = V4130
-				reg36003 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36003 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4131 := __args[0]
 					_ = V4131
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1include, V4129, V4130, V4131)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1include, V4129, V4130, V4131)
 					return
 				}, 1)
-				__ctx.Return(reg36003)
+				__e.Return(reg36003)
 				return
 			}, 1)
-			__ctx.Return(reg36002)
+			__e.Return(reg36002)
 			return
 		}, 1)
 		reg36005 := PrimCons(reg36000, reg36001)
-		reg36006 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36005)
+		reg36006 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36005)
 		_ = reg36006
 		reg36007 := MakeSymbol("shen.type-signature-of-include-all-but")
-		reg36008 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36008 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4119 := __args[0]
 			_ = V4119
-			reg36009 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36009 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4120 := __args[0]
 				_ = V4120
-				reg36010 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36010 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4121 := __args[0]
 					_ = V4121
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1include_1all_1but, V4119, V4120, V4121)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1include_1all_1but, V4119, V4120, V4121)
 					return
 				}, 1)
-				__ctx.Return(reg36010)
+				__e.Return(reg36010)
 				return
 			}, 1)
-			__ctx.Return(reg36009)
+			__e.Return(reg36009)
 			return
 		}, 1)
 		reg36012 := PrimCons(reg36007, reg36008)
-		reg36013 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36012)
+		reg36013 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36012)
 		_ = reg36013
 		reg36014 := MakeSymbol("shen.type-signature-of-inferences")
-		reg36015 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36015 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4109 := __args[0]
 			_ = V4109
-			reg36016 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36016 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4110 := __args[0]
 				_ = V4110
-				reg36017 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36017 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4111 := __args[0]
 					_ = V4111
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1inferences, V4109, V4110, V4111)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1inferences, V4109, V4110, V4111)
 					return
 				}, 1)
-				__ctx.Return(reg36017)
+				__e.Return(reg36017)
 				return
 			}, 1)
-			__ctx.Return(reg36016)
+			__e.Return(reg36016)
 			return
 		}, 1)
 		reg36019 := PrimCons(reg36014, reg36015)
-		reg36020 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36019)
+		reg36020 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36019)
 		_ = reg36020
 		reg36021 := MakeSymbol("shen.type-signature-of-shen.insert")
-		reg36022 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36022 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4099 := __args[0]
 			_ = V4099
-			reg36023 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36023 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4100 := __args[0]
 				_ = V4100
-				reg36024 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36024 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4101 := __args[0]
 					_ = V4101
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1shen_4insert, V4099, V4100, V4101)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1shen_4insert, V4099, V4100, V4101)
 					return
 				}, 1)
-				__ctx.Return(reg36024)
+				__e.Return(reg36024)
 				return
 			}, 1)
-			__ctx.Return(reg36023)
+			__e.Return(reg36023)
 			return
 		}, 1)
 		reg36026 := PrimCons(reg36021, reg36022)
-		reg36027 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36026)
+		reg36027 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36026)
 		_ = reg36027
 		reg36028 := MakeSymbol("shen.type-signature-of-integer?")
-		reg36029 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36029 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4089 := __args[0]
 			_ = V4089
-			reg36030 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36030 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4090 := __args[0]
 				_ = V4090
-				reg36031 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36031 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4091 := __args[0]
 					_ = V4091
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1integer_2, V4089, V4090, V4091)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1integer_2, V4089, V4090, V4091)
 					return
 				}, 1)
-				__ctx.Return(reg36031)
+				__e.Return(reg36031)
 				return
 			}, 1)
-			__ctx.Return(reg36030)
+			__e.Return(reg36030)
 			return
 		}, 1)
 		reg36033 := PrimCons(reg36028, reg36029)
-		reg36034 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36033)
+		reg36034 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36033)
 		_ = reg36034
 		reg36035 := MakeSymbol("shen.type-signature-of-internal")
-		reg36036 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36036 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4079 := __args[0]
 			_ = V4079
-			reg36037 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36037 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4080 := __args[0]
 				_ = V4080
-				reg36038 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36038 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4081 := __args[0]
 					_ = V4081
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1internal, V4079, V4080, V4081)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1internal, V4079, V4080, V4081)
 					return
 				}, 1)
-				__ctx.Return(reg36038)
+				__e.Return(reg36038)
 				return
 			}, 1)
-			__ctx.Return(reg36037)
+			__e.Return(reg36037)
 			return
 		}, 1)
 		reg36040 := PrimCons(reg36035, reg36036)
-		reg36041 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36040)
+		reg36041 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36040)
 		_ = reg36041
 		reg36042 := MakeSymbol("shen.type-signature-of-intersection")
-		reg36043 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36043 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4069 := __args[0]
 			_ = V4069
-			reg36044 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36044 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4070 := __args[0]
 				_ = V4070
-				reg36045 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36045 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4071 := __args[0]
 					_ = V4071
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1intersection, V4069, V4070, V4071)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1intersection, V4069, V4070, V4071)
 					return
 				}, 1)
-				__ctx.Return(reg36045)
+				__e.Return(reg36045)
 				return
 			}, 1)
-			__ctx.Return(reg36044)
+			__e.Return(reg36044)
 			return
 		}, 1)
 		reg36047 := PrimCons(reg36042, reg36043)
-		reg36048 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36047)
+		reg36048 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36047)
 		_ = reg36048
 		reg36049 := MakeSymbol("shen.type-signature-of-kill")
-		reg36050 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36050 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4059 := __args[0]
 			_ = V4059
-			reg36051 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36051 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4060 := __args[0]
 				_ = V4060
-				reg36052 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36052 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4061 := __args[0]
 					_ = V4061
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1kill, V4059, V4060, V4061)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1kill, V4059, V4060, V4061)
 					return
 				}, 1)
-				__ctx.Return(reg36052)
+				__e.Return(reg36052)
 				return
 			}, 1)
-			__ctx.Return(reg36051)
+			__e.Return(reg36051)
 			return
 		}, 1)
 		reg36054 := PrimCons(reg36049, reg36050)
-		reg36055 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36054)
+		reg36055 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36054)
 		_ = reg36055
 		reg36056 := MakeSymbol("shen.type-signature-of-language")
-		reg36057 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36057 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4049 := __args[0]
 			_ = V4049
-			reg36058 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36058 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4050 := __args[0]
 				_ = V4050
-				reg36059 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36059 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4051 := __args[0]
 					_ = V4051
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1language, V4049, V4050, V4051)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1language, V4049, V4050, V4051)
 					return
 				}, 1)
-				__ctx.Return(reg36059)
+				__e.Return(reg36059)
 				return
 			}, 1)
-			__ctx.Return(reg36058)
+			__e.Return(reg36058)
 			return
 		}, 1)
 		reg36061 := PrimCons(reg36056, reg36057)
-		reg36062 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36061)
+		reg36062 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36061)
 		_ = reg36062
 		reg36063 := MakeSymbol("shen.type-signature-of-length")
-		reg36064 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36064 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4039 := __args[0]
 			_ = V4039
-			reg36065 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36065 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4040 := __args[0]
 				_ = V4040
-				reg36066 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36066 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4041 := __args[0]
 					_ = V4041
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1length, V4039, V4040, V4041)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1length, V4039, V4040, V4041)
 					return
 				}, 1)
-				__ctx.Return(reg36066)
+				__e.Return(reg36066)
 				return
 			}, 1)
-			__ctx.Return(reg36065)
+			__e.Return(reg36065)
 			return
 		}, 1)
 		reg36068 := PrimCons(reg36063, reg36064)
-		reg36069 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36068)
+		reg36069 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36068)
 		_ = reg36069
 		reg36070 := MakeSymbol("shen.type-signature-of-limit")
-		reg36071 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36071 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4029 := __args[0]
 			_ = V4029
-			reg36072 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36072 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4030 := __args[0]
 				_ = V4030
-				reg36073 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36073 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4031 := __args[0]
 					_ = V4031
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1limit, V4029, V4030, V4031)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1limit, V4029, V4030, V4031)
 					return
 				}, 1)
-				__ctx.Return(reg36073)
+				__e.Return(reg36073)
 				return
 			}, 1)
-			__ctx.Return(reg36072)
+			__e.Return(reg36072)
 			return
 		}, 1)
 		reg36075 := PrimCons(reg36070, reg36071)
-		reg36076 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36075)
+		reg36076 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36075)
 		_ = reg36076
 		reg36077 := MakeSymbol("shen.type-signature-of-load")
-		reg36078 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36078 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4019 := __args[0]
 			_ = V4019
-			reg36079 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36079 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4020 := __args[0]
 				_ = V4020
-				reg36080 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36080 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4021 := __args[0]
 					_ = V4021
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1load, V4019, V4020, V4021)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1load, V4019, V4020, V4021)
 					return
 				}, 1)
-				__ctx.Return(reg36080)
+				__e.Return(reg36080)
 				return
 			}, 1)
-			__ctx.Return(reg36079)
+			__e.Return(reg36079)
 			return
 		}, 1)
 		reg36082 := PrimCons(reg36077, reg36078)
-		reg36083 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36082)
+		reg36083 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36082)
 		_ = reg36083
 		reg36084 := MakeSymbol("shen.type-signature-of-map")
-		reg36085 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36085 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V4009 := __args[0]
 			_ = V4009
-			reg36086 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36086 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4010 := __args[0]
 				_ = V4010
-				reg36087 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36087 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4011 := __args[0]
 					_ = V4011
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1map, V4009, V4010, V4011)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1map, V4009, V4010, V4011)
 					return
 				}, 1)
-				__ctx.Return(reg36087)
+				__e.Return(reg36087)
 				return
 			}, 1)
-			__ctx.Return(reg36086)
+			__e.Return(reg36086)
 			return
 		}, 1)
 		reg36089 := PrimCons(reg36084, reg36085)
-		reg36090 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36089)
+		reg36090 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36089)
 		_ = reg36090
 		reg36091 := MakeSymbol("shen.type-signature-of-mapcan")
-		reg36092 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36092 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3999 := __args[0]
 			_ = V3999
-			reg36093 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36093 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V4000 := __args[0]
 				_ = V4000
-				reg36094 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36094 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V4001 := __args[0]
 					_ = V4001
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1mapcan, V3999, V4000, V4001)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1mapcan, V3999, V4000, V4001)
 					return
 				}, 1)
-				__ctx.Return(reg36094)
+				__e.Return(reg36094)
 				return
 			}, 1)
-			__ctx.Return(reg36093)
+			__e.Return(reg36093)
 			return
 		}, 1)
 		reg36096 := PrimCons(reg36091, reg36092)
-		reg36097 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36096)
+		reg36097 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36096)
 		_ = reg36097
 		reg36098 := MakeSymbol("shen.type-signature-of-maxinferences")
-		reg36099 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36099 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3989 := __args[0]
 			_ = V3989
-			reg36100 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36100 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3990 := __args[0]
 				_ = V3990
-				reg36101 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36101 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3991 := __args[0]
 					_ = V3991
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1maxinferences, V3989, V3990, V3991)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1maxinferences, V3989, V3990, V3991)
 					return
 				}, 1)
-				__ctx.Return(reg36101)
+				__e.Return(reg36101)
 				return
 			}, 1)
-			__ctx.Return(reg36100)
+			__e.Return(reg36100)
 			return
 		}, 1)
 		reg36103 := PrimCons(reg36098, reg36099)
-		reg36104 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36103)
+		reg36104 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36103)
 		_ = reg36104
 		reg36105 := MakeSymbol("shen.type-signature-of-n->string")
-		reg36106 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36106 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3979 := __args[0]
 			_ = V3979
-			reg36107 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36107 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3980 := __args[0]
 				_ = V3980
-				reg36108 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36108 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3981 := __args[0]
 					_ = V3981
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1n_1_6string, V3979, V3980, V3981)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1n_1_6string, V3979, V3980, V3981)
 					return
 				}, 1)
-				__ctx.Return(reg36108)
+				__e.Return(reg36108)
 				return
 			}, 1)
-			__ctx.Return(reg36107)
+			__e.Return(reg36107)
 			return
 		}, 1)
 		reg36110 := PrimCons(reg36105, reg36106)
-		reg36111 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36110)
+		reg36111 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36110)
 		_ = reg36111
 		reg36112 := MakeSymbol("shen.type-signature-of-nl")
-		reg36113 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36113 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3969 := __args[0]
 			_ = V3969
-			reg36114 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36114 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3970 := __args[0]
 				_ = V3970
-				reg36115 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36115 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3971 := __args[0]
 					_ = V3971
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1nl, V3969, V3970, V3971)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1nl, V3969, V3970, V3971)
 					return
 				}, 1)
-				__ctx.Return(reg36115)
+				__e.Return(reg36115)
 				return
 			}, 1)
-			__ctx.Return(reg36114)
+			__e.Return(reg36114)
 			return
 		}, 1)
 		reg36117 := PrimCons(reg36112, reg36113)
-		reg36118 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36117)
+		reg36118 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36117)
 		_ = reg36118
 		reg36119 := MakeSymbol("shen.type-signature-of-not")
-		reg36120 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36120 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3959 := __args[0]
 			_ = V3959
-			reg36121 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36121 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3960 := __args[0]
 				_ = V3960
-				reg36122 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36122 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3961 := __args[0]
 					_ = V3961
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1not, V3959, V3960, V3961)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1not, V3959, V3960, V3961)
 					return
 				}, 1)
-				__ctx.Return(reg36122)
+				__e.Return(reg36122)
 				return
 			}, 1)
-			__ctx.Return(reg36121)
+			__e.Return(reg36121)
 			return
 		}, 1)
 		reg36124 := PrimCons(reg36119, reg36120)
-		reg36125 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36124)
+		reg36125 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36124)
 		_ = reg36125
 		reg36126 := MakeSymbol("shen.type-signature-of-nth")
-		reg36127 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36127 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3949 := __args[0]
 			_ = V3949
-			reg36128 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36128 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3950 := __args[0]
 				_ = V3950
-				reg36129 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36129 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3951 := __args[0]
 					_ = V3951
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1nth, V3949, V3950, V3951)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1nth, V3949, V3950, V3951)
 					return
 				}, 1)
-				__ctx.Return(reg36129)
+				__e.Return(reg36129)
 				return
 			}, 1)
-			__ctx.Return(reg36128)
+			__e.Return(reg36128)
 			return
 		}, 1)
 		reg36131 := PrimCons(reg36126, reg36127)
-		reg36132 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36131)
+		reg36132 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36131)
 		_ = reg36132
 		reg36133 := MakeSymbol("shen.type-signature-of-number?")
-		reg36134 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36134 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3939 := __args[0]
 			_ = V3939
-			reg36135 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36135 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3940 := __args[0]
 				_ = V3940
-				reg36136 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36136 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3941 := __args[0]
 					_ = V3941
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1number_2, V3939, V3940, V3941)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1number_2, V3939, V3940, V3941)
 					return
 				}, 1)
-				__ctx.Return(reg36136)
+				__e.Return(reg36136)
 				return
 			}, 1)
-			__ctx.Return(reg36135)
+			__e.Return(reg36135)
 			return
 		}, 1)
 		reg36138 := PrimCons(reg36133, reg36134)
-		reg36139 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36138)
+		reg36139 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36138)
 		_ = reg36139
 		reg36140 := MakeSymbol("shen.type-signature-of-occurrences")
-		reg36141 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36141 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3929 := __args[0]
 			_ = V3929
-			reg36142 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36142 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3930 := __args[0]
 				_ = V3930
-				reg36143 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36143 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3931 := __args[0]
 					_ = V3931
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1occurrences, V3929, V3930, V3931)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1occurrences, V3929, V3930, V3931)
 					return
 				}, 1)
-				__ctx.Return(reg36143)
+				__e.Return(reg36143)
 				return
 			}, 1)
-			__ctx.Return(reg36142)
+			__e.Return(reg36142)
 			return
 		}, 1)
 		reg36145 := PrimCons(reg36140, reg36141)
-		reg36146 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36145)
+		reg36146 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36145)
 		_ = reg36146
 		reg36147 := MakeSymbol("shen.type-signature-of-occurs-check")
-		reg36148 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36148 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3919 := __args[0]
 			_ = V3919
-			reg36149 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36149 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3920 := __args[0]
 				_ = V3920
-				reg36150 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36150 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3921 := __args[0]
 					_ = V3921
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1occurs_1check, V3919, V3920, V3921)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1occurs_1check, V3919, V3920, V3921)
 					return
 				}, 1)
-				__ctx.Return(reg36150)
+				__e.Return(reg36150)
 				return
 			}, 1)
-			__ctx.Return(reg36149)
+			__e.Return(reg36149)
 			return
 		}, 1)
 		reg36152 := PrimCons(reg36147, reg36148)
-		reg36153 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36152)
+		reg36153 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36152)
 		_ = reg36153
 		reg36154 := MakeSymbol("shen.type-signature-of-optimise")
-		reg36155 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36155 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3909 := __args[0]
 			_ = V3909
-			reg36156 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36156 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3910 := __args[0]
 				_ = V3910
-				reg36157 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36157 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3911 := __args[0]
 					_ = V3911
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1optimise, V3909, V3910, V3911)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1optimise, V3909, V3910, V3911)
 					return
 				}, 1)
-				__ctx.Return(reg36157)
+				__e.Return(reg36157)
 				return
 			}, 1)
-			__ctx.Return(reg36156)
+			__e.Return(reg36156)
 			return
 		}, 1)
 		reg36159 := PrimCons(reg36154, reg36155)
-		reg36160 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36159)
+		reg36160 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36159)
 		_ = reg36160
 		reg36161 := MakeSymbol("shen.type-signature-of-or")
-		reg36162 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36162 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3899 := __args[0]
 			_ = V3899
-			reg36163 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36163 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3900 := __args[0]
 				_ = V3900
-				reg36164 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36164 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3901 := __args[0]
 					_ = V3901
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1or, V3899, V3900, V3901)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1or, V3899, V3900, V3901)
 					return
 				}, 1)
-				__ctx.Return(reg36164)
+				__e.Return(reg36164)
 				return
 			}, 1)
-			__ctx.Return(reg36163)
+			__e.Return(reg36163)
 			return
 		}, 1)
 		reg36166 := PrimCons(reg36161, reg36162)
-		reg36167 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36166)
+		reg36167 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36166)
 		_ = reg36167
 		reg36168 := MakeSymbol("shen.type-signature-of-os")
-		reg36169 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36169 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3889 := __args[0]
 			_ = V3889
-			reg36170 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36170 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3890 := __args[0]
 				_ = V3890
-				reg36171 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36171 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3891 := __args[0]
 					_ = V3891
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1os, V3889, V3890, V3891)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1os, V3889, V3890, V3891)
 					return
 				}, 1)
-				__ctx.Return(reg36171)
+				__e.Return(reg36171)
 				return
 			}, 1)
-			__ctx.Return(reg36170)
+			__e.Return(reg36170)
 			return
 		}, 1)
 		reg36173 := PrimCons(reg36168, reg36169)
-		reg36174 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36173)
+		reg36174 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36173)
 		_ = reg36174
 		reg36175 := MakeSymbol("shen.type-signature-of-package?")
-		reg36176 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36176 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3879 := __args[0]
 			_ = V3879
-			reg36177 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36177 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3880 := __args[0]
 				_ = V3880
-				reg36178 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36178 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3881 := __args[0]
 					_ = V3881
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1package_2, V3879, V3880, V3881)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1package_2, V3879, V3880, V3881)
 					return
 				}, 1)
-				__ctx.Return(reg36178)
+				__e.Return(reg36178)
 				return
 			}, 1)
-			__ctx.Return(reg36177)
+			__e.Return(reg36177)
 			return
 		}, 1)
 		reg36180 := PrimCons(reg36175, reg36176)
-		reg36181 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36180)
+		reg36181 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36180)
 		_ = reg36181
 		reg36182 := MakeSymbol("shen.type-signature-of-port")
-		reg36183 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36183 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3869 := __args[0]
 			_ = V3869
-			reg36184 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36184 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3870 := __args[0]
 				_ = V3870
-				reg36185 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36185 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3871 := __args[0]
 					_ = V3871
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1port, V3869, V3870, V3871)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1port, V3869, V3870, V3871)
 					return
 				}, 1)
-				__ctx.Return(reg36185)
+				__e.Return(reg36185)
 				return
 			}, 1)
-			__ctx.Return(reg36184)
+			__e.Return(reg36184)
 			return
 		}, 1)
 		reg36187 := PrimCons(reg36182, reg36183)
-		reg36188 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36187)
+		reg36188 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36187)
 		_ = reg36188
 		reg36189 := MakeSymbol("shen.type-signature-of-porters")
-		reg36190 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36190 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3859 := __args[0]
 			_ = V3859
-			reg36191 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36191 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3860 := __args[0]
 				_ = V3860
-				reg36192 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36192 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3861 := __args[0]
 					_ = V3861
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1porters, V3859, V3860, V3861)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1porters, V3859, V3860, V3861)
 					return
 				}, 1)
-				__ctx.Return(reg36192)
+				__e.Return(reg36192)
 				return
 			}, 1)
-			__ctx.Return(reg36191)
+			__e.Return(reg36191)
 			return
 		}, 1)
 		reg36194 := PrimCons(reg36189, reg36190)
-		reg36195 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36194)
+		reg36195 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36194)
 		_ = reg36195
 		reg36196 := MakeSymbol("shen.type-signature-of-pos")
-		reg36197 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36197 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3849 := __args[0]
 			_ = V3849
-			reg36198 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36198 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3850 := __args[0]
 				_ = V3850
-				reg36199 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36199 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3851 := __args[0]
 					_ = V3851
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1pos, V3849, V3850, V3851)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1pos, V3849, V3850, V3851)
 					return
 				}, 1)
-				__ctx.Return(reg36199)
+				__e.Return(reg36199)
 				return
 			}, 1)
-			__ctx.Return(reg36198)
+			__e.Return(reg36198)
 			return
 		}, 1)
 		reg36201 := PrimCons(reg36196, reg36197)
-		reg36202 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36201)
+		reg36202 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36201)
 		_ = reg36202
 		reg36203 := MakeSymbol("shen.type-signature-of-pr")
-		reg36204 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36204 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3839 := __args[0]
 			_ = V3839
-			reg36205 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36205 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3840 := __args[0]
 				_ = V3840
-				reg36206 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36206 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3841 := __args[0]
 					_ = V3841
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1pr, V3839, V3840, V3841)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1pr, V3839, V3840, V3841)
 					return
 				}, 1)
-				__ctx.Return(reg36206)
+				__e.Return(reg36206)
 				return
 			}, 1)
-			__ctx.Return(reg36205)
+			__e.Return(reg36205)
 			return
 		}, 1)
 		reg36208 := PrimCons(reg36203, reg36204)
-		reg36209 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36208)
+		reg36209 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36208)
 		_ = reg36209
 		reg36210 := MakeSymbol("shen.type-signature-of-print")
-		reg36211 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36211 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3829 := __args[0]
 			_ = V3829
-			reg36212 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36212 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3830 := __args[0]
 				_ = V3830
-				reg36213 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36213 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3831 := __args[0]
 					_ = V3831
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1print, V3829, V3830, V3831)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1print, V3829, V3830, V3831)
 					return
 				}, 1)
-				__ctx.Return(reg36213)
+				__e.Return(reg36213)
 				return
 			}, 1)
-			__ctx.Return(reg36212)
+			__e.Return(reg36212)
 			return
 		}, 1)
 		reg36215 := PrimCons(reg36210, reg36211)
-		reg36216 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36215)
+		reg36216 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36215)
 		_ = reg36216
 		reg36217 := MakeSymbol("shen.type-signature-of-profile")
-		reg36218 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36218 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3819 := __args[0]
 			_ = V3819
-			reg36219 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36219 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3820 := __args[0]
 				_ = V3820
-				reg36220 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36220 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3821 := __args[0]
 					_ = V3821
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1profile, V3819, V3820, V3821)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1profile, V3819, V3820, V3821)
 					return
 				}, 1)
-				__ctx.Return(reg36220)
+				__e.Return(reg36220)
 				return
 			}, 1)
-			__ctx.Return(reg36219)
+			__e.Return(reg36219)
 			return
 		}, 1)
 		reg36222 := PrimCons(reg36217, reg36218)
-		reg36223 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36222)
+		reg36223 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36222)
 		_ = reg36223
 		reg36224 := MakeSymbol("shen.type-signature-of-preclude")
-		reg36225 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36225 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3809 := __args[0]
 			_ = V3809
-			reg36226 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36226 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3810 := __args[0]
 				_ = V3810
-				reg36227 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36227 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3811 := __args[0]
 					_ = V3811
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1preclude, V3809, V3810, V3811)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1preclude, V3809, V3810, V3811)
 					return
 				}, 1)
-				__ctx.Return(reg36227)
+				__e.Return(reg36227)
 				return
 			}, 1)
-			__ctx.Return(reg36226)
+			__e.Return(reg36226)
 			return
 		}, 1)
 		reg36229 := PrimCons(reg36224, reg36225)
-		reg36230 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36229)
+		reg36230 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36229)
 		_ = reg36230
 		reg36231 := MakeSymbol("shen.type-signature-of-shen.proc-nl")
-		reg36232 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36232 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3799 := __args[0]
 			_ = V3799
-			reg36233 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36233 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3800 := __args[0]
 				_ = V3800
-				reg36234 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36234 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3801 := __args[0]
 					_ = V3801
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1shen_4proc_1nl, V3799, V3800, V3801)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1shen_4proc_1nl, V3799, V3800, V3801)
 					return
 				}, 1)
-				__ctx.Return(reg36234)
+				__e.Return(reg36234)
 				return
 			}, 1)
-			__ctx.Return(reg36233)
+			__e.Return(reg36233)
 			return
 		}, 1)
 		reg36236 := PrimCons(reg36231, reg36232)
-		reg36237 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36236)
+		reg36237 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36236)
 		_ = reg36237
 		reg36238 := MakeSymbol("shen.type-signature-of-profile-results")
-		reg36239 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36239 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3789 := __args[0]
 			_ = V3789
-			reg36240 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36240 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3790 := __args[0]
 				_ = V3790
-				reg36241 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36241 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3791 := __args[0]
 					_ = V3791
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1profile_1results, V3789, V3790, V3791)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1profile_1results, V3789, V3790, V3791)
 					return
 				}, 1)
-				__ctx.Return(reg36241)
+				__e.Return(reg36241)
 				return
 			}, 1)
-			__ctx.Return(reg36240)
+			__e.Return(reg36240)
 			return
 		}, 1)
 		reg36243 := PrimCons(reg36238, reg36239)
-		reg36244 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36243)
+		reg36244 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36243)
 		_ = reg36244
 		reg36245 := MakeSymbol("shen.type-signature-of-protect")
-		reg36246 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36246 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3779 := __args[0]
 			_ = V3779
-			reg36247 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36247 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3780 := __args[0]
 				_ = V3780
-				reg36248 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36248 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3781 := __args[0]
 					_ = V3781
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1protect, V3779, V3780, V3781)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1protect, V3779, V3780, V3781)
 					return
 				}, 1)
-				__ctx.Return(reg36248)
+				__e.Return(reg36248)
 				return
 			}, 1)
-			__ctx.Return(reg36247)
+			__e.Return(reg36247)
 			return
 		}, 1)
 		reg36250 := PrimCons(reg36245, reg36246)
-		reg36251 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36250)
+		reg36251 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36250)
 		_ = reg36251
 		reg36252 := MakeSymbol("shen.type-signature-of-preclude-all-but")
-		reg36253 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36253 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3769 := __args[0]
 			_ = V3769
-			reg36254 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36254 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3770 := __args[0]
 				_ = V3770
-				reg36255 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36255 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3771 := __args[0]
 					_ = V3771
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1preclude_1all_1but, V3769, V3770, V3771)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1preclude_1all_1but, V3769, V3770, V3771)
 					return
 				}, 1)
-				__ctx.Return(reg36255)
+				__e.Return(reg36255)
 				return
 			}, 1)
-			__ctx.Return(reg36254)
+			__e.Return(reg36254)
 			return
 		}, 1)
 		reg36257 := PrimCons(reg36252, reg36253)
-		reg36258 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36257)
+		reg36258 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36257)
 		_ = reg36258
 		reg36259 := MakeSymbol("shen.type-signature-of-shen.prhush")
-		reg36260 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36260 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3759 := __args[0]
 			_ = V3759
-			reg36261 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36261 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3760 := __args[0]
 				_ = V3760
-				reg36262 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36262 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3761 := __args[0]
 					_ = V3761
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1shen_4prhush, V3759, V3760, V3761)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1shen_4prhush, V3759, V3760, V3761)
 					return
 				}, 1)
-				__ctx.Return(reg36262)
+				__e.Return(reg36262)
 				return
 			}, 1)
-			__ctx.Return(reg36261)
+			__e.Return(reg36261)
 			return
 		}, 1)
 		reg36264 := PrimCons(reg36259, reg36260)
-		reg36265 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36264)
+		reg36265 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36264)
 		_ = reg36265
 		reg36266 := MakeSymbol("shen.type-signature-of-ps")
-		reg36267 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36267 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3749 := __args[0]
 			_ = V3749
-			reg36268 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36268 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3750 := __args[0]
 				_ = V3750
-				reg36269 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36269 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3751 := __args[0]
 					_ = V3751
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1ps, V3749, V3750, V3751)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1ps, V3749, V3750, V3751)
 					return
 				}, 1)
-				__ctx.Return(reg36269)
+				__e.Return(reg36269)
 				return
 			}, 1)
-			__ctx.Return(reg36268)
+			__e.Return(reg36268)
 			return
 		}, 1)
 		reg36271 := PrimCons(reg36266, reg36267)
-		reg36272 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36271)
+		reg36272 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36271)
 		_ = reg36272
 		reg36273 := MakeSymbol("shen.type-signature-of-read")
-		reg36274 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36274 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3739 := __args[0]
 			_ = V3739
-			reg36275 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36275 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3740 := __args[0]
 				_ = V3740
-				reg36276 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36276 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3741 := __args[0]
 					_ = V3741
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1read, V3739, V3740, V3741)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1read, V3739, V3740, V3741)
 					return
 				}, 1)
-				__ctx.Return(reg36276)
+				__e.Return(reg36276)
 				return
 			}, 1)
-			__ctx.Return(reg36275)
+			__e.Return(reg36275)
 			return
 		}, 1)
 		reg36278 := PrimCons(reg36273, reg36274)
-		reg36279 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36278)
+		reg36279 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36278)
 		_ = reg36279
 		reg36280 := MakeSymbol("shen.type-signature-of-read-byte")
-		reg36281 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36281 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3729 := __args[0]
 			_ = V3729
-			reg36282 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36282 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3730 := __args[0]
 				_ = V3730
-				reg36283 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36283 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3731 := __args[0]
 					_ = V3731
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1read_1byte, V3729, V3730, V3731)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1read_1byte, V3729, V3730, V3731)
 					return
 				}, 1)
-				__ctx.Return(reg36283)
+				__e.Return(reg36283)
 				return
 			}, 1)
-			__ctx.Return(reg36282)
+			__e.Return(reg36282)
 			return
 		}, 1)
 		reg36285 := PrimCons(reg36280, reg36281)
-		reg36286 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36285)
+		reg36286 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36285)
 		_ = reg36286
 		reg36287 := MakeSymbol("shen.type-signature-of-read-file-as-bytelist")
-		reg36288 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36288 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3719 := __args[0]
 			_ = V3719
-			reg36289 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36289 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3720 := __args[0]
 				_ = V3720
-				reg36290 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36290 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3721 := __args[0]
 					_ = V3721
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1read_1file_1as_1bytelist, V3719, V3720, V3721)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1read_1file_1as_1bytelist, V3719, V3720, V3721)
 					return
 				}, 1)
-				__ctx.Return(reg36290)
+				__e.Return(reg36290)
 				return
 			}, 1)
-			__ctx.Return(reg36289)
+			__e.Return(reg36289)
 			return
 		}, 1)
 		reg36292 := PrimCons(reg36287, reg36288)
-		reg36293 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36292)
+		reg36293 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36292)
 		_ = reg36293
 		reg36294 := MakeSymbol("shen.type-signature-of-read-file-as-string")
-		reg36295 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36295 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3709 := __args[0]
 			_ = V3709
-			reg36296 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36296 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3710 := __args[0]
 				_ = V3710
-				reg36297 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36297 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3711 := __args[0]
 					_ = V3711
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1read_1file_1as_1string, V3709, V3710, V3711)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1read_1file_1as_1string, V3709, V3710, V3711)
 					return
 				}, 1)
-				__ctx.Return(reg36297)
+				__e.Return(reg36297)
 				return
 			}, 1)
-			__ctx.Return(reg36296)
+			__e.Return(reg36296)
 			return
 		}, 1)
 		reg36299 := PrimCons(reg36294, reg36295)
-		reg36300 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36299)
+		reg36300 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36299)
 		_ = reg36300
 		reg36301 := MakeSymbol("shen.type-signature-of-read-file")
-		reg36302 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36302 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3699 := __args[0]
 			_ = V3699
-			reg36303 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36303 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3700 := __args[0]
 				_ = V3700
-				reg36304 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36304 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3701 := __args[0]
 					_ = V3701
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1read_1file, V3699, V3700, V3701)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1read_1file, V3699, V3700, V3701)
 					return
 				}, 1)
-				__ctx.Return(reg36304)
+				__e.Return(reg36304)
 				return
 			}, 1)
-			__ctx.Return(reg36303)
+			__e.Return(reg36303)
 			return
 		}, 1)
 		reg36306 := PrimCons(reg36301, reg36302)
-		reg36307 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36306)
+		reg36307 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36306)
 		_ = reg36307
 		reg36308 := MakeSymbol("shen.type-signature-of-read-from-string")
-		reg36309 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36309 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3689 := __args[0]
 			_ = V3689
-			reg36310 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36310 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3690 := __args[0]
 				_ = V3690
-				reg36311 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36311 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3691 := __args[0]
 					_ = V3691
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1read_1from_1string, V3689, V3690, V3691)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1read_1from_1string, V3689, V3690, V3691)
 					return
 				}, 1)
-				__ctx.Return(reg36311)
+				__e.Return(reg36311)
 				return
 			}, 1)
-			__ctx.Return(reg36310)
+			__e.Return(reg36310)
 			return
 		}, 1)
 		reg36313 := PrimCons(reg36308, reg36309)
-		reg36314 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36313)
+		reg36314 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36313)
 		_ = reg36314
 		reg36315 := MakeSymbol("shen.type-signature-of-release")
-		reg36316 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36316 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3679 := __args[0]
 			_ = V3679
-			reg36317 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36317 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3680 := __args[0]
 				_ = V3680
-				reg36318 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36318 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3681 := __args[0]
 					_ = V3681
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1release, V3679, V3680, V3681)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1release, V3679, V3680, V3681)
 					return
 				}, 1)
-				__ctx.Return(reg36318)
+				__e.Return(reg36318)
 				return
 			}, 1)
-			__ctx.Return(reg36317)
+			__e.Return(reg36317)
 			return
 		}, 1)
 		reg36320 := PrimCons(reg36315, reg36316)
-		reg36321 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36320)
+		reg36321 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36320)
 		_ = reg36321
 		reg36322 := MakeSymbol("shen.type-signature-of-remove")
-		reg36323 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36323 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3669 := __args[0]
 			_ = V3669
-			reg36324 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36324 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3670 := __args[0]
 				_ = V3670
-				reg36325 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36325 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3671 := __args[0]
 					_ = V3671
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1remove, V3669, V3670, V3671)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1remove, V3669, V3670, V3671)
 					return
 				}, 1)
-				__ctx.Return(reg36325)
+				__e.Return(reg36325)
 				return
 			}, 1)
-			__ctx.Return(reg36324)
+			__e.Return(reg36324)
 			return
 		}, 1)
 		reg36327 := PrimCons(reg36322, reg36323)
-		reg36328 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36327)
+		reg36328 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36327)
 		_ = reg36328
 		reg36329 := MakeSymbol("shen.type-signature-of-reverse")
-		reg36330 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36330 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3659 := __args[0]
 			_ = V3659
-			reg36331 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36331 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3660 := __args[0]
 				_ = V3660
-				reg36332 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36332 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3661 := __args[0]
 					_ = V3661
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1reverse, V3659, V3660, V3661)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1reverse, V3659, V3660, V3661)
 					return
 				}, 1)
-				__ctx.Return(reg36332)
+				__e.Return(reg36332)
 				return
 			}, 1)
-			__ctx.Return(reg36331)
+			__e.Return(reg36331)
 			return
 		}, 1)
 		reg36334 := PrimCons(reg36329, reg36330)
-		reg36335 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36334)
+		reg36335 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36334)
 		_ = reg36335
 		reg36336 := MakeSymbol("shen.type-signature-of-simple-error")
-		reg36337 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36337 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3649 := __args[0]
 			_ = V3649
-			reg36338 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36338 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3650 := __args[0]
 				_ = V3650
-				reg36339 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36339 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3651 := __args[0]
 					_ = V3651
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1simple_1error, V3649, V3650, V3651)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1simple_1error, V3649, V3650, V3651)
 					return
 				}, 1)
-				__ctx.Return(reg36339)
+				__e.Return(reg36339)
 				return
 			}, 1)
-			__ctx.Return(reg36338)
+			__e.Return(reg36338)
 			return
 		}, 1)
 		reg36341 := PrimCons(reg36336, reg36337)
-		reg36342 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36341)
+		reg36342 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36341)
 		_ = reg36342
 		reg36343 := MakeSymbol("shen.type-signature-of-snd")
-		reg36344 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36344 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3639 := __args[0]
 			_ = V3639
-			reg36345 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36345 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3640 := __args[0]
 				_ = V3640
-				reg36346 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36346 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3641 := __args[0]
 					_ = V3641
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1snd, V3639, V3640, V3641)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1snd, V3639, V3640, V3641)
 					return
 				}, 1)
-				__ctx.Return(reg36346)
+				__e.Return(reg36346)
 				return
 			}, 1)
-			__ctx.Return(reg36345)
+			__e.Return(reg36345)
 			return
 		}, 1)
 		reg36348 := PrimCons(reg36343, reg36344)
-		reg36349 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36348)
+		reg36349 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36348)
 		_ = reg36349
 		reg36350 := MakeSymbol("shen.type-signature-of-specialise")
-		reg36351 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36351 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3629 := __args[0]
 			_ = V3629
-			reg36352 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36352 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3630 := __args[0]
 				_ = V3630
-				reg36353 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36353 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3631 := __args[0]
 					_ = V3631
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1specialise, V3629, V3630, V3631)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1specialise, V3629, V3630, V3631)
 					return
 				}, 1)
-				__ctx.Return(reg36353)
+				__e.Return(reg36353)
 				return
 			}, 1)
-			__ctx.Return(reg36352)
+			__e.Return(reg36352)
 			return
 		}, 1)
 		reg36355 := PrimCons(reg36350, reg36351)
-		reg36356 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36355)
+		reg36356 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36355)
 		_ = reg36356
 		reg36357 := MakeSymbol("shen.type-signature-of-spy")
-		reg36358 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36358 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3619 := __args[0]
 			_ = V3619
-			reg36359 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36359 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3620 := __args[0]
 				_ = V3620
-				reg36360 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36360 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3621 := __args[0]
 					_ = V3621
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1spy, V3619, V3620, V3621)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1spy, V3619, V3620, V3621)
 					return
 				}, 1)
-				__ctx.Return(reg36360)
+				__e.Return(reg36360)
 				return
 			}, 1)
-			__ctx.Return(reg36359)
+			__e.Return(reg36359)
 			return
 		}, 1)
 		reg36362 := PrimCons(reg36357, reg36358)
-		reg36363 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36362)
+		reg36363 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36362)
 		_ = reg36363
 		reg36364 := MakeSymbol("shen.type-signature-of-step")
-		reg36365 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36365 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3609 := __args[0]
 			_ = V3609
-			reg36366 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36366 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3610 := __args[0]
 				_ = V3610
-				reg36367 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36367 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3611 := __args[0]
 					_ = V3611
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1step, V3609, V3610, V3611)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1step, V3609, V3610, V3611)
 					return
 				}, 1)
-				__ctx.Return(reg36367)
+				__e.Return(reg36367)
 				return
 			}, 1)
-			__ctx.Return(reg36366)
+			__e.Return(reg36366)
 			return
 		}, 1)
 		reg36369 := PrimCons(reg36364, reg36365)
-		reg36370 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36369)
+		reg36370 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36369)
 		_ = reg36370
 		reg36371 := MakeSymbol("shen.type-signature-of-stinput")
-		reg36372 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36372 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3599 := __args[0]
 			_ = V3599
-			reg36373 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36373 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3600 := __args[0]
 				_ = V3600
-				reg36374 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36374 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3601 := __args[0]
 					_ = V3601
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1stinput, V3599, V3600, V3601)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1stinput, V3599, V3600, V3601)
 					return
 				}, 1)
-				__ctx.Return(reg36374)
+				__e.Return(reg36374)
 				return
 			}, 1)
-			__ctx.Return(reg36373)
+			__e.Return(reg36373)
 			return
 		}, 1)
 		reg36376 := PrimCons(reg36371, reg36372)
-		reg36377 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36376)
+		reg36377 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36376)
 		_ = reg36377
 		reg36378 := MakeSymbol("shen.type-signature-of-sterror")
-		reg36379 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36379 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3589 := __args[0]
 			_ = V3589
-			reg36380 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36380 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3590 := __args[0]
 				_ = V3590
-				reg36381 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36381 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3591 := __args[0]
 					_ = V3591
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1sterror, V3589, V3590, V3591)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1sterror, V3589, V3590, V3591)
 					return
 				}, 1)
-				__ctx.Return(reg36381)
+				__e.Return(reg36381)
 				return
 			}, 1)
-			__ctx.Return(reg36380)
+			__e.Return(reg36380)
 			return
 		}, 1)
 		reg36383 := PrimCons(reg36378, reg36379)
-		reg36384 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36383)
+		reg36384 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36383)
 		_ = reg36384
 		reg36385 := MakeSymbol("shen.type-signature-of-stoutput")
-		reg36386 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36386 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3579 := __args[0]
 			_ = V3579
-			reg36387 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36387 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3580 := __args[0]
 				_ = V3580
-				reg36388 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36388 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3581 := __args[0]
 					_ = V3581
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1stoutput, V3579, V3580, V3581)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1stoutput, V3579, V3580, V3581)
 					return
 				}, 1)
-				__ctx.Return(reg36388)
+				__e.Return(reg36388)
 				return
 			}, 1)
-			__ctx.Return(reg36387)
+			__e.Return(reg36387)
 			return
 		}, 1)
 		reg36390 := PrimCons(reg36385, reg36386)
-		reg36391 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36390)
+		reg36391 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36390)
 		_ = reg36391
 		reg36392 := MakeSymbol("shen.type-signature-of-string?")
-		reg36393 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36393 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3569 := __args[0]
 			_ = V3569
-			reg36394 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36394 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3570 := __args[0]
 				_ = V3570
-				reg36395 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36395 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3571 := __args[0]
 					_ = V3571
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1string_2, V3569, V3570, V3571)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1string_2, V3569, V3570, V3571)
 					return
 				}, 1)
-				__ctx.Return(reg36395)
+				__e.Return(reg36395)
 				return
 			}, 1)
-			__ctx.Return(reg36394)
+			__e.Return(reg36394)
 			return
 		}, 1)
 		reg36397 := PrimCons(reg36392, reg36393)
-		reg36398 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36397)
+		reg36398 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36397)
 		_ = reg36398
 		reg36399 := MakeSymbol("shen.type-signature-of-str")
-		reg36400 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36400 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3559 := __args[0]
 			_ = V3559
-			reg36401 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36401 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3560 := __args[0]
 				_ = V3560
-				reg36402 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36402 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3561 := __args[0]
 					_ = V3561
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1str, V3559, V3560, V3561)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1str, V3559, V3560, V3561)
 					return
 				}, 1)
-				__ctx.Return(reg36402)
+				__e.Return(reg36402)
 				return
 			}, 1)
-			__ctx.Return(reg36401)
+			__e.Return(reg36401)
 			return
 		}, 1)
 		reg36404 := PrimCons(reg36399, reg36400)
-		reg36405 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36404)
+		reg36405 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36404)
 		_ = reg36405
 		reg36406 := MakeSymbol("shen.type-signature-of-string->n")
-		reg36407 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36407 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3549 := __args[0]
 			_ = V3549
-			reg36408 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36408 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3550 := __args[0]
 				_ = V3550
-				reg36409 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36409 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3551 := __args[0]
 					_ = V3551
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1string_1_6n, V3549, V3550, V3551)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1string_1_6n, V3549, V3550, V3551)
 					return
 				}, 1)
-				__ctx.Return(reg36409)
+				__e.Return(reg36409)
 				return
 			}, 1)
-			__ctx.Return(reg36408)
+			__e.Return(reg36408)
 			return
 		}, 1)
 		reg36411 := PrimCons(reg36406, reg36407)
-		reg36412 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36411)
+		reg36412 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36411)
 		_ = reg36412
 		reg36413 := MakeSymbol("shen.type-signature-of-string->symbol")
-		reg36414 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36414 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3539 := __args[0]
 			_ = V3539
-			reg36415 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36415 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3540 := __args[0]
 				_ = V3540
-				reg36416 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36416 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3541 := __args[0]
 					_ = V3541
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1string_1_6symbol, V3539, V3540, V3541)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1string_1_6symbol, V3539, V3540, V3541)
 					return
 				}, 1)
-				__ctx.Return(reg36416)
+				__e.Return(reg36416)
 				return
 			}, 1)
-			__ctx.Return(reg36415)
+			__e.Return(reg36415)
 			return
 		}, 1)
 		reg36418 := PrimCons(reg36413, reg36414)
-		reg36419 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36418)
+		reg36419 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36418)
 		_ = reg36419
 		reg36420 := MakeSymbol("shen.type-signature-of-sum")
-		reg36421 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36421 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3529 := __args[0]
 			_ = V3529
-			reg36422 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36422 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3530 := __args[0]
 				_ = V3530
-				reg36423 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36423 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3531 := __args[0]
 					_ = V3531
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1sum, V3529, V3530, V3531)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1sum, V3529, V3530, V3531)
 					return
 				}, 1)
-				__ctx.Return(reg36423)
+				__e.Return(reg36423)
 				return
 			}, 1)
-			__ctx.Return(reg36422)
+			__e.Return(reg36422)
 			return
 		}, 1)
 		reg36425 := PrimCons(reg36420, reg36421)
-		reg36426 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36425)
+		reg36426 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36425)
 		_ = reg36426
 		reg36427 := MakeSymbol("shen.type-signature-of-symbol?")
-		reg36428 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36428 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3519 := __args[0]
 			_ = V3519
-			reg36429 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36429 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3520 := __args[0]
 				_ = V3520
-				reg36430 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36430 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3521 := __args[0]
 					_ = V3521
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1symbol_2, V3519, V3520, V3521)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1symbol_2, V3519, V3520, V3521)
 					return
 				}, 1)
-				__ctx.Return(reg36430)
+				__e.Return(reg36430)
 				return
 			}, 1)
-			__ctx.Return(reg36429)
+			__e.Return(reg36429)
 			return
 		}, 1)
 		reg36432 := PrimCons(reg36427, reg36428)
-		reg36433 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36432)
+		reg36433 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36432)
 		_ = reg36433
 		reg36434 := MakeSymbol("shen.type-signature-of-systemf")
-		reg36435 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36435 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3509 := __args[0]
 			_ = V3509
-			reg36436 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36436 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3510 := __args[0]
 				_ = V3510
-				reg36437 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36437 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3511 := __args[0]
 					_ = V3511
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1systemf, V3509, V3510, V3511)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1systemf, V3509, V3510, V3511)
 					return
 				}, 1)
-				__ctx.Return(reg36437)
+				__e.Return(reg36437)
 				return
 			}, 1)
-			__ctx.Return(reg36436)
+			__e.Return(reg36436)
 			return
 		}, 1)
 		reg36439 := PrimCons(reg36434, reg36435)
-		reg36440 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36439)
+		reg36440 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36439)
 		_ = reg36440
 		reg36441 := MakeSymbol("shen.type-signature-of-tail")
-		reg36442 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36442 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3499 := __args[0]
 			_ = V3499
-			reg36443 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36443 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3500 := __args[0]
 				_ = V3500
-				reg36444 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36444 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3501 := __args[0]
 					_ = V3501
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1tail, V3499, V3500, V3501)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1tail, V3499, V3500, V3501)
 					return
 				}, 1)
-				__ctx.Return(reg36444)
+				__e.Return(reg36444)
 				return
 			}, 1)
-			__ctx.Return(reg36443)
+			__e.Return(reg36443)
 			return
 		}, 1)
 		reg36446 := PrimCons(reg36441, reg36442)
-		reg36447 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36446)
+		reg36447 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36446)
 		_ = reg36447
 		reg36448 := MakeSymbol("shen.type-signature-of-tlstr")
-		reg36449 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36449 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3489 := __args[0]
 			_ = V3489
-			reg36450 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36450 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3490 := __args[0]
 				_ = V3490
-				reg36451 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36451 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3491 := __args[0]
 					_ = V3491
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1tlstr, V3489, V3490, V3491)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1tlstr, V3489, V3490, V3491)
 					return
 				}, 1)
-				__ctx.Return(reg36451)
+				__e.Return(reg36451)
 				return
 			}, 1)
-			__ctx.Return(reg36450)
+			__e.Return(reg36450)
 			return
 		}, 1)
 		reg36453 := PrimCons(reg36448, reg36449)
-		reg36454 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36453)
+		reg36454 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36453)
 		_ = reg36454
 		reg36455 := MakeSymbol("shen.type-signature-of-tlv")
-		reg36456 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36456 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3479 := __args[0]
 			_ = V3479
-			reg36457 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36457 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3480 := __args[0]
 				_ = V3480
-				reg36458 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36458 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3481 := __args[0]
 					_ = V3481
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1tlv, V3479, V3480, V3481)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1tlv, V3479, V3480, V3481)
 					return
 				}, 1)
-				__ctx.Return(reg36458)
+				__e.Return(reg36458)
 				return
 			}, 1)
-			__ctx.Return(reg36457)
+			__e.Return(reg36457)
 			return
 		}, 1)
 		reg36460 := PrimCons(reg36455, reg36456)
-		reg36461 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36460)
+		reg36461 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36460)
 		_ = reg36461
 		reg36462 := MakeSymbol("shen.type-signature-of-tc")
-		reg36463 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36463 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3469 := __args[0]
 			_ = V3469
-			reg36464 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36464 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3470 := __args[0]
 				_ = V3470
-				reg36465 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36465 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3471 := __args[0]
 					_ = V3471
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1tc, V3469, V3470, V3471)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1tc, V3469, V3470, V3471)
 					return
 				}, 1)
-				__ctx.Return(reg36465)
+				__e.Return(reg36465)
 				return
 			}, 1)
-			__ctx.Return(reg36464)
+			__e.Return(reg36464)
 			return
 		}, 1)
 		reg36467 := PrimCons(reg36462, reg36463)
-		reg36468 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36467)
+		reg36468 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36467)
 		_ = reg36468
 		reg36469 := MakeSymbol("shen.type-signature-of-tc?")
-		reg36470 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36470 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3459 := __args[0]
 			_ = V3459
-			reg36471 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36471 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3460 := __args[0]
 				_ = V3460
-				reg36472 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36472 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3461 := __args[0]
 					_ = V3461
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1tc_2, V3459, V3460, V3461)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1tc_2, V3459, V3460, V3461)
 					return
 				}, 1)
-				__ctx.Return(reg36472)
+				__e.Return(reg36472)
 				return
 			}, 1)
-			__ctx.Return(reg36471)
+			__e.Return(reg36471)
 			return
 		}, 1)
 		reg36474 := PrimCons(reg36469, reg36470)
-		reg36475 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36474)
+		reg36475 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36474)
 		_ = reg36475
 		reg36476 := MakeSymbol("shen.type-signature-of-thaw")
-		reg36477 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36477 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3449 := __args[0]
 			_ = V3449
-			reg36478 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36478 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3450 := __args[0]
 				_ = V3450
-				reg36479 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36479 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3451 := __args[0]
 					_ = V3451
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1thaw, V3449, V3450, V3451)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1thaw, V3449, V3450, V3451)
 					return
 				}, 1)
-				__ctx.Return(reg36479)
+				__e.Return(reg36479)
 				return
 			}, 1)
-			__ctx.Return(reg36478)
+			__e.Return(reg36478)
 			return
 		}, 1)
 		reg36481 := PrimCons(reg36476, reg36477)
-		reg36482 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36481)
+		reg36482 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36481)
 		_ = reg36482
 		reg36483 := MakeSymbol("shen.type-signature-of-track")
-		reg36484 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36484 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3439 := __args[0]
 			_ = V3439
-			reg36485 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36485 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3440 := __args[0]
 				_ = V3440
-				reg36486 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36486 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3441 := __args[0]
 					_ = V3441
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1track, V3439, V3440, V3441)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1track, V3439, V3440, V3441)
 					return
 				}, 1)
-				__ctx.Return(reg36486)
+				__e.Return(reg36486)
 				return
 			}, 1)
-			__ctx.Return(reg36485)
+			__e.Return(reg36485)
 			return
 		}, 1)
 		reg36488 := PrimCons(reg36483, reg36484)
-		reg36489 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36488)
+		reg36489 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36488)
 		_ = reg36489
 		reg36490 := MakeSymbol("shen.type-signature-of-trap-error")
-		reg36491 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36491 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3429 := __args[0]
 			_ = V3429
-			reg36492 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36492 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3430 := __args[0]
 				_ = V3430
-				reg36493 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36493 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3431 := __args[0]
 					_ = V3431
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1trap_1error, V3429, V3430, V3431)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1trap_1error, V3429, V3430, V3431)
 					return
 				}, 1)
-				__ctx.Return(reg36493)
+				__e.Return(reg36493)
 				return
 			}, 1)
-			__ctx.Return(reg36492)
+			__e.Return(reg36492)
 			return
 		}, 1)
 		reg36495 := PrimCons(reg36490, reg36491)
-		reg36496 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36495)
+		reg36496 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36495)
 		_ = reg36496
 		reg36497 := MakeSymbol("shen.type-signature-of-tuple?")
-		reg36498 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36498 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3419 := __args[0]
 			_ = V3419
-			reg36499 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36499 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3420 := __args[0]
 				_ = V3420
-				reg36500 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36500 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3421 := __args[0]
 					_ = V3421
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1tuple_2, V3419, V3420, V3421)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1tuple_2, V3419, V3420, V3421)
 					return
 				}, 1)
-				__ctx.Return(reg36500)
+				__e.Return(reg36500)
 				return
 			}, 1)
-			__ctx.Return(reg36499)
+			__e.Return(reg36499)
 			return
 		}, 1)
 		reg36502 := PrimCons(reg36497, reg36498)
-		reg36503 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36502)
+		reg36503 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36502)
 		_ = reg36503
 		reg36504 := MakeSymbol("shen.type-signature-of-undefmacro")
-		reg36505 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36505 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3409 := __args[0]
 			_ = V3409
-			reg36506 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36506 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3410 := __args[0]
 				_ = V3410
-				reg36507 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36507 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3411 := __args[0]
 					_ = V3411
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1undefmacro, V3409, V3410, V3411)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1undefmacro, V3409, V3410, V3411)
 					return
 				}, 1)
-				__ctx.Return(reg36507)
+				__e.Return(reg36507)
 				return
 			}, 1)
-			__ctx.Return(reg36506)
+			__e.Return(reg36506)
 			return
 		}, 1)
 		reg36509 := PrimCons(reg36504, reg36505)
-		reg36510 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36509)
+		reg36510 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36509)
 		_ = reg36510
 		reg36511 := MakeSymbol("shen.type-signature-of-union")
-		reg36512 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36512 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3399 := __args[0]
 			_ = V3399
-			reg36513 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36513 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3400 := __args[0]
 				_ = V3400
-				reg36514 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36514 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3401 := __args[0]
 					_ = V3401
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1union, V3399, V3400, V3401)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1union, V3399, V3400, V3401)
 					return
 				}, 1)
-				__ctx.Return(reg36514)
+				__e.Return(reg36514)
 				return
 			}, 1)
-			__ctx.Return(reg36513)
+			__e.Return(reg36513)
 			return
 		}, 1)
 		reg36516 := PrimCons(reg36511, reg36512)
-		reg36517 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36516)
+		reg36517 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36516)
 		_ = reg36517
 		reg36518 := MakeSymbol("shen.type-signature-of-unprofile")
-		reg36519 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36519 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3389 := __args[0]
 			_ = V3389
-			reg36520 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36520 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3390 := __args[0]
 				_ = V3390
-				reg36521 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36521 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3391 := __args[0]
 					_ = V3391
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1unprofile, V3389, V3390, V3391)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1unprofile, V3389, V3390, V3391)
 					return
 				}, 1)
-				__ctx.Return(reg36521)
+				__e.Return(reg36521)
 				return
 			}, 1)
-			__ctx.Return(reg36520)
+			__e.Return(reg36520)
 			return
 		}, 1)
 		reg36523 := PrimCons(reg36518, reg36519)
-		reg36524 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36523)
+		reg36524 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36523)
 		_ = reg36524
 		reg36525 := MakeSymbol("shen.type-signature-of-untrack")
-		reg36526 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36526 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3379 := __args[0]
 			_ = V3379
-			reg36527 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36527 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3380 := __args[0]
 				_ = V3380
-				reg36528 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36528 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3381 := __args[0]
 					_ = V3381
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1untrack, V3379, V3380, V3381)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1untrack, V3379, V3380, V3381)
 					return
 				}, 1)
-				__ctx.Return(reg36528)
+				__e.Return(reg36528)
 				return
 			}, 1)
-			__ctx.Return(reg36527)
+			__e.Return(reg36527)
 			return
 		}, 1)
 		reg36530 := PrimCons(reg36525, reg36526)
-		reg36531 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36530)
+		reg36531 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36530)
 		_ = reg36531
 		reg36532 := MakeSymbol("shen.type-signature-of-unspecialise")
-		reg36533 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36533 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3369 := __args[0]
 			_ = V3369
-			reg36534 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36534 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3370 := __args[0]
 				_ = V3370
-				reg36535 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36535 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3371 := __args[0]
 					_ = V3371
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1unspecialise, V3369, V3370, V3371)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1unspecialise, V3369, V3370, V3371)
 					return
 				}, 1)
-				__ctx.Return(reg36535)
+				__e.Return(reg36535)
 				return
 			}, 1)
-			__ctx.Return(reg36534)
+			__e.Return(reg36534)
 			return
 		}, 1)
 		reg36537 := PrimCons(reg36532, reg36533)
-		reg36538 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36537)
+		reg36538 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36537)
 		_ = reg36538
 		reg36539 := MakeSymbol("shen.type-signature-of-variable?")
-		reg36540 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36540 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3359 := __args[0]
 			_ = V3359
-			reg36541 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36541 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3360 := __args[0]
 				_ = V3360
-				reg36542 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36542 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3361 := __args[0]
 					_ = V3361
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1variable_2, V3359, V3360, V3361)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1variable_2, V3359, V3360, V3361)
 					return
 				}, 1)
-				__ctx.Return(reg36542)
+				__e.Return(reg36542)
 				return
 			}, 1)
-			__ctx.Return(reg36541)
+			__e.Return(reg36541)
 			return
 		}, 1)
 		reg36544 := PrimCons(reg36539, reg36540)
-		reg36545 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36544)
+		reg36545 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36544)
 		_ = reg36545
 		reg36546 := MakeSymbol("shen.type-signature-of-vector?")
-		reg36547 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36547 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3349 := __args[0]
 			_ = V3349
-			reg36548 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36548 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3350 := __args[0]
 				_ = V3350
-				reg36549 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36549 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3351 := __args[0]
 					_ = V3351
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1vector_2, V3349, V3350, V3351)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1vector_2, V3349, V3350, V3351)
 					return
 				}, 1)
-				__ctx.Return(reg36549)
+				__e.Return(reg36549)
 				return
 			}, 1)
-			__ctx.Return(reg36548)
+			__e.Return(reg36548)
 			return
 		}, 1)
 		reg36551 := PrimCons(reg36546, reg36547)
-		reg36552 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36551)
+		reg36552 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36551)
 		_ = reg36552
 		reg36553 := MakeSymbol("shen.type-signature-of-version")
-		reg36554 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36554 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3339 := __args[0]
 			_ = V3339
-			reg36555 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36555 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3340 := __args[0]
 				_ = V3340
-				reg36556 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36556 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3341 := __args[0]
 					_ = V3341
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1version, V3339, V3340, V3341)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1version, V3339, V3340, V3341)
 					return
 				}, 1)
-				__ctx.Return(reg36556)
+				__e.Return(reg36556)
 				return
 			}, 1)
-			__ctx.Return(reg36555)
+			__e.Return(reg36555)
 			return
 		}, 1)
 		reg36558 := PrimCons(reg36553, reg36554)
-		reg36559 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36558)
+		reg36559 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36558)
 		_ = reg36559
 		reg36560 := MakeSymbol("shen.type-signature-of-write-to-file")
-		reg36561 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36561 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3329 := __args[0]
 			_ = V3329
-			reg36562 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36562 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3330 := __args[0]
 				_ = V3330
-				reg36563 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36563 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3331 := __args[0]
 					_ = V3331
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1write_1to_1file, V3329, V3330, V3331)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1write_1to_1file, V3329, V3330, V3331)
 					return
 				}, 1)
-				__ctx.Return(reg36563)
+				__e.Return(reg36563)
 				return
 			}, 1)
-			__ctx.Return(reg36562)
+			__e.Return(reg36562)
 			return
 		}, 1)
 		reg36565 := PrimCons(reg36560, reg36561)
-		reg36566 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36565)
+		reg36566 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36565)
 		_ = reg36566
 		reg36567 := MakeSymbol("shen.type-signature-of-write-byte")
-		reg36568 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36568 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3319 := __args[0]
 			_ = V3319
-			reg36569 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36569 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3320 := __args[0]
 				_ = V3320
-				reg36570 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36570 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3321 := __args[0]
 					_ = V3321
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1write_1byte, V3319, V3320, V3321)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1write_1byte, V3319, V3320, V3321)
 					return
 				}, 1)
-				__ctx.Return(reg36570)
+				__e.Return(reg36570)
 				return
 			}, 1)
-			__ctx.Return(reg36569)
+			__e.Return(reg36569)
 			return
 		}, 1)
 		reg36572 := PrimCons(reg36567, reg36568)
-		reg36573 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36572)
+		reg36573 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36572)
 		_ = reg36573
 		reg36574 := MakeSymbol("shen.type-signature-of-y-or-n?")
-		reg36575 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36575 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3309 := __args[0]
 			_ = V3309
-			reg36576 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36576 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3310 := __args[0]
 				_ = V3310
-				reg36577 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36577 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3311 := __args[0]
 					_ = V3311
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1y_1or_1n_2, V3309, V3310, V3311)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1y_1or_1n_2, V3309, V3310, V3311)
 					return
 				}, 1)
-				__ctx.Return(reg36577)
+				__e.Return(reg36577)
 				return
 			}, 1)
-			__ctx.Return(reg36576)
+			__e.Return(reg36576)
 			return
 		}, 1)
 		reg36579 := PrimCons(reg36574, reg36575)
-		reg36580 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36579)
+		reg36580 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36579)
 		_ = reg36580
 		reg36581 := MakeSymbol("shen.type-signature-of->")
-		reg36582 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36582 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3299 := __args[0]
 			_ = V3299
-			reg36583 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36583 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3300 := __args[0]
 				_ = V3300
-				reg36584 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36584 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3301 := __args[0]
 					_ = V3301
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_6, V3299, V3300, V3301)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_6, V3299, V3300, V3301)
 					return
 				}, 1)
-				__ctx.Return(reg36584)
+				__e.Return(reg36584)
 				return
 			}, 1)
-			__ctx.Return(reg36583)
+			__e.Return(reg36583)
 			return
 		}, 1)
 		reg36586 := PrimCons(reg36581, reg36582)
-		reg36587 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36586)
+		reg36587 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36586)
 		_ = reg36587
 		reg36588 := MakeSymbol("shen.type-signature-of-<")
-		reg36589 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36589 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3289 := __args[0]
 			_ = V3289
-			reg36590 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36590 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3290 := __args[0]
 				_ = V3290
-				reg36591 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36591 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3291 := __args[0]
 					_ = V3291
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_5, V3289, V3290, V3291)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_5, V3289, V3290, V3291)
 					return
 				}, 1)
-				__ctx.Return(reg36591)
+				__e.Return(reg36591)
 				return
 			}, 1)
-			__ctx.Return(reg36590)
+			__e.Return(reg36590)
 			return
 		}, 1)
 		reg36593 := PrimCons(reg36588, reg36589)
-		reg36594 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36593)
+		reg36594 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36593)
 		_ = reg36594
 		reg36595 := MakeSymbol("shen.type-signature-of->=")
-		reg36596 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36596 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3279 := __args[0]
 			_ = V3279
-			reg36597 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36597 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3280 := __args[0]
 				_ = V3280
-				reg36598 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36598 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3281 := __args[0]
 					_ = V3281
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_6_a, V3279, V3280, V3281)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_6_a, V3279, V3280, V3281)
 					return
 				}, 1)
-				__ctx.Return(reg36598)
+				__e.Return(reg36598)
 				return
 			}, 1)
-			__ctx.Return(reg36597)
+			__e.Return(reg36597)
 			return
 		}, 1)
 		reg36600 := PrimCons(reg36595, reg36596)
-		reg36601 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36600)
+		reg36601 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36600)
 		_ = reg36601
 		reg36602 := MakeSymbol("shen.type-signature-of-<=")
-		reg36603 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36603 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3269 := __args[0]
 			_ = V3269
-			reg36604 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36604 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3270 := __args[0]
 				_ = V3270
-				reg36605 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36605 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3271 := __args[0]
 					_ = V3271
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_5_a, V3269, V3270, V3271)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_5_a, V3269, V3270, V3271)
 					return
 				}, 1)
-				__ctx.Return(reg36605)
+				__e.Return(reg36605)
 				return
 			}, 1)
-			__ctx.Return(reg36604)
+			__e.Return(reg36604)
 			return
 		}, 1)
 		reg36607 := PrimCons(reg36602, reg36603)
-		reg36608 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36607)
+		reg36608 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36607)
 		_ = reg36608
 		reg36609 := MakeSymbol("shen.type-signature-of-=")
-		reg36610 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36610 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3259 := __args[0]
 			_ = V3259
-			reg36611 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36611 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3260 := __args[0]
 				_ = V3260
-				reg36612 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36612 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3261 := __args[0]
 					_ = V3261
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_a, V3259, V3260, V3261)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_a, V3259, V3260, V3261)
 					return
 				}, 1)
-				__ctx.Return(reg36612)
+				__e.Return(reg36612)
 				return
 			}, 1)
-			__ctx.Return(reg36611)
+			__e.Return(reg36611)
 			return
 		}, 1)
 		reg36614 := PrimCons(reg36609, reg36610)
-		reg36615 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36614)
+		reg36615 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36614)
 		_ = reg36615
 		reg36616 := MakeSymbol("shen.type-signature-of-+")
-		reg36617 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36617 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3249 := __args[0]
 			_ = V3249
-			reg36618 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36618 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3250 := __args[0]
 				_ = V3250
-				reg36619 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36619 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3251 := __args[0]
 					_ = V3251
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_7, V3249, V3250, V3251)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_7, V3249, V3250, V3251)
 					return
 				}, 1)
-				__ctx.Return(reg36619)
+				__e.Return(reg36619)
 				return
 			}, 1)
-			__ctx.Return(reg36618)
+			__e.Return(reg36618)
 			return
 		}, 1)
 		reg36621 := PrimCons(reg36616, reg36617)
-		reg36622 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36621)
+		reg36622 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36621)
 		_ = reg36622
 		reg36623 := MakeSymbol("shen.type-signature-of-/")
-		reg36624 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36624 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3239 := __args[0]
 			_ = V3239
-			reg36625 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36625 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3240 := __args[0]
 				_ = V3240
-				reg36626 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36626 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3241 := __args[0]
 					_ = V3241
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_c, V3239, V3240, V3241)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_c, V3239, V3240, V3241)
 					return
 				}, 1)
-				__ctx.Return(reg36626)
+				__e.Return(reg36626)
 				return
 			}, 1)
-			__ctx.Return(reg36625)
+			__e.Return(reg36625)
 			return
 		}, 1)
 		reg36628 := PrimCons(reg36623, reg36624)
-		reg36629 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36628)
+		reg36629 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36628)
 		_ = reg36629
 		reg36630 := MakeSymbol("shen.type-signature-of--")
-		reg36631 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36631 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3229 := __args[0]
 			_ = V3229
-			reg36632 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36632 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3230 := __args[0]
 				_ = V3230
-				reg36633 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36633 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3231 := __args[0]
 					_ = V3231
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_1, V3229, V3230, V3231)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_1, V3229, V3230, V3231)
 					return
 				}, 1)
-				__ctx.Return(reg36633)
+				__e.Return(reg36633)
 				return
 			}, 1)
-			__ctx.Return(reg36632)
+			__e.Return(reg36632)
 			return
 		}, 1)
 		reg36635 := PrimCons(reg36630, reg36631)
-		reg36636 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36635)
+		reg36636 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36635)
 		_ = reg36636
 		reg36637 := MakeSymbol("shen.type-signature-of-*")
-		reg36638 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36638 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3219 := __args[0]
 			_ = V3219
-			reg36639 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36639 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3220 := __args[0]
 				_ = V3220
-				reg36640 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36640 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3221 := __args[0]
 					_ = V3221
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_d, V3219, V3220, V3221)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_d, V3219, V3220, V3221)
 					return
 				}, 1)
-				__ctx.Return(reg36640)
+				__e.Return(reg36640)
 				return
 			}, 1)
-			__ctx.Return(reg36639)
+			__e.Return(reg36639)
 			return
 		}, 1)
 		reg36642 := PrimCons(reg36637, reg36638)
-		reg36643 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36642)
+		reg36643 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36642)
 		_ = reg36643
 		reg36644 := MakeSymbol("shen.type-signature-of-==")
-		reg36645 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36645 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V3209 := __args[0]
 			_ = V3209
-			reg36646 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36646 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V3210 := __args[0]
 				_ = V3210
-				reg36647 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36647 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V3211 := __args[0]
 					_ = V3211
-					__ctx.TailApply(__defun__shen_4type_1signature_1of_1_a_a, V3209, V3210, V3211)
+					__e.TailApply(__defun__shen_4type_1signature_1of_1_a_a, V3209, V3210, V3211)
 					return
 				}, 1)
-				__ctx.Return(reg36647)
+				__e.Return(reg36647)
 				return
 			}, 1)
-			__ctx.Return(reg36646)
+			__e.Return(reg36646)
 			return
 		}, 1)
 		reg36649 := PrimCons(reg36644, reg36645)
-		__ctx.TailApply(__defun__shen_4set_1lambda_1form_1entry, reg36649)
+		__e.TailApply(__defun__shen_4set_1lambda_1form_1entry, reg36649)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.initialise-signedfunc-lambda-forms", value: __defun__shen_4initialise_1signedfunc_1lambda_1forms})
 
-	__defun__shen_4initialise_1lambda_1forms = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4initialise_1lambda_1forms = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg36651 := MakeSymbol("shen.datatype-error")
-		reg36652 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36652 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4datatype_1error, X)
+			__e.TailApply(__defun__shen_4datatype_1error, X)
 			return
 		}, 1)
 		reg36654 := PrimCons(reg36651, reg36652)
-		reg36655 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36654)
+		reg36655 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36654)
 		_ = reg36655
 		reg36656 := MakeSymbol("shen.tuple")
-		reg36657 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36657 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4tuple, X)
+			__e.TailApply(__defun__shen_4tuple, X)
 			return
 		}, 1)
 		reg36659 := PrimCons(reg36656, reg36657)
-		reg36660 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36659)
+		reg36660 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36659)
 		_ = reg36660
 		reg36661 := MakeSymbol("shen.pvar")
-		reg36662 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36662 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4pvar, X)
+			__e.TailApply(__defun__shen_4pvar, X)
 			return
 		}, 1)
 		reg36664 := PrimCons(reg36661, reg36662)
-		reg36665 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36664)
+		reg36665 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36664)
 		_ = reg36665
 		reg36666 := MakeSymbol("shen.dictionary")
-		reg36667 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36667 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4dictionary, X)
+			__e.TailApply(__defun__shen_4dictionary, X)
 			return
 		}, 1)
 		reg36669 := PrimCons(reg36666, reg36667)
-		reg36670 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36669)
+		reg36670 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36669)
 		_ = reg36670
 		reg36671 := MakeSymbol("@v")
-		reg36672 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36672 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V668 := __args[0]
 			_ = V668
-			reg36673 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36673 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V669 := __args[0]
 				_ = V669
-				__ctx.TailApply(__defun___8v, V668, V669)
+				__e.TailApply(__defun___8v, V668, V669)
 				return
 			}, 1)
-			__ctx.Return(reg36673)
+			__e.Return(reg36673)
 			return
 		}, 1)
 		reg36675 := PrimCons(reg36671, reg36672)
-		reg36676 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36675)
+		reg36676 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36675)
 		_ = reg36676
 		reg36677 := MakeSymbol("@p")
-		reg36678 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36678 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V666 := __args[0]
 			_ = V666
-			reg36679 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36679 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V667 := __args[0]
 				_ = V667
-				__ctx.TailApply(__defun___8p, V666, V667)
+				__e.TailApply(__defun___8p, V666, V667)
 				return
 			}, 1)
-			__ctx.Return(reg36679)
+			__e.Return(reg36679)
 			return
 		}, 1)
 		reg36681 := PrimCons(reg36677, reg36678)
-		reg36682 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36681)
+		reg36682 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36681)
 		_ = reg36682
 		reg36683 := MakeSymbol("@s")
-		reg36684 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36684 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V664 := __args[0]
 			_ = V664
-			reg36685 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36685 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V665 := __args[0]
 				_ = V665
-				__ctx.TailApply(__defun___8s, V664, V665)
+				__e.TailApply(__defun___8s, V664, V665)
 				return
 			}, 1)
-			__ctx.Return(reg36685)
+			__e.Return(reg36685)
 			return
 		}, 1)
 		reg36687 := PrimCons(reg36683, reg36684)
-		reg36688 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36687)
+		reg36688 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36687)
 		_ = reg36688
 		reg36689 := MakeSymbol("<e>")
-		reg36690 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36690 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V663 := __args[0]
 			_ = V663
-			__ctx.TailApply(__defun___5e_6, V663)
+			__e.TailApply(__defun___5e_6, V663)
 			return
 		}, 1)
 		reg36692 := PrimCons(reg36689, reg36690)
-		reg36693 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36692)
+		reg36693 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36692)
 		_ = reg36693
 		reg36694 := MakeSymbol("<!>")
-		reg36695 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36695 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V662 := __args[0]
 			_ = V662
-			__ctx.TailApply(__defun___5_b_6, V662)
+			__e.TailApply(__defun___5_b_6, V662)
 			return
 		}, 1)
 		reg36697 := PrimCons(reg36694, reg36695)
-		reg36698 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36697)
+		reg36698 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36697)
 		_ = reg36698
 		reg36699 := MakeSymbol("==")
-		reg36700 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36700 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V660 := __args[0]
 			_ = V660
-			reg36701 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36701 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V661 := __args[0]
 				_ = V661
-				__ctx.TailApply(__defun___a_a, V660, V661)
+				__e.TailApply(__defun___a_a, V660, V661)
 				return
 			}, 1)
-			__ctx.Return(reg36701)
+			__e.Return(reg36701)
 			return
 		}, 1)
 		reg36703 := PrimCons(reg36699, reg36700)
-		reg36704 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36703)
+		reg36704 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36703)
 		_ = reg36704
 		reg36705 := MakeSymbol("=")
-		reg36706 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36706 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V658 := __args[0]
 			_ = V658
-			reg36707 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36707 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V659 := __args[0]
 				_ = V659
 				reg36708 := PrimEqual(V658, V659)
-				__ctx.Return(reg36708)
+				__e.Return(reg36708)
 				return
 			}, 1)
-			__ctx.Return(reg36707)
+			__e.Return(reg36707)
 			return
 		}, 1)
 		reg36709 := PrimCons(reg36705, reg36706)
-		reg36710 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36709)
+		reg36710 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36709)
 		_ = reg36710
 		reg36711 := MakeSymbol(">=")
-		reg36712 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36712 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V656 := __args[0]
 			_ = V656
-			reg36713 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36713 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V657 := __args[0]
 				_ = V657
 				reg36714 := PrimGreatEqual(V656, V657)
-				__ctx.Return(reg36714)
+				__e.Return(reg36714)
 				return
 			}, 1)
-			__ctx.Return(reg36713)
+			__e.Return(reg36713)
 			return
 		}, 1)
 		reg36715 := PrimCons(reg36711, reg36712)
-		reg36716 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36715)
+		reg36716 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36715)
 		_ = reg36716
 		reg36717 := MakeSymbol(">")
-		reg36718 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36718 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V654 := __args[0]
 			_ = V654
-			reg36719 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36719 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V655 := __args[0]
 				_ = V655
 				reg36720 := PrimGreatThan(V654, V655)
-				__ctx.Return(reg36720)
+				__e.Return(reg36720)
 				return
 			}, 1)
-			__ctx.Return(reg36719)
+			__e.Return(reg36719)
 			return
 		}, 1)
 		reg36721 := PrimCons(reg36717, reg36718)
-		reg36722 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36721)
+		reg36722 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36721)
 		_ = reg36722
 		reg36723 := MakeSymbol("-")
-		reg36724 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36724 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V652 := __args[0]
 			_ = V652
-			reg36725 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36725 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V653 := __args[0]
 				_ = V653
 				reg36726 := PrimNumberSubtract(V652, V653)
-				__ctx.Return(reg36726)
+				__e.Return(reg36726)
 				return
 			}, 1)
-			__ctx.Return(reg36725)
+			__e.Return(reg36725)
 			return
 		}, 1)
 		reg36727 := PrimCons(reg36723, reg36724)
-		reg36728 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36727)
+		reg36728 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36727)
 		_ = reg36728
 		reg36729 := MakeSymbol("/")
-		reg36730 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36730 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V650 := __args[0]
 			_ = V650
-			reg36731 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36731 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V651 := __args[0]
 				_ = V651
 				reg36732 := PrimNumberDivide(V650, V651)
-				__ctx.Return(reg36732)
+				__e.Return(reg36732)
 				return
 			}, 1)
-			__ctx.Return(reg36731)
+			__e.Return(reg36731)
 			return
 		}, 1)
 		reg36733 := PrimCons(reg36729, reg36730)
-		reg36734 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36733)
+		reg36734 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36733)
 		_ = reg36734
 		reg36735 := MakeSymbol("*")
-		reg36736 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36736 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V648 := __args[0]
 			_ = V648
-			reg36737 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36737 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V649 := __args[0]
 				_ = V649
 				reg36738 := PrimNumberMultiply(V648, V649)
-				__ctx.Return(reg36738)
+				__e.Return(reg36738)
 				return
 			}, 1)
-			__ctx.Return(reg36737)
+			__e.Return(reg36737)
 			return
 		}, 1)
 		reg36739 := PrimCons(reg36735, reg36736)
-		reg36740 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36739)
+		reg36740 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36739)
 		_ = reg36740
 		reg36741 := MakeSymbol("+")
-		reg36742 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36742 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V646 := __args[0]
 			_ = V646
-			reg36743 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36743 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V647 := __args[0]
 				_ = V647
 				reg36744 := PrimNumberAdd(V646, V647)
-				__ctx.Return(reg36744)
+				__e.Return(reg36744)
 				return
 			}, 1)
-			__ctx.Return(reg36743)
+			__e.Return(reg36743)
 			return
 		}, 1)
 		reg36745 := PrimCons(reg36741, reg36742)
-		reg36746 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36745)
+		reg36746 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36745)
 		_ = reg36746
 		reg36747 := MakeSymbol("<=")
-		reg36748 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36748 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V644 := __args[0]
 			_ = V644
-			reg36749 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36749 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V645 := __args[0]
 				_ = V645
 				reg36750 := PrimLessEqual(V644, V645)
-				__ctx.Return(reg36750)
+				__e.Return(reg36750)
 				return
 			}, 1)
-			__ctx.Return(reg36749)
+			__e.Return(reg36749)
 			return
 		}, 1)
 		reg36751 := PrimCons(reg36747, reg36748)
-		reg36752 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36751)
+		reg36752 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36751)
 		_ = reg36752
 		reg36753 := MakeSymbol("<")
-		reg36754 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36754 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V642 := __args[0]
 			_ = V642
-			reg36755 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36755 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V643 := __args[0]
 				_ = V643
 				reg36756 := PrimLessThan(V642, V643)
-				__ctx.Return(reg36756)
+				__e.Return(reg36756)
 				return
 			}, 1)
-			__ctx.Return(reg36755)
+			__e.Return(reg36755)
 			return
 		}, 1)
 		reg36757 := PrimCons(reg36753, reg36754)
-		reg36758 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36757)
+		reg36758 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36757)
 		_ = reg36758
 		reg36759 := MakeSymbol("y-or-n?")
-		reg36760 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36760 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V641 := __args[0]
 			_ = V641
-			__ctx.TailApply(__defun__y_1or_1n_2, V641)
+			__e.TailApply(__defun__y_1or_1n_2, V641)
 			return
 		}, 1)
 		reg36762 := PrimCons(reg36759, reg36760)
-		reg36763 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36762)
+		reg36763 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36762)
 		_ = reg36763
 		reg36764 := MakeSymbol("write-to-file")
-		reg36765 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36765 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V639 := __args[0]
 			_ = V639
-			reg36766 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36766 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V640 := __args[0]
 				_ = V640
-				__ctx.TailApply(__defun__write_1to_1file, V639, V640)
+				__e.TailApply(__defun__write_1to_1file, V639, V640)
 				return
 			}, 1)
-			__ctx.Return(reg36766)
+			__e.Return(reg36766)
 			return
 		}, 1)
 		reg36768 := PrimCons(reg36764, reg36765)
-		reg36769 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36768)
+		reg36769 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36768)
 		_ = reg36769
 		reg36770 := MakeSymbol("write-byte")
-		reg36771 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36771 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V637 := __args[0]
 			_ = V637
-			reg36772 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36772 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V638 := __args[0]
 				_ = V638
 				reg36773 := PrimWriteByte(V637, V638)
-				__ctx.Return(reg36773)
+				__e.Return(reg36773)
 				return
 			}, 1)
-			__ctx.Return(reg36772)
+			__e.Return(reg36772)
 			return
 		}, 1)
 		reg36774 := PrimCons(reg36770, reg36771)
-		reg36775 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36774)
+		reg36775 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36774)
 		_ = reg36775
 		reg36776 := MakeSymbol("variable?")
-		reg36777 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36777 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V636 := __args[0]
 			_ = V636
 			reg36778 := PrimIsVariable(V636)
-			__ctx.Return(reg36778)
+			__e.Return(reg36778)
 			return
 		}, 1)
 		reg36779 := PrimCons(reg36776, reg36777)
-		reg36780 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36779)
+		reg36780 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36779)
 		_ = reg36780
 		reg36781 := MakeSymbol("value")
-		reg36782 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36782 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V635 := __args[0]
 			_ = V635
 			reg36783 := PrimValue(V635)
-			__ctx.Return(reg36783)
+			__e.Return(reg36783)
 			return
 		}, 1)
 		reg36784 := PrimCons(reg36781, reg36782)
-		reg36785 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36784)
+		reg36785 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36784)
 		_ = reg36785
 		reg36786 := MakeSymbol("vector->")
-		reg36787 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36787 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V632 := __args[0]
 			_ = V632
-			reg36788 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36788 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V633 := __args[0]
 				_ = V633
-				reg36789 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36789 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V634 := __args[0]
 					_ = V634
-					__ctx.TailApply(__defun__vector_1_6, V632, V633, V634)
+					__e.TailApply(__defun__vector_1_6, V632, V633, V634)
 					return
 				}, 1)
-				__ctx.Return(reg36789)
+				__e.Return(reg36789)
 				return
 			}, 1)
-			__ctx.Return(reg36788)
+			__e.Return(reg36788)
 			return
 		}, 1)
 		reg36791 := PrimCons(reg36786, reg36787)
-		reg36792 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36791)
+		reg36792 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36791)
 		_ = reg36792
 		reg36793 := MakeSymbol("<-vector")
-		reg36794 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36794 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V630 := __args[0]
 			_ = V630
-			reg36795 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36795 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V631 := __args[0]
 				_ = V631
-				__ctx.TailApply(__defun___5_1vector, V630, V631)
+				__e.TailApply(__defun___5_1vector, V630, V631)
 				return
 			}, 1)
-			__ctx.Return(reg36795)
+			__e.Return(reg36795)
 			return
 		}, 1)
 		reg36797 := PrimCons(reg36793, reg36794)
-		reg36798 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36797)
+		reg36798 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36797)
 		_ = reg36798
 		reg36799 := MakeSymbol("vector")
-		reg36800 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36800 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V629 := __args[0]
 			_ = V629
-			__ctx.TailApply(__defun__vector, V629)
+			__e.TailApply(__defun__vector, V629)
 			return
 		}, 1)
 		reg36802 := PrimCons(reg36799, reg36800)
-		reg36803 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36802)
+		reg36803 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36802)
 		_ = reg36803
 		reg36804 := MakeSymbol("vector?")
-		reg36805 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36805 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V628 := __args[0]
 			_ = V628
-			__ctx.TailApply(__defun__vector_2, V628)
+			__e.TailApply(__defun__vector_2, V628)
 			return
 		}, 1)
 		reg36807 := PrimCons(reg36804, reg36805)
-		reg36808 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36807)
+		reg36808 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36807)
 		_ = reg36808
 		reg36809 := MakeSymbol("unspecialise")
-		reg36810 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36810 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V627 := __args[0]
 			_ = V627
-			__ctx.TailApply(__defun__unspecialise, V627)
+			__e.TailApply(__defun__unspecialise, V627)
 			return
 		}, 1)
 		reg36812 := PrimCons(reg36809, reg36810)
-		reg36813 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36812)
+		reg36813 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36812)
 		_ = reg36813
 		reg36814 := MakeSymbol("untrack")
-		reg36815 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36815 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V626 := __args[0]
 			_ = V626
-			__ctx.TailApply(__defun__untrack, V626)
+			__e.TailApply(__defun__untrack, V626)
 			return
 		}, 1)
 		reg36817 := PrimCons(reg36814, reg36815)
-		reg36818 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36817)
+		reg36818 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36817)
 		_ = reg36818
 		reg36819 := MakeSymbol("union")
-		reg36820 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36820 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V624 := __args[0]
 			_ = V624
-			reg36821 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36821 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V625 := __args[0]
 				_ = V625
-				__ctx.TailApply(__defun__union, V624, V625)
+				__e.TailApply(__defun__union, V624, V625)
 				return
 			}, 1)
-			__ctx.Return(reg36821)
+			__e.Return(reg36821)
 			return
 		}, 1)
 		reg36823 := PrimCons(reg36819, reg36820)
-		reg36824 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36823)
+		reg36824 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36823)
 		_ = reg36824
 		reg36825 := MakeSymbol("unify")
-		reg36826 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36826 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V620 := __args[0]
 			_ = V620
-			reg36827 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36827 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V621 := __args[0]
 				_ = V621
-				reg36828 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36828 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V622 := __args[0]
 					_ = V622
-					reg36829 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg36829 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						V623 := __args[0]
 						_ = V623
-						__ctx.TailApply(__defun__unify, V620, V621, V622, V623)
+						__e.TailApply(__defun__unify, V620, V621, V622, V623)
 						return
 					}, 1)
-					__ctx.Return(reg36829)
+					__e.Return(reg36829)
 					return
 				}, 1)
-				__ctx.Return(reg36828)
+				__e.Return(reg36828)
 				return
 			}, 1)
-			__ctx.Return(reg36827)
+			__e.Return(reg36827)
 			return
 		}, 1)
 		reg36831 := PrimCons(reg36825, reg36826)
-		reg36832 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36831)
+		reg36832 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36831)
 		_ = reg36832
 		reg36833 := MakeSymbol("unify!")
-		reg36834 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36834 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V616 := __args[0]
 			_ = V616
-			reg36835 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36835 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V617 := __args[0]
 				_ = V617
-				reg36836 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36836 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V618 := __args[0]
 					_ = V618
-					reg36837 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg36837 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						V619 := __args[0]
 						_ = V619
-						__ctx.TailApply(__defun__unify_b, V616, V617, V618, V619)
+						__e.TailApply(__defun__unify_b, V616, V617, V618, V619)
 						return
 					}, 1)
-					__ctx.Return(reg36837)
+					__e.Return(reg36837)
 					return
 				}, 1)
-				__ctx.Return(reg36836)
+				__e.Return(reg36836)
 				return
 			}, 1)
-			__ctx.Return(reg36835)
+			__e.Return(reg36835)
 			return
 		}, 1)
 		reg36839 := PrimCons(reg36833, reg36834)
-		reg36840 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36839)
+		reg36840 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36839)
 		_ = reg36840
 		reg36841 := MakeSymbol("unput")
-		reg36842 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36842 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V613 := __args[0]
 			_ = V613
-			reg36843 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36843 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V614 := __args[0]
 				_ = V614
-				reg36844 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36844 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V615 := __args[0]
 					_ = V615
-					__ctx.TailApply(__defun__unput, V613, V614, V615)
+					__e.TailApply(__defun__unput, V613, V614, V615)
 					return
 				}, 1)
-				__ctx.Return(reg36844)
+				__e.Return(reg36844)
 				return
 			}, 1)
-			__ctx.Return(reg36843)
+			__e.Return(reg36843)
 			return
 		}, 1)
 		reg36846 := PrimCons(reg36841, reg36842)
-		reg36847 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36846)
+		reg36847 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36846)
 		_ = reg36847
 		reg36848 := MakeSymbol("unprofile")
-		reg36849 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36849 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V612 := __args[0]
 			_ = V612
-			__ctx.TailApply(__defun__unprofile, V612)
+			__e.TailApply(__defun__unprofile, V612)
 			return
 		}, 1)
 		reg36851 := PrimCons(reg36848, reg36849)
-		reg36852 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36851)
+		reg36852 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36851)
 		_ = reg36852
 		reg36853 := MakeSymbol("undefmacro")
-		reg36854 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36854 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V611 := __args[0]
 			_ = V611
-			__ctx.TailApply(__defun__undefmacro, V611)
+			__e.TailApply(__defun__undefmacro, V611)
 			return
 		}, 1)
 		reg36856 := PrimCons(reg36853, reg36854)
-		reg36857 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36856)
+		reg36857 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36856)
 		_ = reg36857
 		reg36858 := MakeSymbol("return")
-		reg36859 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36859 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V608 := __args[0]
 			_ = V608
-			reg36860 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36860 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V609 := __args[0]
 				_ = V609
-				reg36861 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36861 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V610 := __args[0]
 					_ = V610
-					__ctx.TailApply(__defun__return, V608, V609, V610)
+					__e.TailApply(__defun__return, V608, V609, V610)
 					return
 				}, 1)
-				__ctx.Return(reg36861)
+				__e.Return(reg36861)
 				return
 			}, 1)
-			__ctx.Return(reg36860)
+			__e.Return(reg36860)
 			return
 		}, 1)
 		reg36863 := PrimCons(reg36858, reg36859)
-		reg36864 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36863)
+		reg36864 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36863)
 		_ = reg36864
 		reg36865 := MakeSymbol("type")
-		reg36866 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36866 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V606 := __args[0]
 			_ = V606
-			reg36867 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36867 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V607 := __args[0]
 				_ = V607
 				reg36868 := PrimTypeFunc(V606, V607)
-				__ctx.Return(reg36868)
+				__e.Return(reg36868)
 				return
 			}, 1)
-			__ctx.Return(reg36867)
+			__e.Return(reg36867)
 			return
 		}, 1)
 		reg36869 := PrimCons(reg36865, reg36866)
-		reg36870 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36869)
+		reg36870 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36869)
 		_ = reg36870
 		reg36871 := MakeSymbol("tuple?")
-		reg36872 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36872 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V605 := __args[0]
 			_ = V605
-			__ctx.TailApply(__defun__tuple_2, V605)
+			__e.TailApply(__defun__tuple_2, V605)
 			return
 		}, 1)
 		reg36874 := PrimCons(reg36871, reg36872)
-		reg36875 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36874)
+		reg36875 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36874)
 		_ = reg36875
 		reg36876 := MakeSymbol("trap-error")
-		reg36877 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36877 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V603 := __args[0]
 			_ = V603
-			reg36878 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36878 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V604 := __args[0]
 				_ = V604
-				reg36879 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-					__ctx.Return(V603)
+				reg36879 := MakeNative(func(__e Evaluator, __args ...Obj) {
+					__e.Return(V603)
 					return
 				}, 0)
-				reg36880 := __e.Try(reg36879).Catch(V604)
-				__ctx.Return(reg36880)
+				reg36880 := Try(__e, reg36879).Catch(V604)
+				__e.Return(reg36880)
 				return
 			}, 1)
-			__ctx.Return(reg36878)
+			__e.Return(reg36878)
 			return
 		}, 1)
 		reg36881 := PrimCons(reg36876, reg36877)
-		reg36882 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36881)
+		reg36882 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36881)
 		_ = reg36882
 		reg36883 := MakeSymbol("track")
-		reg36884 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36884 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V602 := __args[0]
 			_ = V602
-			__ctx.TailApply(__defun__track, V602)
+			__e.TailApply(__defun__track, V602)
 			return
 		}, 1)
 		reg36886 := PrimCons(reg36883, reg36884)
-		reg36887 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36886)
+		reg36887 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36886)
 		_ = reg36887
 		reg36888 := MakeSymbol("thaw")
-		reg36889 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36889 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V601 := __args[0]
 			_ = V601
-			__ctx.TailApply(__defun__thaw, V601)
+			__e.TailApply(__defun__thaw, V601)
 			return
 		}, 1)
 		reg36891 := PrimCons(reg36888, reg36889)
-		reg36892 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36891)
+		reg36892 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36891)
 		_ = reg36892
 		reg36893 := MakeSymbol("tc")
-		reg36894 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36894 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V600 := __args[0]
 			_ = V600
-			__ctx.TailApply(__defun__tc, V600)
+			__e.TailApply(__defun__tc, V600)
 			return
 		}, 1)
 		reg36896 := PrimCons(reg36893, reg36894)
-		reg36897 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36896)
+		reg36897 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36896)
 		_ = reg36897
 		reg36898 := MakeSymbol("tl")
-		reg36899 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36899 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V599 := __args[0]
 			_ = V599
 			reg36900 := PrimTail(V599)
-			__ctx.Return(reg36900)
+			__e.Return(reg36900)
 			return
 		}, 1)
 		reg36901 := PrimCons(reg36898, reg36899)
-		reg36902 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36901)
+		reg36902 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36901)
 		_ = reg36902
 		reg36903 := MakeSymbol("tlstr")
-		reg36904 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36904 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V598 := __args[0]
 			_ = V598
 			reg36905 := PrimTailString(V598)
-			__ctx.Return(reg36905)
+			__e.Return(reg36905)
 			return
 		}, 1)
 		reg36906 := PrimCons(reg36903, reg36904)
-		reg36907 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36906)
+		reg36907 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36906)
 		_ = reg36907
 		reg36908 := MakeSymbol("tail")
-		reg36909 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36909 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V597 := __args[0]
 			_ = V597
-			__ctx.TailApply(__defun__tail, V597)
+			__e.TailApply(__defun__tail, V597)
 			return
 		}, 1)
 		reg36911 := PrimCons(reg36908, reg36909)
-		reg36912 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36911)
+		reg36912 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36911)
 		_ = reg36912
 		reg36913 := MakeSymbol("systemf")
-		reg36914 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36914 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V596 := __args[0]
 			_ = V596
-			__ctx.TailApply(__defun__systemf, V596)
+			__e.TailApply(__defun__systemf, V596)
 			return
 		}, 1)
 		reg36916 := PrimCons(reg36913, reg36914)
-		reg36917 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36916)
+		reg36917 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36916)
 		_ = reg36917
 		reg36918 := MakeSymbol("symbol?")
-		reg36919 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36919 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V595 := __args[0]
 			_ = V595
 			reg36920 := PrimIsSymbol(V595)
-			__ctx.Return(reg36920)
+			__e.Return(reg36920)
 			return
 		}, 1)
 		reg36921 := PrimCons(reg36918, reg36919)
-		reg36922 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36921)
+		reg36922 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36921)
 		_ = reg36922
 		reg36923 := MakeSymbol("string->symbol")
-		reg36924 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36924 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V594 := __args[0]
 			_ = V594
-			__ctx.TailApply(__defun__string_1_6symbol, V594)
+			__e.TailApply(__defun__string_1_6symbol, V594)
 			return
 		}, 1)
 		reg36926 := PrimCons(reg36923, reg36924)
-		reg36927 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36926)
+		reg36927 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36926)
 		_ = reg36927
 		reg36928 := MakeSymbol("sum")
-		reg36929 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36929 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V593 := __args[0]
 			_ = V593
-			__ctx.TailApply(__defun__sum, V593)
+			__e.TailApply(__defun__sum, V593)
 			return
 		}, 1)
 		reg36931 := PrimCons(reg36928, reg36929)
-		reg36932 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36931)
+		reg36932 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36931)
 		_ = reg36932
 		reg36933 := MakeSymbol("subst")
-		reg36934 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36934 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V590 := __args[0]
 			_ = V590
-			reg36935 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36935 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V591 := __args[0]
 				_ = V591
-				reg36936 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg36936 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V592 := __args[0]
 					_ = V592
-					__ctx.TailApply(__defun__subst, V590, V591, V592)
+					__e.TailApply(__defun__subst, V590, V591, V592)
 					return
 				}, 1)
-				__ctx.Return(reg36936)
+				__e.Return(reg36936)
 				return
 			}, 1)
-			__ctx.Return(reg36935)
+			__e.Return(reg36935)
 			return
 		}, 1)
 		reg36938 := PrimCons(reg36933, reg36934)
-		reg36939 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36938)
+		reg36939 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36938)
 		_ = reg36939
 		reg36940 := MakeSymbol("string?")
-		reg36941 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36941 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V589 := __args[0]
 			_ = V589
 			reg36942 := PrimIsString(V589)
-			__ctx.Return(reg36942)
+			__e.Return(reg36942)
 			return
 		}, 1)
 		reg36943 := PrimCons(reg36940, reg36941)
-		reg36944 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36943)
+		reg36944 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36943)
 		_ = reg36944
 		reg36945 := MakeSymbol("string->n")
-		reg36946 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36946 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V588 := __args[0]
 			_ = V588
 			reg36947 := PrimStringToNumber(V588)
-			__ctx.Return(reg36947)
+			__e.Return(reg36947)
 			return
 		}, 1)
 		reg36948 := PrimCons(reg36945, reg36946)
-		reg36949 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36948)
+		reg36949 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36948)
 		_ = reg36949
 		reg36950 := MakeSymbol("step")
-		reg36951 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36951 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V587 := __args[0]
 			_ = V587
-			__ctx.TailApply(__defun__step, V587)
+			__e.TailApply(__defun__step, V587)
 			return
 		}, 1)
 		reg36953 := PrimCons(reg36950, reg36951)
-		reg36954 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36953)
+		reg36954 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36953)
 		_ = reg36954
 		reg36955 := MakeSymbol("spy")
-		reg36956 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36956 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V586 := __args[0]
 			_ = V586
-			__ctx.TailApply(__defun__spy, V586)
+			__e.TailApply(__defun__spy, V586)
 			return
 		}, 1)
 		reg36958 := PrimCons(reg36955, reg36956)
-		reg36959 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36958)
+		reg36959 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36958)
 		_ = reg36959
 		reg36960 := MakeSymbol("specialise")
-		reg36961 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36961 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V585 := __args[0]
 			_ = V585
-			__ctx.TailApply(__defun__specialise, V585)
+			__e.TailApply(__defun__specialise, V585)
 			return
 		}, 1)
 		reg36963 := PrimCons(reg36960, reg36961)
-		reg36964 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36963)
+		reg36964 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36963)
 		_ = reg36964
 		reg36965 := MakeSymbol("snd")
-		reg36966 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36966 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V584 := __args[0]
 			_ = V584
-			__ctx.TailApply(__defun__snd, V584)
+			__e.TailApply(__defun__snd, V584)
 			return
 		}, 1)
 		reg36968 := PrimCons(reg36965, reg36966)
-		reg36969 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36968)
+		reg36969 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36968)
 		_ = reg36969
 		reg36970 := MakeSymbol("simple-error")
-		reg36971 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36971 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V583 := __args[0]
 			_ = V583
 			reg36972 := PrimSimpleError(V583)
-			__ctx.Return(reg36972)
+			__e.Return(reg36972)
 			return
 		}, 1)
 		reg36973 := PrimCons(reg36970, reg36971)
-		reg36974 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36973)
+		reg36974 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36973)
 		_ = reg36974
 		reg36975 := MakeSymbol("set")
-		reg36976 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36976 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V581 := __args[0]
 			_ = V581
-			reg36977 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36977 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V582 := __args[0]
 				_ = V582
 				reg36978 := PrimSet(V581, V582)
-				__ctx.Return(reg36978)
+				__e.Return(reg36978)
 				return
 			}, 1)
-			__ctx.Return(reg36977)
+			__e.Return(reg36977)
 			return
 		}, 1)
 		reg36979 := PrimCons(reg36975, reg36976)
-		reg36980 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36979)
+		reg36980 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36979)
 		_ = reg36980
 		reg36981 := MakeSymbol("str")
-		reg36982 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36982 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V580 := __args[0]
 			_ = V580
 			reg36983 := PrimStr(V580)
-			__ctx.Return(reg36983)
+			__e.Return(reg36983)
 			return
 		}, 1)
 		reg36984 := PrimCons(reg36981, reg36982)
-		reg36985 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36984)
+		reg36985 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36984)
 		_ = reg36985
 		reg36986 := MakeSymbol("reverse")
-		reg36987 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36987 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V579 := __args[0]
 			_ = V579
-			__ctx.TailApply(__defun__reverse, V579)
+			__e.TailApply(__defun__reverse, V579)
 			return
 		}, 1)
 		reg36989 := PrimCons(reg36986, reg36987)
-		reg36990 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36989)
+		reg36990 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36989)
 		_ = reg36990
 		reg36991 := MakeSymbol("remove")
-		reg36992 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36992 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V577 := __args[0]
 			_ = V577
-			reg36993 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg36993 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V578 := __args[0]
 				_ = V578
-				__ctx.TailApply(__defun__remove, V577, V578)
+				__e.TailApply(__defun__remove, V577, V578)
 				return
 			}, 1)
-			__ctx.Return(reg36993)
+			__e.Return(reg36993)
 			return
 		}, 1)
 		reg36995 := PrimCons(reg36991, reg36992)
-		reg36996 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg36995)
+		reg36996 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg36995)
 		_ = reg36996
 		reg36997 := MakeSymbol("read")
-		reg36998 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg36998 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V576 := __args[0]
 			_ = V576
-			__ctx.TailApply(__defun__read, V576)
+			__e.TailApply(__defun__read, V576)
 			return
 		}, 1)
 		reg37000 := PrimCons(reg36997, reg36998)
-		reg37001 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37000)
+		reg37001 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37000)
 		_ = reg37001
 		reg37002 := MakeSymbol("read-file")
-		reg37003 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37003 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V575 := __args[0]
 			_ = V575
-			__ctx.TailApply(__defun__read_1file, V575)
+			__e.TailApply(__defun__read_1file, V575)
 			return
 		}, 1)
 		reg37005 := PrimCons(reg37002, reg37003)
-		reg37006 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37005)
+		reg37006 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37005)
 		_ = reg37006
 		reg37007 := MakeSymbol("read-file-as-bytelist")
-		reg37008 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37008 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V574 := __args[0]
 			_ = V574
 			reg37009 := PrimReadFileAsByteList(V574)
-			__ctx.Return(reg37009)
+			__e.Return(reg37009)
 			return
 		}, 1)
 		reg37010 := PrimCons(reg37007, reg37008)
-		reg37011 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37010)
+		reg37011 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37010)
 		_ = reg37011
 		reg37012 := MakeSymbol("read-file-as-string")
-		reg37013 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37013 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V573 := __args[0]
 			_ = V573
 			reg37014 := PrimReadFileAsString(V573)
-			__ctx.Return(reg37014)
+			__e.Return(reg37014)
 			return
 		}, 1)
 		reg37015 := PrimCons(reg37012, reg37013)
-		reg37016 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37015)
+		reg37016 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37015)
 		_ = reg37016
 		reg37017 := MakeSymbol("read-byte")
-		reg37018 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37018 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V572 := __args[0]
 			_ = V572
 			reg37019 := PrimReadByte(V572)
-			__ctx.Return(reg37019)
+			__e.Return(reg37019)
 			return
 		}, 1)
 		reg37020 := PrimCons(reg37017, reg37018)
-		reg37021 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37020)
+		reg37021 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37020)
 		_ = reg37021
 		reg37022 := MakeSymbol("read-from-string")
-		reg37023 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37023 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V571 := __args[0]
 			_ = V571
-			__ctx.TailApply(__defun__read_1from_1string, V571)
+			__e.TailApply(__defun__read_1from_1string, V571)
 			return
 		}, 1)
 		reg37025 := PrimCons(reg37022, reg37023)
-		reg37026 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37025)
+		reg37026 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37025)
 		_ = reg37026
 		reg37027 := MakeSymbol("package?")
-		reg37028 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37028 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V570 := __args[0]
 			_ = V570
-			__ctx.TailApply(__defun__package_2, V570)
+			__e.TailApply(__defun__package_2, V570)
 			return
 		}, 1)
 		reg37030 := PrimCons(reg37027, reg37028)
-		reg37031 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37030)
+		reg37031 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37030)
 		_ = reg37031
 		reg37032 := MakeSymbol("put")
-		reg37033 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37033 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V566 := __args[0]
 			_ = V566
-			reg37034 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37034 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V567 := __args[0]
 				_ = V567
-				reg37035 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg37035 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V568 := __args[0]
 					_ = V568
-					reg37036 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg37036 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						V569 := __args[0]
 						_ = V569
-						__ctx.TailApply(__defun__put, V566, V567, V568, V569)
+						__e.TailApply(__defun__put, V566, V567, V568, V569)
 						return
 					}, 1)
-					__ctx.Return(reg37036)
+					__e.Return(reg37036)
 					return
 				}, 1)
-				__ctx.Return(reg37035)
+				__e.Return(reg37035)
 				return
 			}, 1)
-			__ctx.Return(reg37034)
+			__e.Return(reg37034)
 			return
 		}, 1)
 		reg37038 := PrimCons(reg37032, reg37033)
-		reg37039 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37038)
+		reg37039 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37038)
 		_ = reg37039
 		reg37040 := MakeSymbol("preclude")
-		reg37041 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37041 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V565 := __args[0]
 			_ = V565
-			__ctx.TailApply(__defun__preclude, V565)
+			__e.TailApply(__defun__preclude, V565)
 			return
 		}, 1)
 		reg37043 := PrimCons(reg37040, reg37041)
-		reg37044 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37043)
+		reg37044 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37043)
 		_ = reg37044
 		reg37045 := MakeSymbol("preclude-all-but")
-		reg37046 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37046 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V564 := __args[0]
 			_ = V564
-			__ctx.TailApply(__defun__preclude_1all_1but, V564)
+			__e.TailApply(__defun__preclude_1all_1but, V564)
 			return
 		}, 1)
 		reg37048 := PrimCons(reg37045, reg37046)
-		reg37049 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37048)
+		reg37049 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37048)
 		_ = reg37049
 		reg37050 := MakeSymbol("ps")
-		reg37051 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37051 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V563 := __args[0]
 			_ = V563
-			__ctx.TailApply(__defun__ps, V563)
+			__e.TailApply(__defun__ps, V563)
 			return
 		}, 1)
 		reg37053 := PrimCons(reg37050, reg37051)
-		reg37054 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37053)
+		reg37054 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37053)
 		_ = reg37054
 		reg37055 := MakeSymbol("protect")
-		reg37056 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37056 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V562 := __args[0]
 			_ = V562
-			__ctx.TailApply(__defun__protect, V562)
+			__e.TailApply(__defun__protect, V562)
 			return
 		}, 1)
 		reg37058 := PrimCons(reg37055, reg37056)
-		reg37059 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37058)
+		reg37059 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37058)
 		_ = reg37059
 		reg37060 := MakeSymbol("profile-results")
-		reg37061 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37061 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V561 := __args[0]
 			_ = V561
-			__ctx.TailApply(__defun__profile_1results, V561)
+			__e.TailApply(__defun__profile_1results, V561)
 			return
 		}, 1)
 		reg37063 := PrimCons(reg37060, reg37061)
-		reg37064 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37063)
+		reg37064 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37063)
 		_ = reg37064
 		reg37065 := MakeSymbol("profile")
-		reg37066 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37066 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V560 := __args[0]
 			_ = V560
-			__ctx.TailApply(__defun__profile, V560)
+			__e.TailApply(__defun__profile, V560)
 			return
 		}, 1)
 		reg37068 := PrimCons(reg37065, reg37066)
-		reg37069 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37068)
+		reg37069 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37068)
 		_ = reg37069
 		reg37070 := MakeSymbol("print")
-		reg37071 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37071 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V559 := __args[0]
 			_ = V559
-			__ctx.TailApply(__defun__print, V559)
+			__e.TailApply(__defun__print, V559)
 			return
 		}, 1)
 		reg37073 := PrimCons(reg37070, reg37071)
-		reg37074 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37073)
+		reg37074 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37073)
 		_ = reg37074
 		reg37075 := MakeSymbol("pr")
-		reg37076 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37076 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V557 := __args[0]
 			_ = V557
-			reg37077 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37077 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V558 := __args[0]
 				_ = V558
-				__ctx.TailApply(__defun__pr, V557, V558)
+				__e.TailApply(__defun__pr, V557, V558)
 				return
 			}, 1)
-			__ctx.Return(reg37077)
+			__e.Return(reg37077)
 			return
 		}, 1)
 		reg37079 := PrimCons(reg37075, reg37076)
-		reg37080 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37079)
+		reg37080 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37079)
 		_ = reg37080
 		reg37081 := MakeSymbol("pos")
-		reg37082 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37082 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V555 := __args[0]
 			_ = V555
-			reg37083 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37083 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V556 := __args[0]
 				_ = V556
 				reg37084 := PrimPos(V555, V556)
-				__ctx.Return(reg37084)
+				__e.Return(reg37084)
 				return
 			}, 1)
-			__ctx.Return(reg37083)
+			__e.Return(reg37083)
 			return
 		}, 1)
 		reg37085 := PrimCons(reg37081, reg37082)
-		reg37086 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37085)
+		reg37086 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37085)
 		_ = reg37086
 		reg37087 := MakeSymbol("or")
-		reg37088 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37088 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V553 := __args[0]
 			_ = V553
-			reg37089 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37089 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V554 := __args[0]
 				_ = V554
 				if V553 == True {
 					reg37090 := True
-					__ctx.Return(reg37090)
+					__e.Return(reg37090)
 					return
 				} else {
 					if V554 == True {
 						reg37091 := True
-						__ctx.Return(reg37091)
+						__e.Return(reg37091)
 						return
 					} else {
 						reg37092 := False
-						__ctx.Return(reg37092)
+						__e.Return(reg37092)
 						return
 					}
 				}
 			}, 1)
-			__ctx.Return(reg37089)
+			__e.Return(reg37089)
 			return
 		}, 1)
 		reg37093 := PrimCons(reg37087, reg37088)
-		reg37094 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37093)
+		reg37094 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37093)
 		_ = reg37094
 		reg37095 := MakeSymbol("optimise")
-		reg37096 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37096 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V552 := __args[0]
 			_ = V552
-			__ctx.TailApply(__defun__optimise, V552)
+			__e.TailApply(__defun__optimise, V552)
 			return
 		}, 1)
 		reg37098 := PrimCons(reg37095, reg37096)
-		reg37099 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37098)
+		reg37099 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37098)
 		_ = reg37099
 		reg37100 := MakeSymbol("open")
-		reg37101 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37101 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V550 := __args[0]
 			_ = V550
-			reg37102 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37102 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V551 := __args[0]
 				_ = V551
 				reg37103 := PrimOpenStream(V550, V551)
-				__ctx.Return(reg37103)
+				__e.Return(reg37103)
 				return
 			}, 1)
-			__ctx.Return(reg37102)
+			__e.Return(reg37102)
 			return
 		}, 1)
 		reg37104 := PrimCons(reg37100, reg37101)
-		reg37105 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37104)
+		reg37105 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37104)
 		_ = reg37105
 		reg37106 := MakeSymbol("occurrences")
-		reg37107 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37107 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V548 := __args[0]
 			_ = V548
-			reg37108 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37108 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V549 := __args[0]
 				_ = V549
-				__ctx.TailApply(__defun__occurrences, V548, V549)
+				__e.TailApply(__defun__occurrences, V548, V549)
 				return
 			}, 1)
-			__ctx.Return(reg37108)
+			__e.Return(reg37108)
 			return
 		}, 1)
 		reg37110 := PrimCons(reg37106, reg37107)
-		reg37111 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37110)
+		reg37111 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37110)
 		_ = reg37111
 		reg37112 := MakeSymbol("occurs-check")
-		reg37113 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37113 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V547 := __args[0]
 			_ = V547
-			__ctx.TailApply(__defun__occurs_1check, V547)
+			__e.TailApply(__defun__occurs_1check, V547)
 			return
 		}, 1)
 		reg37115 := PrimCons(reg37112, reg37113)
-		reg37116 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37115)
+		reg37116 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37115)
 		_ = reg37116
 		reg37117 := MakeSymbol("n->string")
-		reg37118 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37118 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V546 := __args[0]
 			_ = V546
 			reg37119 := PrimNumberToString(V546)
-			__ctx.Return(reg37119)
+			__e.Return(reg37119)
 			return
 		}, 1)
 		reg37120 := PrimCons(reg37117, reg37118)
-		reg37121 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37120)
+		reg37121 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37120)
 		_ = reg37121
 		reg37122 := MakeSymbol("number?")
-		reg37123 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37123 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V545 := __args[0]
 			_ = V545
 			reg37124 := PrimIsNumber(V545)
-			__ctx.Return(reg37124)
+			__e.Return(reg37124)
 			return
 		}, 1)
 		reg37125 := PrimCons(reg37122, reg37123)
-		reg37126 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37125)
+		reg37126 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37125)
 		_ = reg37126
 		reg37127 := MakeSymbol("nth")
-		reg37128 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37128 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V543 := __args[0]
 			_ = V543
-			reg37129 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37129 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V544 := __args[0]
 				_ = V544
-				__ctx.TailApply(__defun__nth, V543, V544)
+				__e.TailApply(__defun__nth, V543, V544)
 				return
 			}, 1)
-			__ctx.Return(reg37129)
+			__e.Return(reg37129)
 			return
 		}, 1)
 		reg37131 := PrimCons(reg37127, reg37128)
-		reg37132 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37131)
+		reg37132 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37131)
 		_ = reg37132
 		reg37133 := MakeSymbol("not")
-		reg37134 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37134 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V542 := __args[0]
 			_ = V542
 			reg37135 := PrimNot(V542)
-			__ctx.Return(reg37135)
+			__e.Return(reg37135)
 			return
 		}, 1)
 		reg37136 := PrimCons(reg37133, reg37134)
-		reg37137 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37136)
+		reg37137 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37136)
 		_ = reg37137
 		reg37138 := MakeSymbol("nl")
-		reg37139 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37139 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V541 := __args[0]
 			_ = V541
-			__ctx.TailApply(__defun__nl, V541)
+			__e.TailApply(__defun__nl, V541)
 			return
 		}, 1)
 		reg37141 := PrimCons(reg37138, reg37139)
-		reg37142 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37141)
+		reg37142 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37141)
 		_ = reg37142
 		reg37143 := MakeSymbol("macroexpand")
-		reg37144 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37144 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V540 := __args[0]
 			_ = V540
-			__ctx.TailApply(__defun__macroexpand, V540)
+			__e.TailApply(__defun__macroexpand, V540)
 			return
 		}, 1)
 		reg37146 := PrimCons(reg37143, reg37144)
-		reg37147 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37146)
+		reg37147 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37146)
 		_ = reg37147
 		reg37148 := MakeSymbol("maxinferences")
-		reg37149 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37149 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V539 := __args[0]
 			_ = V539
-			__ctx.TailApply(__defun__maxinferences, V539)
+			__e.TailApply(__defun__maxinferences, V539)
 			return
 		}, 1)
 		reg37151 := PrimCons(reg37148, reg37149)
-		reg37152 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37151)
+		reg37152 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37151)
 		_ = reg37152
 		reg37153 := MakeSymbol("mapcan")
-		reg37154 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37154 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V537 := __args[0]
 			_ = V537
-			reg37155 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37155 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V538 := __args[0]
 				_ = V538
-				__ctx.TailApply(__defun__mapcan, V537, V538)
+				__e.TailApply(__defun__mapcan, V537, V538)
 				return
 			}, 1)
-			__ctx.Return(reg37155)
+			__e.Return(reg37155)
 			return
 		}, 1)
 		reg37157 := PrimCons(reg37153, reg37154)
-		reg37158 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37157)
+		reg37158 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37157)
 		_ = reg37158
 		reg37159 := MakeSymbol("map")
-		reg37160 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37160 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V535 := __args[0]
 			_ = V535
-			reg37161 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37161 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V536 := __args[0]
 				_ = V536
-				__ctx.TailApply(__defun__map, V535, V536)
+				__e.TailApply(__defun__map, V535, V536)
 				return
 			}, 1)
-			__ctx.Return(reg37161)
+			__e.Return(reg37161)
 			return
 		}, 1)
 		reg37163 := PrimCons(reg37159, reg37160)
-		reg37164 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37163)
+		reg37164 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37163)
 		_ = reg37164
 		reg37165 := MakeSymbol("load")
-		reg37166 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37166 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V534 := __args[0]
 			_ = V534
-			__ctx.TailApply(__defun__load, V534)
+			__e.TailApply(__defun__load, V534)
 			return
 		}, 1)
 		reg37168 := PrimCons(reg37165, reg37166)
-		reg37169 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37168)
+		reg37169 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37168)
 		_ = reg37169
 		reg37170 := MakeSymbol("lineread")
-		reg37171 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37171 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V533 := __args[0]
 			_ = V533
-			__ctx.TailApply(__defun__lineread, V533)
+			__e.TailApply(__defun__lineread, V533)
 			return
 		}, 1)
 		reg37173 := PrimCons(reg37170, reg37171)
-		reg37174 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37173)
+		reg37174 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37173)
 		_ = reg37174
 		reg37175 := MakeSymbol("limit")
-		reg37176 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37176 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V532 := __args[0]
 			_ = V532
-			__ctx.TailApply(__defun__limit, V532)
+			__e.TailApply(__defun__limit, V532)
 			return
 		}, 1)
 		reg37178 := PrimCons(reg37175, reg37176)
-		reg37179 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37178)
+		reg37179 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37178)
 		_ = reg37179
 		reg37180 := MakeSymbol("length")
-		reg37181 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37181 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V531 := __args[0]
 			_ = V531
-			__ctx.TailApply(__defun__length, V531)
+			__e.TailApply(__defun__length, V531)
 			return
 		}, 1)
 		reg37183 := PrimCons(reg37180, reg37181)
-		reg37184 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37183)
+		reg37184 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37183)
 		_ = reg37184
 		reg37185 := MakeSymbol("intersection")
-		reg37186 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37186 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V529 := __args[0]
 			_ = V529
-			reg37187 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37187 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V530 := __args[0]
 				_ = V530
-				__ctx.TailApply(__defun__intersection, V529, V530)
+				__e.TailApply(__defun__intersection, V529, V530)
 				return
 			}, 1)
-			__ctx.Return(reg37187)
+			__e.Return(reg37187)
 			return
 		}, 1)
 		reg37189 := PrimCons(reg37185, reg37186)
-		reg37190 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37189)
+		reg37190 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37189)
 		_ = reg37190
 		reg37191 := MakeSymbol("intern")
-		reg37192 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37192 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V528 := __args[0]
 			_ = V528
 			reg37193 := PrimIntern(V528)
-			__ctx.Return(reg37193)
+			__e.Return(reg37193)
 			return
 		}, 1)
 		reg37194 := PrimCons(reg37191, reg37192)
-		reg37195 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37194)
+		reg37195 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37194)
 		_ = reg37195
 		reg37196 := MakeSymbol("integer?")
-		reg37197 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37197 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V527 := __args[0]
 			_ = V527
 			reg37198 := PrimIsInteger(V527)
-			__ctx.Return(reg37198)
+			__e.Return(reg37198)
 			return
 		}, 1)
 		reg37199 := PrimCons(reg37196, reg37197)
-		reg37200 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37199)
+		reg37200 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37199)
 		_ = reg37200
 		reg37201 := MakeSymbol("input")
-		reg37202 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37202 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V526 := __args[0]
 			_ = V526
-			__ctx.TailApply(__defun__input, V526)
+			__e.TailApply(__defun__input, V526)
 			return
 		}, 1)
 		reg37204 := PrimCons(reg37201, reg37202)
-		reg37205 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37204)
+		reg37205 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37204)
 		_ = reg37205
 		reg37206 := MakeSymbol("input+")
-		reg37207 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37207 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V524 := __args[0]
 			_ = V524
-			reg37208 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37208 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V525 := __args[0]
 				_ = V525
-				__ctx.TailApply(__defun__input_7, V524, V525)
+				__e.TailApply(__defun__input_7, V524, V525)
 				return
 			}, 1)
-			__ctx.Return(reg37208)
+			__e.Return(reg37208)
 			return
 		}, 1)
 		reg37210 := PrimCons(reg37206, reg37207)
-		reg37211 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37210)
+		reg37211 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37210)
 		_ = reg37211
 		reg37212 := MakeSymbol("include")
-		reg37213 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37213 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V523 := __args[0]
 			_ = V523
-			__ctx.TailApply(__defun__include, V523)
+			__e.TailApply(__defun__include, V523)
 			return
 		}, 1)
 		reg37215 := PrimCons(reg37212, reg37213)
-		reg37216 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37215)
+		reg37216 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37215)
 		_ = reg37216
 		reg37217 := MakeSymbol("include-all-but")
-		reg37218 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37218 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V522 := __args[0]
 			_ = V522
-			__ctx.TailApply(__defun__include_1all_1but, V522)
+			__e.TailApply(__defun__include_1all_1but, V522)
 			return
 		}, 1)
 		reg37220 := PrimCons(reg37217, reg37218)
-		reg37221 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37220)
+		reg37221 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37220)
 		_ = reg37221
 		reg37222 := MakeSymbol("internal")
-		reg37223 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37223 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V521 := __args[0]
 			_ = V521
-			__ctx.TailApply(__defun__internal, V521)
+			__e.TailApply(__defun__internal, V521)
 			return
 		}, 1)
 		reg37225 := PrimCons(reg37222, reg37223)
-		reg37226 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37225)
+		reg37226 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37225)
 		_ = reg37226
 		reg37227 := MakeSymbol("if")
-		reg37228 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37228 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V518 := __args[0]
 			_ = V518
-			reg37229 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37229 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V519 := __args[0]
 				_ = V519
-				reg37230 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg37230 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V520 := __args[0]
 					_ = V520
 					if V518 == True {
-						__ctx.Return(V519)
+						__e.Return(V519)
 						return
 					} else {
-						__ctx.Return(V520)
+						__e.Return(V520)
 						return
 					}
 				}, 1)
-				__ctx.Return(reg37230)
+				__e.Return(reg37230)
 				return
 			}, 1)
-			__ctx.Return(reg37229)
+			__e.Return(reg37229)
 			return
 		}, 1)
 		reg37231 := PrimCons(reg37227, reg37228)
-		reg37232 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37231)
+		reg37232 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37231)
 		_ = reg37232
 		reg37233 := MakeSymbol("identical")
-		reg37234 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37234 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V514 := __args[0]
 			_ = V514
-			reg37235 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37235 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V515 := __args[0]
 				_ = V515
-				reg37236 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg37236 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V516 := __args[0]
 					_ = V516
-					reg37237 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg37237 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						V517 := __args[0]
 						_ = V517
-						__ctx.TailApply(__defun__identical, V514, V515, V516, V517)
+						__e.TailApply(__defun__identical, V514, V515, V516, V517)
 						return
 					}, 1)
-					__ctx.Return(reg37237)
+					__e.Return(reg37237)
 					return
 				}, 1)
-				__ctx.Return(reg37236)
+				__e.Return(reg37236)
 				return
 			}, 1)
-			__ctx.Return(reg37235)
+			__e.Return(reg37235)
 			return
 		}, 1)
 		reg37239 := PrimCons(reg37233, reg37234)
-		reg37240 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37239)
+		reg37240 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37239)
 		_ = reg37240
 		reg37241 := MakeSymbol("head")
-		reg37242 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37242 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V513 := __args[0]
 			_ = V513
-			__ctx.TailApply(__defun__head, V513)
+			__e.TailApply(__defun__head, V513)
 			return
 		}, 1)
 		reg37244 := PrimCons(reg37241, reg37242)
-		reg37245 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37244)
+		reg37245 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37244)
 		_ = reg37245
 		reg37246 := MakeSymbol("hd")
-		reg37247 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37247 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V512 := __args[0]
 			_ = V512
 			reg37248 := PrimHead(V512)
-			__ctx.Return(reg37248)
+			__e.Return(reg37248)
 			return
 		}, 1)
 		reg37249 := PrimCons(reg37246, reg37247)
-		reg37250 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37249)
+		reg37250 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37249)
 		_ = reg37250
 		reg37251 := MakeSymbol("hdv")
-		reg37252 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37252 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V511 := __args[0]
 			_ = V511
-			__ctx.TailApply(__defun__hdv, V511)
+			__e.TailApply(__defun__hdv, V511)
 			return
 		}, 1)
 		reg37254 := PrimCons(reg37251, reg37252)
-		reg37255 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37254)
+		reg37255 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37254)
 		_ = reg37255
 		reg37256 := MakeSymbol("hdstr")
-		reg37257 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37257 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V510 := __args[0]
 			_ = V510
-			__ctx.TailApply(__defun__hdstr, V510)
+			__e.TailApply(__defun__hdstr, V510)
 			return
 		}, 1)
 		reg37259 := PrimCons(reg37256, reg37257)
-		reg37260 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37259)
+		reg37260 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37259)
 		_ = reg37260
 		reg37261 := MakeSymbol("hash")
-		reg37262 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37262 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V508 := __args[0]
 			_ = V508
-			reg37263 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37263 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V509 := __args[0]
 				_ = V509
-				__ctx.TailApply(__defun__hash, V508, V509)
+				__e.TailApply(__defun__hash, V508, V509)
 				return
 			}, 1)
-			__ctx.Return(reg37263)
+			__e.Return(reg37263)
 			return
 		}, 1)
 		reg37265 := PrimCons(reg37261, reg37262)
-		reg37266 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37265)
+		reg37266 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37265)
 		_ = reg37266
 		reg37267 := MakeSymbol("get")
-		reg37268 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37268 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V505 := __args[0]
 			_ = V505
-			reg37269 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37269 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V506 := __args[0]
 				_ = V506
-				reg37270 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg37270 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V507 := __args[0]
 					_ = V507
-					__ctx.TailApply(__defun__get, V505, V506, V507)
+					__e.TailApply(__defun__get, V505, V506, V507)
 					return
 				}, 1)
-				__ctx.Return(reg37270)
+				__e.Return(reg37270)
 				return
 			}, 1)
-			__ctx.Return(reg37269)
+			__e.Return(reg37269)
 			return
 		}, 1)
 		reg37272 := PrimCons(reg37267, reg37268)
-		reg37273 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37272)
+		reg37273 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37272)
 		_ = reg37273
 		reg37274 := MakeSymbol("get-time")
-		reg37275 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37275 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V504 := __args[0]
 			_ = V504
 			reg37276 := PrimGetTime(V504)
-			__ctx.Return(reg37276)
+			__e.Return(reg37276)
 			return
 		}, 1)
 		reg37277 := PrimCons(reg37274, reg37275)
-		reg37278 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37277)
+		reg37278 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37277)
 		_ = reg37278
 		reg37279 := MakeSymbol("gensym")
-		reg37280 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37280 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V503 := __args[0]
 			_ = V503
-			__ctx.TailApply(__defun__gensym, V503)
+			__e.TailApply(__defun__gensym, V503)
 			return
 		}, 1)
 		reg37282 := PrimCons(reg37279, reg37280)
-		reg37283 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37282)
+		reg37283 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37282)
 		_ = reg37283
 		reg37284 := MakeSymbol("fst")
-		reg37285 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37285 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V502 := __args[0]
 			_ = V502
-			__ctx.TailApply(__defun__fst, V502)
+			__e.TailApply(__defun__fst, V502)
 			return
 		}, 1)
 		reg37287 := PrimCons(reg37284, reg37285)
-		reg37288 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37287)
+		reg37288 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37287)
 		_ = reg37288
 		reg37289 := MakeSymbol("freeze")
-		reg37290 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37290 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V501 := __args[0]
 			_ = V501
-			reg37291 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-				__ctx.Return(V501)
+			reg37291 := MakeNative(func(__e Evaluator, __args ...Obj) {
+				__e.Return(V501)
 				return
 			}, 0)
-			__ctx.Return(reg37291)
+			__e.Return(reg37291)
 			return
 		}, 1)
 		reg37292 := PrimCons(reg37289, reg37290)
-		reg37293 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37292)
+		reg37293 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37292)
 		_ = reg37293
 		reg37294 := MakeSymbol("fix")
-		reg37295 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37295 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V499 := __args[0]
 			_ = V499
-			reg37296 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37296 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V500 := __args[0]
 				_ = V500
-				__ctx.TailApply(__defun__fix, V499, V500)
+				__e.TailApply(__defun__fix, V499, V500)
 				return
 			}, 1)
-			__ctx.Return(reg37296)
+			__e.Return(reg37296)
 			return
 		}, 1)
 		reg37298 := PrimCons(reg37294, reg37295)
-		reg37299 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37298)
+		reg37299 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37298)
 		_ = reg37299
 		reg37300 := MakeSymbol("fail-if")
-		reg37301 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37301 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V497 := __args[0]
 			_ = V497
-			reg37302 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37302 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V498 := __args[0]
 				_ = V498
-				__ctx.TailApply(__defun__fail_1if, V497, V498)
+				__e.TailApply(__defun__fail_1if, V497, V498)
 				return
 			}, 1)
-			__ctx.Return(reg37302)
+			__e.Return(reg37302)
 			return
 		}, 1)
 		reg37304 := PrimCons(reg37300, reg37301)
-		reg37305 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37304)
+		reg37305 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37304)
 		_ = reg37305
 		reg37306 := MakeSymbol("findall")
-		reg37307 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37307 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V492 := __args[0]
 			_ = V492
-			reg37308 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37308 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V493 := __args[0]
 				_ = V493
-				reg37309 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg37309 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V494 := __args[0]
 					_ = V494
-					reg37310 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg37310 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						V495 := __args[0]
 						_ = V495
-						reg37311 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+						reg37311 := MakeNative(func(__e Evaluator, __args ...Obj) {
 							V496 := __args[0]
 							_ = V496
-							__ctx.TailApply(__defun__findall, V492, V493, V494, V495, V496)
+							__e.TailApply(__defun__findall, V492, V493, V494, V495, V496)
 							return
 						}, 1)
-						__ctx.Return(reg37311)
+						__e.Return(reg37311)
 						return
 					}, 1)
-					__ctx.Return(reg37310)
+					__e.Return(reg37310)
 					return
 				}, 1)
-				__ctx.Return(reg37309)
+				__e.Return(reg37309)
 				return
 			}, 1)
-			__ctx.Return(reg37308)
+			__e.Return(reg37308)
 			return
 		}, 1)
 		reg37313 := PrimCons(reg37306, reg37307)
-		reg37314 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37313)
+		reg37314 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37313)
 		_ = reg37314
 		reg37315 := MakeSymbol("enable-type-theory")
-		reg37316 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37316 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V491 := __args[0]
 			_ = V491
-			__ctx.TailApply(__defun__enable_1type_1theory, V491)
+			__e.TailApply(__defun__enable_1type_1theory, V491)
 			return
 		}, 1)
 		reg37318 := PrimCons(reg37315, reg37316)
-		reg37319 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37318)
+		reg37319 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37318)
 		_ = reg37319
 		reg37320 := MakeSymbol("explode")
-		reg37321 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37321 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V490 := __args[0]
 			_ = V490
-			__ctx.TailApply(__defun__explode, V490)
+			__e.TailApply(__defun__explode, V490)
 			return
 		}, 1)
 		reg37323 := PrimCons(reg37320, reg37321)
-		reg37324 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37323)
+		reg37324 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37323)
 		_ = reg37324
 		reg37325 := MakeSymbol("external")
-		reg37326 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37326 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V489 := __args[0]
 			_ = V489
-			__ctx.TailApply(__defun__external, V489)
+			__e.TailApply(__defun__external, V489)
 			return
 		}, 1)
 		reg37328 := PrimCons(reg37325, reg37326)
-		reg37329 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37328)
+		reg37329 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37328)
 		_ = reg37329
 		reg37330 := MakeSymbol("eval-kl")
-		reg37331 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37331 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V488 := __args[0]
 			_ = V488
 			reg37332 := PrimEvalKL(__e, V488)
-			__ctx.Return(reg37332)
+			__e.Return(reg37332)
 			return
 		}, 1)
 		reg37333 := PrimCons(reg37330, reg37331)
-		reg37334 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37333)
+		reg37334 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37333)
 		_ = reg37334
 		reg37335 := MakeSymbol("eval")
-		reg37336 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37336 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V487 := __args[0]
 			_ = V487
-			__ctx.TailApply(__defun__eval, V487)
+			__e.TailApply(__defun__eval, V487)
 			return
 		}, 1)
 		reg37338 := PrimCons(reg37335, reg37336)
-		reg37339 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37338)
+		reg37339 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37338)
 		_ = reg37339
 		reg37340 := MakeSymbol("error-to-string")
-		reg37341 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37341 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V486 := __args[0]
 			_ = V486
 			reg37342 := PrimErrorToString(V486)
-			__ctx.Return(reg37342)
+			__e.Return(reg37342)
 			return
 		}, 1)
 		reg37343 := PrimCons(reg37340, reg37341)
-		reg37344 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37343)
+		reg37344 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37343)
 		_ = reg37344
 		reg37345 := MakeSymbol("empty?")
-		reg37346 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37346 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V485 := __args[0]
 			_ = V485
-			__ctx.TailApply(__defun__empty_2, V485)
+			__e.TailApply(__defun__empty_2, V485)
 			return
 		}, 1)
 		reg37348 := PrimCons(reg37345, reg37346)
-		reg37349 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37348)
+		reg37349 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37348)
 		_ = reg37349
 		reg37350 := MakeSymbol("element?")
-		reg37351 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37351 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V483 := __args[0]
 			_ = V483
-			reg37352 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37352 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V484 := __args[0]
 				_ = V484
-				__ctx.TailApply(__defun__element_2, V483, V484)
+				__e.TailApply(__defun__element_2, V483, V484)
 				return
 			}, 1)
-			__ctx.Return(reg37352)
+			__e.Return(reg37352)
 			return
 		}, 1)
 		reg37354 := PrimCons(reg37350, reg37351)
-		reg37355 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37354)
+		reg37355 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37354)
 		_ = reg37355
 		reg37356 := MakeSymbol("do")
-		reg37357 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37357 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V481 := __args[0]
 			_ = V481
-			reg37358 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37358 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V482 := __args[0]
 				_ = V482
 				_ = V481
-				__ctx.Return(V482)
+				__e.Return(V482)
 				return
 			}, 1)
-			__ctx.Return(reg37358)
+			__e.Return(reg37358)
 			return
 		}, 1)
 		reg37359 := PrimCons(reg37356, reg37357)
-		reg37360 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37359)
+		reg37360 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37359)
 		_ = reg37360
 		reg37361 := MakeSymbol("difference")
-		reg37362 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37362 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V479 := __args[0]
 			_ = V479
-			reg37363 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37363 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V480 := __args[0]
 				_ = V480
-				__ctx.TailApply(__defun__difference, V479, V480)
+				__e.TailApply(__defun__difference, V479, V480)
 				return
 			}, 1)
-			__ctx.Return(reg37363)
+			__e.Return(reg37363)
 			return
 		}, 1)
 		reg37365 := PrimCons(reg37361, reg37362)
-		reg37366 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37365)
+		reg37366 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37365)
 		_ = reg37366
 		reg37367 := MakeSymbol("destroy")
-		reg37368 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37368 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V478 := __args[0]
 			_ = V478
-			__ctx.TailApply(__defun__destroy, V478)
+			__e.TailApply(__defun__destroy, V478)
 			return
 		}, 1)
 		reg37370 := PrimCons(reg37367, reg37368)
-		reg37371 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37370)
+		reg37371 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37370)
 		_ = reg37371
 		reg37372 := MakeSymbol("declare")
-		reg37373 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37373 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V476 := __args[0]
 			_ = V476
-			reg37374 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37374 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V477 := __args[0]
 				_ = V477
-				__ctx.TailApply(__defun__declare, V476, V477)
+				__e.TailApply(__defun__declare, V476, V477)
 				return
 			}, 1)
-			__ctx.Return(reg37374)
+			__e.Return(reg37374)
 			return
 		}, 1)
 		reg37376 := PrimCons(reg37372, reg37373)
-		reg37377 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37376)
+		reg37377 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37376)
 		_ = reg37377
 		reg37378 := MakeSymbol("cn")
-		reg37379 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37379 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V474 := __args[0]
 			_ = V474
-			reg37380 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37380 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V475 := __args[0]
 				_ = V475
 				reg37381 := PrimStringConcat(V474, V475)
-				__ctx.Return(reg37381)
+				__e.Return(reg37381)
 				return
 			}, 1)
-			__ctx.Return(reg37380)
+			__e.Return(reg37380)
 			return
 		}, 1)
 		reg37382 := PrimCons(reg37378, reg37379)
-		reg37383 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37382)
+		reg37383 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37382)
 		_ = reg37383
 		reg37384 := MakeSymbol("cons?")
-		reg37385 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37385 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V473 := __args[0]
 			_ = V473
 			reg37386 := PrimIsPair(V473)
-			__ctx.Return(reg37386)
+			__e.Return(reg37386)
 			return
 		}, 1)
 		reg37387 := PrimCons(reg37384, reg37385)
-		reg37388 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37387)
+		reg37388 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37387)
 		_ = reg37388
 		reg37389 := MakeSymbol("cons")
-		reg37390 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37390 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V471 := __args[0]
 			_ = V471
-			reg37391 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37391 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V472 := __args[0]
 				_ = V472
 				reg37392 := PrimCons(V471, V472)
-				__ctx.Return(reg37392)
+				__e.Return(reg37392)
 				return
 			}, 1)
-			__ctx.Return(reg37391)
+			__e.Return(reg37391)
 			return
 		}, 1)
 		reg37393 := PrimCons(reg37389, reg37390)
-		reg37394 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37393)
+		reg37394 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37393)
 		_ = reg37394
 		reg37395 := MakeSymbol("concat")
-		reg37396 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37396 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V469 := __args[0]
 			_ = V469
-			reg37397 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37397 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V470 := __args[0]
 				_ = V470
-				__ctx.TailApply(__defun__concat, V469, V470)
+				__e.TailApply(__defun__concat, V469, V470)
 				return
 			}, 1)
-			__ctx.Return(reg37397)
+			__e.Return(reg37397)
 			return
 		}, 1)
 		reg37399 := PrimCons(reg37395, reg37396)
-		reg37400 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37399)
+		reg37400 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37399)
 		_ = reg37400
 		reg37401 := MakeSymbol("compile")
-		reg37402 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37402 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V466 := __args[0]
 			_ = V466
-			reg37403 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37403 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V467 := __args[0]
 				_ = V467
-				reg37404 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg37404 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V468 := __args[0]
 					_ = V468
-					__ctx.TailApply(__defun__compile, V466, V467, V468)
+					__e.TailApply(__defun__compile, V466, V467, V468)
 					return
 				}, 1)
-				__ctx.Return(reg37404)
+				__e.Return(reg37404)
 				return
 			}, 1)
-			__ctx.Return(reg37403)
+			__e.Return(reg37403)
 			return
 		}, 1)
 		reg37406 := PrimCons(reg37401, reg37402)
-		reg37407 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37406)
+		reg37407 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37406)
 		_ = reg37407
 		reg37408 := MakeSymbol("cd")
-		reg37409 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37409 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V465 := __args[0]
 			_ = V465
-			__ctx.TailApply(__defun__cd, V465)
+			__e.TailApply(__defun__cd, V465)
 			return
 		}, 1)
 		reg37411 := PrimCons(reg37408, reg37409)
-		reg37412 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37411)
+		reg37412 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37411)
 		_ = reg37412
 		reg37413 := MakeSymbol("close")
-		reg37414 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37414 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V464 := __args[0]
 			_ = V464
 			reg37415 := PrimCloseStream(V464)
-			__ctx.Return(reg37415)
+			__e.Return(reg37415)
 			return
 		}, 1)
 		reg37416 := PrimCons(reg37413, reg37414)
-		reg37417 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37416)
+		reg37417 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37416)
 		_ = reg37417
 		reg37418 := MakeSymbol("bound?")
-		reg37419 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37419 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V463 := __args[0]
 			_ = V463
-			__ctx.TailApply(__defun__bound_2, V463)
+			__e.TailApply(__defun__bound_2, V463)
 			return
 		}, 1)
 		reg37421 := PrimCons(reg37418, reg37419)
-		reg37422 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37421)
+		reg37422 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37421)
 		_ = reg37422
 		reg37423 := MakeSymbol("boolean?")
-		reg37424 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37424 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V462 := __args[0]
 			_ = V462
-			__ctx.TailApply(__defun__boolean_2, V462)
+			__e.TailApply(__defun__boolean_2, V462)
 			return
 		}, 1)
 		reg37426 := PrimCons(reg37423, reg37424)
-		reg37427 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37426)
+		reg37427 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37426)
 		_ = reg37427
 		reg37428 := MakeSymbol("assoc")
-		reg37429 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37429 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V460 := __args[0]
 			_ = V460
-			reg37430 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37430 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V461 := __args[0]
 				_ = V461
-				__ctx.TailApply(__defun__assoc, V460, V461)
+				__e.TailApply(__defun__assoc, V460, V461)
 				return
 			}, 1)
-			__ctx.Return(reg37430)
+			__e.Return(reg37430)
 			return
 		}, 1)
 		reg37432 := PrimCons(reg37428, reg37429)
-		reg37433 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37432)
+		reg37433 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37432)
 		_ = reg37433
 		reg37434 := MakeSymbol("arity")
-		reg37435 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37435 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V459 := __args[0]
 			_ = V459
-			__ctx.TailApply(__defun__arity, V459)
+			__e.TailApply(__defun__arity, V459)
 			return
 		}, 1)
 		reg37437 := PrimCons(reg37434, reg37435)
-		reg37438 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37437)
+		reg37438 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37437)
 		_ = reg37438
 		reg37439 := MakeSymbol("append")
-		reg37440 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37440 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V457 := __args[0]
 			_ = V457
-			reg37441 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37441 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V458 := __args[0]
 				_ = V458
-				__ctx.TailApply(__defun__append, V457, V458)
+				__e.TailApply(__defun__append, V457, V458)
 				return
 			}, 1)
-			__ctx.Return(reg37441)
+			__e.Return(reg37441)
 			return
 		}, 1)
 		reg37443 := PrimCons(reg37439, reg37440)
-		reg37444 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37443)
+		reg37444 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37443)
 		_ = reg37444
 		reg37445 := MakeSymbol("and")
-		reg37446 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37446 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V455 := __args[0]
 			_ = V455
-			reg37447 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37447 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V456 := __args[0]
 				_ = V456
 				if V455 == True {
 					if V456 == True {
 						reg37448 := True
-						__ctx.Return(reg37448)
+						__e.Return(reg37448)
 						return
 					} else {
 						reg37449 := False
-						__ctx.Return(reg37449)
+						__e.Return(reg37449)
 						return
 					}
 				} else {
 					reg37450 := False
-					__ctx.Return(reg37450)
+					__e.Return(reg37450)
 					return
 				}
 			}, 1)
-			__ctx.Return(reg37447)
+			__e.Return(reg37447)
 			return
 		}, 1)
 		reg37451 := PrimCons(reg37445, reg37446)
-		reg37452 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37451)
+		reg37452 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37451)
 		_ = reg37452
 		reg37453 := MakeSymbol("adjoin")
-		reg37454 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37454 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V453 := __args[0]
 			_ = V453
-			reg37455 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37455 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V454 := __args[0]
 				_ = V454
-				__ctx.TailApply(__defun__adjoin, V453, V454)
+				__e.TailApply(__defun__adjoin, V453, V454)
 				return
 			}, 1)
-			__ctx.Return(reg37455)
+			__e.Return(reg37455)
 			return
 		}, 1)
 		reg37457 := PrimCons(reg37453, reg37454)
-		reg37458 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37457)
+		reg37458 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37457)
 		_ = reg37458
 		reg37459 := MakeSymbol("<-address")
-		reg37460 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37460 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V451 := __args[0]
 			_ = V451
-			reg37461 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37461 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V452 := __args[0]
 				_ = V452
 				reg37462 := PrimVectorGet(V451, V452)
-				__ctx.Return(reg37462)
+				__e.Return(reg37462)
 				return
 			}, 1)
-			__ctx.Return(reg37461)
+			__e.Return(reg37461)
 			return
 		}, 1)
 		reg37463 := PrimCons(reg37459, reg37460)
-		reg37464 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37463)
+		reg37464 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37463)
 		_ = reg37464
 		reg37465 := MakeSymbol("address->")
-		reg37466 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37466 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V448 := __args[0]
 			_ = V448
-			reg37467 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg37467 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				V449 := __args[0]
 				_ = V449
-				reg37468 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg37468 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					V450 := __args[0]
 					_ = V450
 					reg37469 := PrimVectorSet(V448, V449, V450)
-					__ctx.Return(reg37469)
+					__e.Return(reg37469)
 					return
 				}, 1)
-				__ctx.Return(reg37468)
+				__e.Return(reg37468)
 				return
 			}, 1)
-			__ctx.Return(reg37467)
+			__e.Return(reg37467)
 			return
 		}, 1)
 		reg37470 := PrimCons(reg37465, reg37466)
-		reg37471 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37470)
+		reg37471 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37470)
 		_ = reg37471
 		reg37472 := MakeSymbol("absvector?")
-		reg37473 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37473 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V447 := __args[0]
 			_ = V447
 			reg37474 := PrimIsVector(V447)
-			__ctx.Return(reg37474)
+			__e.Return(reg37474)
 			return
 		}, 1)
 		reg37475 := PrimCons(reg37472, reg37473)
-		reg37476 := __e.Call(__defun__shen_4set_1lambda_1form_1entry, reg37475)
+		reg37476 := Call(__e, __defun__shen_4set_1lambda_1form_1entry, reg37475)
 		_ = reg37476
 		reg37477 := MakeSymbol("absvector")
-		reg37478 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg37478 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			V446 := __args[0]
 			_ = V446
 			reg37479 := PrimAbsvector(V446)
-			__ctx.Return(reg37479)
+			__e.Return(reg37479)
 			return
 		}, 1)
 		reg37480 := PrimCons(reg37477, reg37478)
-		__ctx.TailApply(__defun__shen_4set_1lambda_1form_1entry, reg37480)
+		__e.TailApply(__defun__shen_4set_1lambda_1form_1entry, reg37480)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.initialise-lambda-forms", value: __defun__shen_4initialise_1lambda_1forms})
 
-	__defun__shen_4initialise = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-		reg37482 := __e.Call(__defun__shen_4initialise_1environment)
+	__defun__shen_4initialise = MakeNative(func(__e Evaluator, __args ...Obj) {
+		reg37482 := Call(__e, __defun__shen_4initialise_1environment)
 		_ = reg37482
-		reg37483 := __e.Call(__defun__shen_4initialise_1lambda_1forms)
+		reg37483 := Call(__e, __defun__shen_4initialise_1lambda_1forms)
 		_ = reg37483
-		reg37484 := __e.Call(__defun__shen_4initialise_1signedfunc_1lambda_1forms)
+		reg37484 := Call(__e, __defun__shen_4initialise_1signedfunc_1lambda_1forms)
 		_ = reg37484
-		__ctx.TailApply(__defun__shen_4initialise_1signedfuncs)
+		__e.TailApply(__defun__shen_4initialise_1signedfuncs)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.initialise", value: __defun__shen_4initialise})

--- a/cmd/shen/load.go
+++ b/cmd/shen/load.go
@@ -15,12 +15,12 @@ var __defun__shen_4_5sig_7rest_6 Obj        // shen.<sig+rest>
 var __defun__write_1to_1file Obj            // write-to-file
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg16463 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg16463)
+		__e.Return(reg16463)
 		return
 	}, 0))
-	__defun__load = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__load = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V671 := __args[0]
 		_ = V671
 		reg16464 := MakeSymbol("run")
@@ -29,8 +29,8 @@ func init() {
 		_ = Start
 		reg16466 := MakeSymbol("shen.*tc*")
 		reg16467 := PrimValue(reg16466)
-		reg16468 := __e.Call(__defun__read_1file, V671)
-		reg16469 := __e.Call(__defun__shen_4load_1help, reg16467, reg16468)
+		reg16468 := Call(__e, __defun__read_1file, V671)
+		reg16469 := Call(__e, __defun__shen_4load_1help, reg16467, reg16468)
 		Result := reg16469
 		_ = Result
 		reg16470 := MakeSymbol("run")
@@ -45,8 +45,8 @@ func init() {
 		reg16475 := MakeString(" secs\n")
 		reg16476 := PrimStringConcat(reg16474, reg16475)
 		reg16477 := PrimStringConcat(reg16473, reg16476)
-		reg16478 := __e.Call(__defun__stoutput)
-		reg16479 := __e.Call(__defun__shen_4prhush, reg16477, reg16478)
+		reg16478 := Call(__e, __defun__stoutput)
+		reg16479 := Call(__e, __defun__shen_4prhush, reg16477, reg16478)
 		Message := reg16479
 		_ = Message
 		Load := Result
@@ -56,13 +56,13 @@ func init() {
 		var reg16491 Obj
 		if reg16481 == True {
 			reg16482 := MakeString("\ntypechecked in ")
-			reg16483 := __e.Call(__defun__inferences)
+			reg16483 := Call(__e, __defun__inferences)
 			reg16484 := MakeString(" inferences\n")
 			reg16485 := MakeSymbol("shen.a")
-			reg16486 := __e.Call(__defun__shen_4app, reg16483, reg16484, reg16485)
+			reg16486 := Call(__e, __defun__shen_4app, reg16483, reg16484, reg16485)
 			reg16487 := PrimStringConcat(reg16482, reg16486)
-			reg16488 := __e.Call(__defun__stoutput)
-			reg16489 := __e.Call(__defun__shen_4prhush, reg16487, reg16488)
+			reg16488 := Call(__e, __defun__stoutput)
+			reg16489 := Call(__e, __defun__shen_4prhush, reg16487, reg16488)
 			reg16491 = reg16489
 		} else {
 			reg16490 := MakeSymbol("shen.skip")
@@ -71,12 +71,12 @@ func init() {
 		Infs := reg16491
 		_ = Infs
 		reg16492 := MakeSymbol("loaded")
-		__ctx.Return(reg16492)
+		__e.Return(reg16492)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "load", value: __defun__load})
 
-	__defun__shen_4load_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4load_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V678 := __args[0]
 		_ = V678
 		V679 := __args[1]
@@ -84,71 +84,71 @@ func init() {
 		reg16493 := False
 		reg16494 := PrimEqual(reg16493, V678)
 		if reg16494 == True {
-			reg16495 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg16495 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				reg16496 := __e.Call(__defun__shen_4eval_1without_1macros, X)
+				reg16496 := Call(__e, __defun__shen_4eval_1without_1macros, X)
 				reg16497 := MakeString("\n")
 				reg16498 := MakeSymbol("shen.s")
-				reg16499 := __e.Call(__defun__shen_4app, reg16496, reg16497, reg16498)
-				reg16500 := __e.Call(__defun__stoutput)
-				__ctx.TailApply(__defun__shen_4prhush, reg16499, reg16500)
+				reg16499 := Call(__e, __defun__shen_4app, reg16496, reg16497, reg16498)
+				reg16500 := Call(__e, __defun__stoutput)
+				__e.TailApply(__defun__shen_4prhush, reg16499, reg16500)
 				return
 			}, 1)
-			__ctx.TailApply(__defun__shen_4for_1each, reg16495, V679)
+			__e.TailApply(__defun__shen_4for_1each, reg16495, V679)
 			return
 		} else {
-			reg16503 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg16503 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				__ctx.TailApply(__defun__shen_4remove_1synonyms, X)
+				__e.TailApply(__defun__shen_4remove_1synonyms, X)
 				return
 			}, 1)
-			reg16505 := __e.Call(__defun__mapcan, reg16503, V679)
+			reg16505 := Call(__e, __defun__mapcan, reg16503, V679)
 			RemoveSynonyms := reg16505
 			_ = RemoveSynonyms
-			reg16506 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg16506 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				__ctx.TailApply(__defun__shen_4typetable, X)
+				__e.TailApply(__defun__shen_4typetable, X)
 				return
 			}, 1)
-			reg16508 := __e.Call(__defun__mapcan, reg16506, RemoveSynonyms)
+			reg16508 := Call(__e, __defun__mapcan, reg16506, RemoveSynonyms)
 			Table := reg16508
 			_ = Table
-			reg16509 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg16509 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				__ctx.TailApply(__defun__shen_4assumetype, X)
+				__e.TailApply(__defun__shen_4assumetype, X)
 				return
 			}, 1)
-			reg16511 := __e.Call(__defun__shen_4for_1each, reg16509, Table)
+			reg16511 := Call(__e, __defun__shen_4for_1each, reg16509, Table)
 			Assume := reg16511
 			_ = Assume
-			reg16512 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-				reg16513 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg16512 := MakeNative(func(__e Evaluator, __args ...Obj) {
+				reg16513 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					X := __args[0]
 					_ = X
-					__ctx.TailApply(__defun__shen_4typecheck_1and_1load, X)
+					__e.TailApply(__defun__shen_4typecheck_1and_1load, X)
 					return
 				}, 1)
-				__ctx.TailApply(__defun__shen_4for_1each, reg16513, RemoveSynonyms)
+				__e.TailApply(__defun__shen_4for_1each, reg16513, RemoveSynonyms)
 				return
 			}, 0)
-			reg16516 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg16516 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
-				__ctx.TailApply(__defun__shen_4unwind_1types, E, Table)
+				__e.TailApply(__defun__shen_4unwind_1types, E, Table)
 				return
 			}, 1)
-			reg16518 := __e.Try(reg16512).Catch(reg16516)
-			__ctx.Return(reg16518)
+			reg16518 := Try(__e, reg16512).Catch(reg16516)
+			__e.Return(reg16518)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.load-help", value: __defun__shen_4load_1help})
 
-	__defun__shen_4remove_1synonyms = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4remove_1synonyms = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V681 := __args[0]
 		_ = V681
 		reg16519 := PrimIsPair(V681)
@@ -171,34 +171,34 @@ func init() {
 			reg16527 = reg16526
 		}
 		if reg16527 == True {
-			reg16528 := __e.Call(__defun__eval, V681)
+			reg16528 := Call(__e, __defun__eval, V681)
 			_ = reg16528
 			reg16529 := Nil
-			__ctx.Return(reg16529)
+			__e.Return(reg16529)
 			return
 		} else {
 			reg16530 := Nil
 			reg16531 := PrimCons(V681, reg16530)
-			__ctx.Return(reg16531)
+			__e.Return(reg16531)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.remove-synonyms", value: __defun__shen_4remove_1synonyms})
 
-	__defun__shen_4typecheck_1and_1load = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4typecheck_1and_1load = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V683 := __args[0]
 		_ = V683
 		reg16532 := MakeNumber(1)
-		reg16533 := __e.Call(__defun__nl, reg16532)
+		reg16533 := Call(__e, __defun__nl, reg16532)
 		_ = reg16533
 		reg16534 := MakeSymbol("A")
-		reg16535 := __e.Call(__defun__gensym, reg16534)
-		__ctx.TailApply(__defun__shen_4typecheck_1and_1evaluate, V683, reg16535)
+		reg16535 := Call(__e, __defun__gensym, reg16534)
+		__e.TailApply(__defun__shen_4typecheck_1and_1evaluate, V683, reg16535)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.typecheck-and-load", value: __defun__shen_4typecheck_1and_1load})
 
-	__defun__shen_4typetable = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4typetable = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V689 := __args[0]
 		_ = V689
 		reg16537 := PrimIsPair(V689)
@@ -238,27 +238,27 @@ func init() {
 			reg16552 = reg16551
 		}
 		if reg16552 == True {
-			reg16553 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg16553 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Y := __args[0]
 				_ = Y
-				__ctx.TailApply(__defun__shen_4_5sig_7rest_6, Y)
+				__e.TailApply(__defun__shen_4_5sig_7rest_6, Y)
 				return
 			}, 1)
 			reg16555 := PrimTail(V689)
 			reg16556 := PrimTail(reg16555)
-			reg16557 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg16557 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg16558 := PrimTail(V689)
 				reg16559 := PrimHead(reg16558)
 				reg16560 := MakeString(" lacks a proper signature.\n")
 				reg16561 := MakeSymbol("shen.a")
-				reg16562 := __e.Call(__defun__shen_4app, reg16559, reg16560, reg16561)
+				reg16562 := Call(__e, __defun__shen_4app, reg16559, reg16560, reg16561)
 				reg16563 := PrimSimpleError(reg16562)
-				__ctx.Return(reg16563)
+				__e.Return(reg16563)
 				return
 			}, 1)
-			reg16564 := __e.Call(__defun__compile, reg16553, reg16556, reg16557)
+			reg16564 := Call(__e, __defun__compile, reg16553, reg16556, reg16557)
 			Sig := reg16564
 			_ = Sig
 			reg16565 := PrimTail(V689)
@@ -266,34 +266,34 @@ func init() {
 			reg16567 := PrimCons(reg16566, Sig)
 			reg16568 := Nil
 			reg16569 := PrimCons(reg16567, reg16568)
-			__ctx.Return(reg16569)
+			__e.Return(reg16569)
 			return
 		} else {
 			reg16570 := Nil
-			__ctx.Return(reg16570)
+			__e.Return(reg16570)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.typetable", value: __defun__shen_4typetable})
 
-	__defun__shen_4assumetype = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4assumetype = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V691 := __args[0]
 		_ = V691
 		reg16571 := PrimIsPair(V691)
 		if reg16571 == True {
 			reg16572 := PrimHead(V691)
 			reg16573 := PrimTail(V691)
-			__ctx.TailApply(__defun__declare, reg16572, reg16573)
+			__e.TailApply(__defun__declare, reg16572, reg16573)
 			return
 		} else {
 			reg16575 := MakeSymbol("shen.assumetype")
-			__ctx.TailApply(__defun__shen_4f__error, reg16575)
+			__e.TailApply(__defun__shen_4f__error, reg16575)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.assumetype", value: __defun__shen_4assumetype})
 
-	__defun__shen_4unwind_1types = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4unwind_1types = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V698 := __args[0]
 		_ = V698
 		V699 := __args[1]
@@ -303,7 +303,7 @@ func init() {
 		if reg16578 == True {
 			reg16579 := PrimErrorToString(V698)
 			reg16580 := PrimSimpleError(reg16579)
-			__ctx.Return(reg16580)
+			__e.Return(reg16580)
 			return
 		} else {
 			reg16581 := PrimIsPair(V699)
@@ -327,34 +327,34 @@ func init() {
 			if reg16588 == True {
 				reg16589 := PrimHead(V699)
 				reg16590 := PrimHead(reg16589)
-				reg16591 := __e.Call(__defun__shen_4remtype, reg16590)
+				reg16591 := Call(__e, __defun__shen_4remtype, reg16590)
 				_ = reg16591
 				reg16592 := PrimTail(V699)
-				__ctx.TailApply(__defun__shen_4unwind_1types, V698, reg16592)
+				__e.TailApply(__defun__shen_4unwind_1types, V698, reg16592)
 				return
 			} else {
 				reg16594 := MakeSymbol("shen.unwind-types")
-				__ctx.TailApply(__defun__shen_4f__error, reg16594)
+				__e.TailApply(__defun__shen_4f__error, reg16594)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.unwind-types", value: __defun__shen_4unwind_1types})
 
-	__defun__shen_4remtype = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4remtype = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V701 := __args[0]
 		_ = V701
 		reg16596 := MakeSymbol("shen.*signedfuncs*")
 		reg16597 := MakeSymbol("shen.*signedfuncs*")
 		reg16598 := PrimValue(reg16597)
-		reg16599 := __e.Call(__defun__shen_4removetype, V701, reg16598)
+		reg16599 := Call(__e, __defun__shen_4removetype, V701, reg16598)
 		reg16600 := PrimSet(reg16596, reg16599)
-		__ctx.Return(reg16600)
+		__e.Return(reg16600)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.remtype", value: __defun__shen_4remtype})
 
-	__defun__shen_4removetype = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4removetype = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V709 := __args[0]
 		_ = V709
 		V710 := __args[1]
@@ -363,7 +363,7 @@ func init() {
 		reg16602 := PrimEqual(reg16601, V710)
 		if reg16602 == True {
 			reg16603 := Nil
-			__ctx.Return(reg16603)
+			__e.Return(reg16603)
 			return
 		} else {
 			reg16604 := PrimIsPair(V710)
@@ -406,20 +406,20 @@ func init() {
 				reg16620 := PrimHead(V710)
 				reg16621 := PrimHead(reg16620)
 				reg16622 := PrimTail(V710)
-				__ctx.TailApply(__defun__shen_4removetype, reg16621, reg16622)
+				__e.TailApply(__defun__shen_4removetype, reg16621, reg16622)
 				return
 			} else {
 				reg16624 := PrimIsPair(V710)
 				if reg16624 == True {
 					reg16625 := PrimHead(V710)
 					reg16626 := PrimTail(V710)
-					reg16627 := __e.Call(__defun__shen_4removetype, V709, reg16626)
+					reg16627 := Call(__e, __defun__shen_4removetype, V709, reg16626)
 					reg16628 := PrimCons(reg16625, reg16627)
-					__ctx.Return(reg16628)
+					__e.Return(reg16628)
 					return
 				} else {
 					reg16629 := MakeSymbol("shen.removetype")
-					__ctx.TailApply(__defun__shen_4f__error, reg16629)
+					__e.TailApply(__defun__shen_4f__error, reg16629)
 					return
 				}
 			}
@@ -427,39 +427,39 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.removetype", value: __defun__shen_4removetype})
 
-	__defun__shen_4_5sig_7rest_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5sig_7rest_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V712 := __args[0]
 		_ = V712
-		reg16631 := __e.Call(__defun__shen_4_5signature_6, V712)
+		reg16631 := Call(__e, __defun__shen_4_5signature_6, V712)
 		Parse__shen_4_5signature_6 := reg16631
 		_ = Parse__shen_4_5signature_6
-		reg16632 := __e.Call(__defun__fail)
+		reg16632 := Call(__e, __defun__fail)
 		reg16633 := PrimEqual(reg16632, Parse__shen_4_5signature_6)
 		reg16634 := PrimNot(reg16633)
 		if reg16634 == True {
-			reg16635 := __e.Call(__defun___5_b_6, Parse__shen_4_5signature_6)
+			reg16635 := Call(__e, __defun___5_b_6, Parse__shen_4_5signature_6)
 			Parse___5_b_6 := reg16635
 			_ = Parse___5_b_6
-			reg16636 := __e.Call(__defun__fail)
+			reg16636 := Call(__e, __defun__fail)
 			reg16637 := PrimEqual(reg16636, Parse___5_b_6)
 			reg16638 := PrimNot(reg16637)
 			if reg16638 == True {
 				reg16639 := PrimHead(Parse___5_b_6)
-				reg16640 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5signature_6)
-				__ctx.TailApply(__defun__shen_4pair, reg16639, reg16640)
+				reg16640 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5signature_6)
+				__e.TailApply(__defun__shen_4pair, reg16639, reg16640)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<sig+rest>", value: __defun__shen_4_5sig_7rest_6})
 
-	__defun__write_1to_1file = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__write_1to_1file = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V715 := __args[0]
 		_ = V715
 		V716 := __args[1]
@@ -473,23 +473,23 @@ func init() {
 		if reg16646 == True {
 			reg16647 := MakeString("\n\n")
 			reg16648 := MakeSymbol("shen.a")
-			reg16649 := __e.Call(__defun__shen_4app, V716, reg16647, reg16648)
+			reg16649 := Call(__e, __defun__shen_4app, V716, reg16647, reg16648)
 			reg16653 = reg16649
 		} else {
 			reg16650 := MakeString("\n\n")
 			reg16651 := MakeSymbol("shen.s")
-			reg16652 := __e.Call(__defun__shen_4app, V716, reg16650, reg16651)
+			reg16652 := Call(__e, __defun__shen_4app, V716, reg16650, reg16651)
 			reg16653 = reg16652
 		}
 		String := reg16653
 		_ = String
-		reg16654 := __e.Call(__defun__pr, String, Stream)
+		reg16654 := Call(__e, __defun__pr, String, Stream)
 		Write := reg16654
 		_ = Write
 		reg16655 := PrimCloseStream(Stream)
 		Close := reg16655
 		_ = Close
-		__ctx.Return(V716)
+		__e.Return(V716)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "write-to-file", value: __defun__write_1to_1file})

--- a/cmd/shen/macros.go
+++ b/cmd/shen/macros.go
@@ -35,37 +35,37 @@ var __defun__shen_4findpos Obj                     // shen.findpos
 var __defun__shen_4remove_1nth Obj                 // shen.remove-nth
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg17415 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg17415)
+		__e.Return(reg17415)
 		return
 	}, 0))
-	__defun__macroexpand = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__macroexpand = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V718 := __args[0]
 		_ = V718
 		reg17416 := MakeSymbol("*macros*")
 		reg17417 := PrimValue(reg17416)
-		reg17418 := __e.Call(__defun__shen_4compose, reg17417, V718)
+		reg17418 := Call(__e, __defun__shen_4compose, reg17417, V718)
 		Y := reg17418
 		_ = Y
 		reg17419 := PrimEqual(V718, Y)
 		if reg17419 == True {
-			__ctx.Return(V718)
+			__e.Return(V718)
 			return
 		} else {
-			reg17420 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg17420 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Z := __args[0]
 				_ = Z
-				__ctx.TailApply(__defun__macroexpand, Z)
+				__e.TailApply(__defun__macroexpand, Z)
 				return
 			}, 1)
-			__ctx.TailApply(__defun__shen_4walk, reg17420, Y)
+			__e.TailApply(__defun__shen_4walk, reg17420, Y)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "macroexpand", value: __defun__macroexpand})
 
-	__defun__shen_4error_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4error_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V720 := __args[0]
 		_ = V720
 		reg17423 := PrimIsPair(V720)
@@ -110,20 +110,20 @@ func init() {
 			reg17441 := PrimHead(reg17440)
 			reg17442 := PrimTail(V720)
 			reg17443 := PrimTail(reg17442)
-			reg17444 := __e.Call(__defun__shen_4mkstr, reg17441, reg17443)
+			reg17444 := Call(__e, __defun__shen_4mkstr, reg17441, reg17443)
 			reg17445 := Nil
 			reg17446 := PrimCons(reg17444, reg17445)
 			reg17447 := PrimCons(reg17439, reg17446)
-			__ctx.Return(reg17447)
+			__e.Return(reg17447)
 			return
 		} else {
-			__ctx.Return(V720)
+			__e.Return(V720)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.error-macro", value: __defun__shen_4error_1macro})
 
-	__defun__shen_4output_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4output_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V722 := __args[0]
 		_ = V722
 		reg17448 := PrimIsPair(V722)
@@ -168,7 +168,7 @@ func init() {
 			reg17466 := PrimHead(reg17465)
 			reg17467 := PrimTail(V722)
 			reg17468 := PrimTail(reg17467)
-			reg17469 := __e.Call(__defun__shen_4mkstr, reg17466, reg17468)
+			reg17469 := Call(__e, __defun__shen_4mkstr, reg17466, reg17468)
 			reg17470 := MakeSymbol("stoutput")
 			reg17471 := Nil
 			reg17472 := PrimCons(reg17470, reg17471)
@@ -176,7 +176,7 @@ func init() {
 			reg17474 := PrimCons(reg17472, reg17473)
 			reg17475 := PrimCons(reg17469, reg17474)
 			reg17476 := PrimCons(reg17464, reg17475)
-			__ctx.Return(reg17476)
+			__e.Return(reg17476)
 			return
 		} else {
 			reg17477 := PrimIsPair(V722)
@@ -245,17 +245,17 @@ func init() {
 				reg17509 := PrimCons(reg17507, reg17508)
 				reg17510 := PrimCons(reg17504, reg17509)
 				reg17511 := PrimCons(reg17502, reg17510)
-				__ctx.Return(reg17511)
+				__e.Return(reg17511)
 				return
 			} else {
-				__ctx.Return(V722)
+				__e.Return(V722)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.output-macro", value: __defun__shen_4output_1macro})
 
-	__defun__shen_4make_1string_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4make_1string_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V724 := __args[0]
 		_ = V724
 		reg17512 := PrimIsPair(V724)
@@ -299,16 +299,16 @@ func init() {
 			reg17529 := PrimHead(reg17528)
 			reg17530 := PrimTail(V724)
 			reg17531 := PrimTail(reg17530)
-			__ctx.TailApply(__defun__shen_4mkstr, reg17529, reg17531)
+			__e.TailApply(__defun__shen_4mkstr, reg17529, reg17531)
 			return
 		} else {
-			__ctx.Return(V724)
+			__e.Return(V724)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.make-string-macro", value: __defun__shen_4make_1string_1macro})
 
-	__defun__shen_4input_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4input_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V726 := __args[0]
 		_ = V726
 		reg17533 := PrimIsPair(V726)
@@ -356,7 +356,7 @@ func init() {
 			reg17554 := Nil
 			reg17555 := PrimCons(reg17553, reg17554)
 			reg17556 := PrimCons(reg17550, reg17555)
-			__ctx.Return(reg17556)
+			__e.Return(reg17556)
 			return
 		} else {
 			reg17557 := PrimIsPair(V726)
@@ -404,7 +404,7 @@ func init() {
 				reg17578 := Nil
 				reg17579 := PrimCons(reg17577, reg17578)
 				reg17580 := PrimCons(reg17574, reg17579)
-				__ctx.Return(reg17580)
+				__e.Return(reg17580)
 				return
 			} else {
 				reg17581 := PrimIsPair(V726)
@@ -452,7 +452,7 @@ func init() {
 					reg17602 := Nil
 					reg17603 := PrimCons(reg17601, reg17602)
 					reg17604 := PrimCons(reg17598, reg17603)
-					__ctx.Return(reg17604)
+					__e.Return(reg17604)
 					return
 				} else {
 					reg17605 := PrimIsPair(V726)
@@ -521,7 +521,7 @@ func init() {
 						reg17637 := PrimCons(reg17635, reg17636)
 						reg17638 := PrimCons(reg17632, reg17637)
 						reg17639 := PrimCons(reg17630, reg17638)
-						__ctx.Return(reg17639)
+						__e.Return(reg17639)
 						return
 					} else {
 						reg17640 := PrimIsPair(V726)
@@ -569,10 +569,10 @@ func init() {
 							reg17661 := Nil
 							reg17662 := PrimCons(reg17660, reg17661)
 							reg17663 := PrimCons(reg17657, reg17662)
-							__ctx.Return(reg17663)
+							__e.Return(reg17663)
 							return
 						} else {
-							__ctx.Return(V726)
+							__e.Return(V726)
 							return
 						}
 					}
@@ -582,7 +582,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.input-macro", value: __defun__shen_4input_1macro})
 
-	__defun__shen_4compose = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4compose = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V729 := __args[0]
 		_ = V729
 		V730 := __args[1]
@@ -590,7 +590,7 @@ func init() {
 		reg17665 := Nil
 		reg17666 := PrimEqual(reg17665, V729)
 		if reg17666 == True {
-			__ctx.Return(V730)
+			__e.Return(V730)
 			return
 		} else {
 			reg17667 := PrimIsPair(V729)
@@ -599,19 +599,19 @@ func init() {
 				reg17669 := PrimHead(V729)
 				f17664 := reg17669
 				_ = f17664
-				reg17670 := __e.Call(f17664, V730)
-				__ctx.TailApply(__defun__shen_4compose, reg17668, reg17670)
+				reg17670 := Call(__e, f17664, V730)
+				__e.TailApply(__defun__shen_4compose, reg17668, reg17670)
 				return
 			} else {
 				reg17672 := MakeSymbol("shen.compose")
-				__ctx.TailApply(__defun__shen_4f__error, reg17672)
+				__e.TailApply(__defun__shen_4f__error, reg17672)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.compose", value: __defun__shen_4compose})
 
-	__defun__shen_4compile_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4compile_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V732 := __args[0]
 		_ = V732
 		reg17674 := PrimIsPair(V732)
@@ -729,16 +729,16 @@ func init() {
 			reg17745 := PrimCons(reg17713, reg17744)
 			reg17746 := PrimCons(reg17710, reg17745)
 			reg17747 := PrimCons(reg17708, reg17746)
-			__ctx.Return(reg17747)
+			__e.Return(reg17747)
 			return
 		} else {
-			__ctx.Return(V732)
+			__e.Return(V732)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.compile-macro", value: __defun__shen_4compile_1macro})
 
-	__defun__shen_4prolog_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prolog_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V734 := __args[0]
 		_ = V734
 		reg17748 := PrimIsPair(V734)
@@ -768,37 +768,37 @@ func init() {
 			reg17761 := PrimCons(reg17759, reg17760)
 			reg17762 := MakeSymbol("NPP")
 			reg17763 := PrimTail(V734)
-			reg17764 := __e.Call(__defun__shen_4bld_1prolog_1call, reg17762, reg17763)
+			reg17764 := Call(__e, __defun__shen_4bld_1prolog_1call, reg17762, reg17763)
 			Calls := reg17764
 			_ = Calls
 			reg17765 := PrimTail(V734)
-			reg17766 := __e.Call(__defun__shen_4extract__vars, reg17765)
+			reg17766 := Call(__e, __defun__shen_4extract__vars, reg17765)
 			Vs := reg17766
 			_ = Vs
 			reg17767 := PrimTail(V734)
-			reg17768 := __e.Call(__defun__shen_4externally_1bound, reg17767)
+			reg17768 := Call(__e, __defun__shen_4externally_1bound, reg17767)
 			External := reg17768
 			_ = External
-			reg17769 := __e.Call(__defun__difference, Vs, External)
+			reg17769 := Call(__e, __defun__difference, Vs, External)
 			PrologVs := reg17769
 			_ = PrologVs
 			reg17770 := MakeSymbol("NPP")
-			reg17771 := __e.Call(__defun__shen_4locally_1bind_1prolog_1vs, reg17770, PrologVs, Calls)
+			reg17771 := Call(__e, __defun__shen_4locally_1bind_1prolog_1vs, reg17770, PrologVs, Calls)
 			reg17772 := Nil
 			reg17773 := PrimCons(reg17771, reg17772)
 			reg17774 := PrimCons(reg17761, reg17773)
 			reg17775 := PrimCons(reg17758, reg17774)
 			reg17776 := PrimCons(reg17757, reg17775)
-			__ctx.Return(reg17776)
+			__e.Return(reg17776)
 			return
 		} else {
-			__ctx.Return(V734)
+			__e.Return(V734)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.prolog-macro", value: __defun__shen_4prolog_1macro})
 
-	__defun__shen_4externally_1bound = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4externally_1bound = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V740 := __args[0]
 		_ = V740
 		reg17777 := PrimIsPair(V740)
@@ -858,27 +858,27 @@ func init() {
 		}
 		if reg17801 == True {
 			reg17802 := PrimTail(V740)
-			__ctx.Return(reg17802)
+			__e.Return(reg17802)
 			return
 		} else {
 			reg17803 := PrimIsPair(V740)
 			if reg17803 == True {
 				reg17804 := PrimHead(V740)
-				reg17805 := __e.Call(__defun__shen_4externally_1bound, reg17804)
+				reg17805 := Call(__e, __defun__shen_4externally_1bound, reg17804)
 				reg17806 := PrimTail(V740)
-				reg17807 := __e.Call(__defun__shen_4externally_1bound, reg17806)
-				__ctx.TailApply(__defun__union, reg17805, reg17807)
+				reg17807 := Call(__e, __defun__shen_4externally_1bound, reg17806)
+				__e.TailApply(__defun__union, reg17805, reg17807)
 				return
 			} else {
 				reg17809 := Nil
-				__ctx.Return(reg17809)
+				__e.Return(reg17809)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.externally-bound", value: __defun__shen_4externally_1bound})
 
-	__defun__shen_4locally_1bind_1prolog_1vs = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4locally_1bind_1prolog_1vs = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V758 := __args[0]
 		_ = V758
 		V759 := __args[1]
@@ -888,7 +888,7 @@ func init() {
 		reg17810 := Nil
 		reg17811 := PrimEqual(reg17810, V759)
 		if reg17811 == True {
-			__ctx.Return(V760)
+			__e.Return(V760)
 			return
 		} else {
 			reg17812 := PrimIsPair(V759)
@@ -900,25 +900,25 @@ func init() {
 				reg17817 := PrimCons(V758, reg17816)
 				reg17818 := PrimCons(reg17815, reg17817)
 				reg17819 := PrimTail(V759)
-				reg17820 := __e.Call(__defun__shen_4locally_1bind_1prolog_1vs, V758, reg17819, V760)
+				reg17820 := Call(__e, __defun__shen_4locally_1bind_1prolog_1vs, V758, reg17819, V760)
 				reg17821 := Nil
 				reg17822 := PrimCons(reg17820, reg17821)
 				reg17823 := PrimCons(reg17818, reg17822)
 				reg17824 := PrimCons(reg17814, reg17823)
 				reg17825 := PrimCons(reg17813, reg17824)
-				__ctx.Return(reg17825)
+				__e.Return(reg17825)
 				return
 			} else {
 				reg17826 := MakeString("implementation error inp locally-bind-prolog-vs")
 				reg17827 := PrimSimpleError(reg17826)
-				__ctx.Return(reg17827)
+				__e.Return(reg17827)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.locally-bind-prolog-vs", value: __defun__shen_4locally_1bind_1prolog_1vs})
 
-	__defun__shen_4bld_1prolog_1call = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4bld_1prolog_1call = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V773 := __args[0]
 		_ = V773
 		V774 := __args[1]
@@ -927,7 +927,7 @@ func init() {
 		reg17829 := PrimEqual(reg17828, V774)
 		if reg17829 == True {
 			reg17830 := True
-			__ctx.Return(reg17830)
+			__e.Return(reg17830)
 			return
 		} else {
 			reg17831 := PrimIsPair(V774)
@@ -954,7 +954,7 @@ func init() {
 				reg17841 := False
 				reg17842 := MakeSymbol("freeze")
 				reg17843 := PrimTail(V774)
-				reg17844 := __e.Call(__defun__shen_4bld_1prolog_1call, V773, reg17843)
+				reg17844 := Call(__e, __defun__shen_4bld_1prolog_1call, V773, reg17843)
 				reg17845 := Nil
 				reg17846 := PrimCons(reg17844, reg17845)
 				reg17847 := PrimCons(reg17842, reg17846)
@@ -963,7 +963,7 @@ func init() {
 				reg17850 := PrimCons(V773, reg17849)
 				reg17851 := PrimCons(reg17841, reg17850)
 				reg17852 := PrimCons(reg17840, reg17851)
-				__ctx.Return(reg17852)
+				__e.Return(reg17852)
 				return
 			} else {
 				reg17853 := PrimIsPair(V774)
@@ -1046,10 +1046,10 @@ func init() {
 					reg17889 := PrimHead(V774)
 					reg17890 := PrimTail(reg17889)
 					reg17891 := PrimHead(reg17890)
-					reg17892 := __e.Call(__defun__shen_4insert_1deref, reg17891, V773)
+					reg17892 := Call(__e, __defun__shen_4insert_1deref, reg17891, V773)
 					reg17893 := MakeSymbol("freeze")
 					reg17894 := PrimTail(V774)
-					reg17895 := __e.Call(__defun__shen_4bld_1prolog_1call, V773, reg17894)
+					reg17895 := Call(__e, __defun__shen_4bld_1prolog_1call, V773, reg17894)
 					reg17896 := Nil
 					reg17897 := PrimCons(reg17895, reg17896)
 					reg17898 := PrimCons(reg17893, reg17897)
@@ -1058,7 +1058,7 @@ func init() {
 					reg17901 := PrimCons(V773, reg17900)
 					reg17902 := PrimCons(reg17892, reg17901)
 					reg17903 := PrimCons(reg17888, reg17902)
-					__ctx.Return(reg17903)
+					__e.Return(reg17903)
 					return
 				} else {
 					reg17904 := PrimIsPair(V774)
@@ -1165,10 +1165,10 @@ func init() {
 						reg17954 := PrimTail(reg17953)
 						reg17955 := PrimTail(reg17954)
 						reg17956 := PrimHead(reg17955)
-						reg17957 := __e.Call(__defun__shen_4insert_1deref, reg17956, V773)
+						reg17957 := Call(__e, __defun__shen_4insert_1deref, reg17956, V773)
 						reg17958 := MakeSymbol("freeze")
 						reg17959 := PrimTail(V774)
-						reg17960 := __e.Call(__defun__shen_4bld_1prolog_1call, V773, reg17959)
+						reg17960 := Call(__e, __defun__shen_4bld_1prolog_1call, V773, reg17959)
 						reg17961 := Nil
 						reg17962 := PrimCons(reg17960, reg17961)
 						reg17963 := PrimCons(reg17958, reg17962)
@@ -1178,7 +1178,7 @@ func init() {
 						reg17967 := PrimCons(reg17957, reg17966)
 						reg17968 := PrimCons(reg17952, reg17967)
 						reg17969 := PrimCons(reg17949, reg17968)
-						__ctx.Return(reg17969)
+						__e.Return(reg17969)
 						return
 					} else {
 						reg17970 := PrimIsPair(V774)
@@ -1258,7 +1258,7 @@ func init() {
 						}
 						if reg18004 == True {
 							reg18005 := PrimTail(V774)
-							__ctx.TailApply(__defun__shen_4bld_1prolog_1call, V773, reg18005)
+							__e.TailApply(__defun__shen_4bld_1prolog_1call, V773, reg18005)
 							return
 						} else {
 							reg18007 := PrimIsPair(V774)
@@ -1365,10 +1365,10 @@ func init() {
 								reg18057 := PrimTail(reg18056)
 								reg18058 := PrimTail(reg18057)
 								reg18059 := PrimHead(reg18058)
-								reg18060 := __e.Call(__defun__shen_4insert_1lazyderef, reg18059, V773)
+								reg18060 := Call(__e, __defun__shen_4insert_1lazyderef, reg18059, V773)
 								reg18061 := MakeSymbol("freeze")
 								reg18062 := PrimTail(V774)
-								reg18063 := __e.Call(__defun__shen_4bld_1prolog_1call, V773, reg18062)
+								reg18063 := Call(__e, __defun__shen_4bld_1prolog_1call, V773, reg18062)
 								reg18064 := Nil
 								reg18065 := PrimCons(reg18063, reg18064)
 								reg18066 := PrimCons(reg18061, reg18065)
@@ -1378,7 +1378,7 @@ func init() {
 								reg18070 := PrimCons(reg18060, reg18069)
 								reg18071 := PrimCons(reg18055, reg18070)
 								reg18072 := PrimCons(reg18052, reg18071)
-								__ctx.Return(reg18072)
+								__e.Return(reg18072)
 								return
 							} else {
 								reg18073 := PrimIsPair(V774)
@@ -1461,10 +1461,10 @@ func init() {
 									reg18109 := PrimHead(V774)
 									reg18110 := PrimTail(reg18109)
 									reg18111 := PrimHead(reg18110)
-									reg18112 := __e.Call(__defun__shen_4insert_1lazyderef, reg18111, V773)
+									reg18112 := Call(__e, __defun__shen_4insert_1lazyderef, reg18111, V773)
 									reg18113 := MakeSymbol("freeze")
 									reg18114 := PrimTail(V774)
-									reg18115 := __e.Call(__defun__shen_4bld_1prolog_1call, V773, reg18114)
+									reg18115 := Call(__e, __defun__shen_4bld_1prolog_1call, V773, reg18114)
 									reg18116 := Nil
 									reg18117 := PrimCons(reg18115, reg18116)
 									reg18118 := PrimCons(reg18113, reg18117)
@@ -1473,7 +1473,7 @@ func init() {
 									reg18121 := PrimCons(V773, reg18120)
 									reg18122 := PrimCons(reg18112, reg18121)
 									reg18123 := PrimCons(reg18108, reg18122)
-									__ctx.Return(reg18123)
+									__e.Return(reg18123)
 									return
 								} else {
 									reg18124 := PrimIsPair(V774)
@@ -1481,19 +1481,19 @@ func init() {
 										reg18125 := PrimHead(V774)
 										reg18126 := MakeSymbol("freeze")
 										reg18127 := PrimTail(V774)
-										reg18128 := __e.Call(__defun__shen_4bld_1prolog_1call, V773, reg18127)
+										reg18128 := Call(__e, __defun__shen_4bld_1prolog_1call, V773, reg18127)
 										reg18129 := Nil
 										reg18130 := PrimCons(reg18128, reg18129)
 										reg18131 := PrimCons(reg18126, reg18130)
 										reg18132 := Nil
 										reg18133 := PrimCons(reg18131, reg18132)
 										reg18134 := PrimCons(V773, reg18133)
-										__ctx.TailApply(__defun__append, reg18125, reg18134)
+										__e.TailApply(__defun__append, reg18125, reg18134)
 										return
 									} else {
 										reg18136 := MakeString("implementation error in bld-prolog-call")
 										reg18137 := PrimSimpleError(reg18136)
-										__ctx.Return(reg18137)
+										__e.Return(reg18137)
 										return
 									}
 								}
@@ -1506,7 +1506,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.bld-prolog-call", value: __defun__shen_4bld_1prolog_1call})
 
-	__defun__shen_4defprolog_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4defprolog_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V776 := __args[0]
 		_ = V776
 		reg18138 := PrimIsPair(V776)
@@ -1546,31 +1546,31 @@ func init() {
 			reg18153 = reg18152
 		}
 		if reg18153 == True {
-			reg18154 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg18154 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Y := __args[0]
 				_ = Y
-				__ctx.TailApply(__defun__shen_4_5defprolog_6, Y)
+				__e.TailApply(__defun__shen_4_5defprolog_6, Y)
 				return
 			}, 1)
 			reg18156 := PrimTail(V776)
-			reg18157 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg18157 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Y := __args[0]
 				_ = Y
 				reg18158 := PrimTail(V776)
 				reg18159 := PrimHead(reg18158)
-				__ctx.TailApply(__defun__shen_4prolog_1error, reg18159, Y)
+				__e.TailApply(__defun__shen_4prolog_1error, reg18159, Y)
 				return
 			}, 1)
-			__ctx.TailApply(__defun__compile, reg18154, reg18156, reg18157)
+			__e.TailApply(__defun__compile, reg18154, reg18156, reg18157)
 			return
 		} else {
-			__ctx.Return(V776)
+			__e.Return(V776)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.defprolog-macro", value: __defun__shen_4defprolog_1macro})
 
-	__defun__shen_4datatype_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4datatype_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V778 := __args[0]
 		_ = V778
 		reg18162 := PrimIsPair(V778)
@@ -1613,7 +1613,7 @@ func init() {
 			reg18178 := MakeSymbol("shen.process-datatype")
 			reg18179 := PrimTail(V778)
 			reg18180 := PrimHead(reg18179)
-			reg18181 := __e.Call(__defun__shen_4intern_1type, reg18180)
+			reg18181 := Call(__e, __defun__shen_4intern_1type, reg18180)
 			reg18182 := MakeSymbol("compile")
 			reg18183 := MakeSymbol("lambda")
 			reg18184 := MakeSymbol("X")
@@ -1628,7 +1628,7 @@ func init() {
 			reg18193 := PrimCons(reg18183, reg18192)
 			reg18194 := PrimTail(V778)
 			reg18195 := PrimTail(reg18194)
-			reg18196 := __e.Call(__defun__shen_4rcons__form, reg18195)
+			reg18196 := Call(__e, __defun__shen_4rcons__form, reg18195)
 			reg18197 := MakeSymbol("function")
 			reg18198 := MakeSymbol("shen.datatype-error")
 			reg18199 := Nil
@@ -1643,28 +1643,28 @@ func init() {
 			reg18208 := PrimCons(reg18206, reg18207)
 			reg18209 := PrimCons(reg18181, reg18208)
 			reg18210 := PrimCons(reg18178, reg18209)
-			__ctx.Return(reg18210)
+			__e.Return(reg18210)
 			return
 		} else {
-			__ctx.Return(V778)
+			__e.Return(V778)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.datatype-macro", value: __defun__shen_4datatype_1macro})
 
-	__defun__shen_4intern_1type = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4intern_1type = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V780 := __args[0]
 		_ = V780
 		reg18211 := PrimStr(V780)
 		reg18212 := MakeString("#type")
 		reg18213 := PrimStringConcat(reg18211, reg18212)
 		reg18214 := PrimIntern(reg18213)
-		__ctx.Return(reg18214)
+		__e.Return(reg18214)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.intern-type", value: __defun__shen_4intern_1type})
 
-	__defun__shen_4_8s_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_8s_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V782 := __args[0]
 		_ = V782
 		reg18215 := PrimIsPair(V782)
@@ -1748,12 +1748,12 @@ func init() {
 			reg18252 := PrimTail(V782)
 			reg18253 := PrimTail(reg18252)
 			reg18254 := PrimCons(reg18251, reg18253)
-			reg18255 := __e.Call(__defun__shen_4_8s_1macro, reg18254)
+			reg18255 := Call(__e, __defun__shen_4_8s_1macro, reg18254)
 			reg18256 := Nil
 			reg18257 := PrimCons(reg18255, reg18256)
 			reg18258 := PrimCons(reg18250, reg18257)
 			reg18259 := PrimCons(reg18248, reg18258)
-			__ctx.Return(reg18259)
+			__e.Return(reg18259)
 			return
 		} else {
 			reg18260 := PrimIsPair(V782)
@@ -1851,33 +1851,33 @@ func init() {
 			if reg18301 == True {
 				reg18302 := PrimTail(V782)
 				reg18303 := PrimHead(reg18302)
-				reg18304 := __e.Call(__defun__explode, reg18303)
+				reg18304 := Call(__e, __defun__explode, reg18303)
 				E := reg18304
 				_ = E
-				reg18305 := __e.Call(__defun__length, E)
+				reg18305 := Call(__e, __defun__length, E)
 				reg18306 := MakeNumber(1)
 				reg18307 := PrimGreatThan(reg18305, reg18306)
 				if reg18307 == True {
 					reg18308 := MakeSymbol("@s")
 					reg18309 := PrimTail(V782)
 					reg18310 := PrimTail(reg18309)
-					reg18311 := __e.Call(__defun__append, E, reg18310)
+					reg18311 := Call(__e, __defun__append, E, reg18310)
 					reg18312 := PrimCons(reg18308, reg18311)
-					__ctx.TailApply(__defun__shen_4_8s_1macro, reg18312)
+					__e.TailApply(__defun__shen_4_8s_1macro, reg18312)
 					return
 				} else {
-					__ctx.Return(V782)
+					__e.Return(V782)
 					return
 				}
 			} else {
-				__ctx.Return(V782)
+				__e.Return(V782)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.@s-macro", value: __defun__shen_4_8s_1macro})
 
-	__defun__shen_4synonyms_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4synonyms_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V784 := __args[0]
 		_ = V784
 		reg18314 := PrimIsPair(V784)
@@ -1902,35 +1902,35 @@ func init() {
 		if reg18322 == True {
 			reg18323 := MakeSymbol("shen.synonyms-help")
 			reg18324 := PrimTail(V784)
-			reg18325 := __e.Call(__defun__shen_4curry_1synonyms, reg18324)
-			reg18326 := __e.Call(__defun__shen_4rcons__form, reg18325)
+			reg18325 := Call(__e, __defun__shen_4curry_1synonyms, reg18324)
+			reg18326 := Call(__e, __defun__shen_4rcons__form, reg18325)
 			reg18327 := Nil
 			reg18328 := PrimCons(reg18326, reg18327)
 			reg18329 := PrimCons(reg18323, reg18328)
-			__ctx.Return(reg18329)
+			__e.Return(reg18329)
 			return
 		} else {
-			__ctx.Return(V784)
+			__e.Return(V784)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.synonyms-macro", value: __defun__shen_4synonyms_1macro})
 
-	__defun__shen_4curry_1synonyms = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4curry_1synonyms = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V786 := __args[0]
 		_ = V786
-		reg18330 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg18330 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4curry_1type, X)
+			__e.TailApply(__defun__shen_4curry_1type, X)
 			return
 		}, 1)
-		__ctx.TailApply(__defun__map, reg18330, V786)
+		__e.TailApply(__defun__map, reg18330, V786)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.curry-synonyms", value: __defun__shen_4curry_1synonyms})
 
-	__defun__shen_4nl_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4nl_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V788 := __args[0]
 		_ = V788
 		reg18333 := PrimIsPair(V788)
@@ -1976,16 +1976,16 @@ func init() {
 			reg18352 := Nil
 			reg18353 := PrimCons(reg18351, reg18352)
 			reg18354 := PrimCons(reg18350, reg18353)
-			__ctx.Return(reg18354)
+			__e.Return(reg18354)
 			return
 		} else {
-			__ctx.Return(V788)
+			__e.Return(V788)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.nl-macro", value: __defun__shen_4nl_1macro})
 
-	__defun__shen_4assoc_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4assoc_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V790 := __args[0]
 		_ = V790
 		reg18355 := PrimIsPair(V790)
@@ -2024,7 +2024,7 @@ func init() {
 						reg18380 := PrimCons(reg18368, reg18379)
 						reg18381 := PrimCons(reg18367, reg18380)
 						reg18382 := PrimCons(reg18366, reg18381)
-						reg18383 := __e.Call(__defun__element_2, reg18365, reg18382)
+						reg18383 := Call(__e, __defun__element_2, reg18365, reg18382)
 						var reg18386 Obj
 						if reg18383 == True {
 							reg18384 := True
@@ -2085,21 +2085,21 @@ func init() {
 			reg18408 := PrimTail(V790)
 			reg18409 := PrimTail(reg18408)
 			reg18410 := PrimCons(reg18407, reg18409)
-			reg18411 := __e.Call(__defun__shen_4assoc_1macro, reg18410)
+			reg18411 := Call(__e, __defun__shen_4assoc_1macro, reg18410)
 			reg18412 := Nil
 			reg18413 := PrimCons(reg18411, reg18412)
 			reg18414 := PrimCons(reg18406, reg18413)
 			reg18415 := PrimCons(reg18404, reg18414)
-			__ctx.Return(reg18415)
+			__e.Return(reg18415)
 			return
 		} else {
-			__ctx.Return(V790)
+			__e.Return(V790)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.assoc-macro", value: __defun__shen_4assoc_1macro})
 
-	__defun__shen_4let_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4let_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V792 := __args[0]
 		_ = V792
 		reg18416 := PrimIsPair(V792)
@@ -2207,22 +2207,22 @@ func init() {
 			reg18467 := PrimTail(reg18466)
 			reg18468 := PrimTail(reg18467)
 			reg18469 := PrimCons(reg18465, reg18468)
-			reg18470 := __e.Call(__defun__shen_4let_1macro, reg18469)
+			reg18470 := Call(__e, __defun__shen_4let_1macro, reg18469)
 			reg18471 := Nil
 			reg18472 := PrimCons(reg18470, reg18471)
 			reg18473 := PrimCons(reg18464, reg18472)
 			reg18474 := PrimCons(reg18461, reg18473)
 			reg18475 := PrimCons(reg18459, reg18474)
-			__ctx.Return(reg18475)
+			__e.Return(reg18475)
 			return
 		} else {
-			__ctx.Return(V792)
+			__e.Return(V792)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.let-macro", value: __defun__shen_4let_1macro})
 
-	__defun__shen_4abs_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4abs_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V794 := __args[0]
 		_ = V794
 		reg18476 := PrimIsPair(V794)
@@ -2306,12 +2306,12 @@ func init() {
 			reg18513 := PrimTail(V794)
 			reg18514 := PrimTail(reg18513)
 			reg18515 := PrimCons(reg18512, reg18514)
-			reg18516 := __e.Call(__defun__shen_4abs_1macro, reg18515)
+			reg18516 := Call(__e, __defun__shen_4abs_1macro, reg18515)
 			reg18517 := Nil
 			reg18518 := PrimCons(reg18516, reg18517)
 			reg18519 := PrimCons(reg18511, reg18518)
 			reg18520 := PrimCons(reg18509, reg18519)
-			__ctx.Return(reg18520)
+			__e.Return(reg18520)
 			return
 		} else {
 			reg18521 := PrimIsPair(V794)
@@ -2392,17 +2392,17 @@ func init() {
 				reg18555 := MakeSymbol("lambda")
 				reg18556 := PrimTail(V794)
 				reg18557 := PrimCons(reg18555, reg18556)
-				__ctx.Return(reg18557)
+				__e.Return(reg18557)
 				return
 			} else {
-				__ctx.Return(V794)
+				__e.Return(V794)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.abs-macro", value: __defun__shen_4abs_1macro})
 
-	__defun__shen_4cases_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4cases_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V798 := __args[0]
 		_ = V798
 		reg18558 := PrimIsPair(V798)
@@ -2482,7 +2482,7 @@ func init() {
 			reg18591 := PrimTail(V798)
 			reg18592 := PrimTail(reg18591)
 			reg18593 := PrimHead(reg18592)
-			__ctx.Return(reg18593)
+			__e.Return(reg18593)
 			return
 		} else {
 			reg18594 := PrimIsPair(V798)
@@ -2576,7 +2576,7 @@ func init() {
 				reg18641 := PrimCons(reg18633, reg18640)
 				reg18642 := PrimCons(reg18630, reg18641)
 				reg18643 := PrimCons(reg18628, reg18642)
-				__ctx.Return(reg18643)
+				__e.Return(reg18643)
 				return
 			} else {
 				reg18644 := PrimIsPair(V798)
@@ -2645,13 +2645,13 @@ func init() {
 					reg18676 := PrimTail(reg18675)
 					reg18677 := PrimTail(reg18676)
 					reg18678 := PrimCons(reg18674, reg18677)
-					reg18679 := __e.Call(__defun__shen_4cases_1macro, reg18678)
+					reg18679 := Call(__e, __defun__shen_4cases_1macro, reg18678)
 					reg18680 := Nil
 					reg18681 := PrimCons(reg18679, reg18680)
 					reg18682 := PrimCons(reg18673, reg18681)
 					reg18683 := PrimCons(reg18670, reg18682)
 					reg18684 := PrimCons(reg18668, reg18683)
-					__ctx.Return(reg18684)
+					__e.Return(reg18684)
 					return
 				} else {
 					reg18685 := PrimIsPair(V798)
@@ -2712,10 +2712,10 @@ func init() {
 					if reg18709 == True {
 						reg18710 := MakeString("error: odd number of case elements\n")
 						reg18711 := PrimSimpleError(reg18710)
-						__ctx.Return(reg18711)
+						__e.Return(reg18711)
 						return
 					} else {
-						__ctx.Return(V798)
+						__e.Return(V798)
 						return
 					}
 				}
@@ -2724,7 +2724,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.cases-macro", value: __defun__shen_4cases_1macro})
 
-	__defun__shen_4timer_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4timer_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V800 := __args[0]
 		_ = V800
 		reg18712 := PrimIsPair(V800)
@@ -2847,16 +2847,16 @@ func init() {
 			reg18798 := PrimCons(reg18743, reg18797)
 			reg18799 := PrimCons(reg18738, reg18798)
 			reg18800 := PrimCons(reg18737, reg18799)
-			__ctx.TailApply(__defun__shen_4let_1macro, reg18800)
+			__e.TailApply(__defun__shen_4let_1macro, reg18800)
 			return
 		} else {
-			__ctx.Return(V800)
+			__e.Return(V800)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.timer-macro", value: __defun__shen_4timer_1macro})
 
-	__defun__shen_4tuple_1up = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4tuple_1up = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V802 := __args[0]
 		_ = V802
 		reg18802 := PrimIsPair(V802)
@@ -2864,21 +2864,21 @@ func init() {
 			reg18803 := MakeSymbol("@p")
 			reg18804 := PrimHead(V802)
 			reg18805 := PrimTail(V802)
-			reg18806 := __e.Call(__defun__shen_4tuple_1up, reg18805)
+			reg18806 := Call(__e, __defun__shen_4tuple_1up, reg18805)
 			reg18807 := Nil
 			reg18808 := PrimCons(reg18806, reg18807)
 			reg18809 := PrimCons(reg18804, reg18808)
 			reg18810 := PrimCons(reg18803, reg18809)
-			__ctx.Return(reg18810)
+			__e.Return(reg18810)
 			return
 		} else {
-			__ctx.Return(V802)
+			__e.Return(V802)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.tuple-up", value: __defun__shen_4tuple_1up})
 
-	__defun__shen_4put_cget_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4put_cget_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V804 := __args[0]
 		_ = V804
 		reg18811 := PrimIsPair(V804)
@@ -2997,7 +2997,7 @@ func init() {
 			reg18873 := PrimCons(reg18860, reg18872)
 			reg18874 := PrimCons(reg18857, reg18873)
 			reg18875 := PrimCons(reg18855, reg18874)
-			__ctx.Return(reg18875)
+			__e.Return(reg18875)
 			return
 		} else {
 			reg18876 := PrimIsPair(V804)
@@ -3091,7 +3091,7 @@ func init() {
 				reg18923 := PrimCons(reg18915, reg18922)
 				reg18924 := PrimCons(reg18912, reg18923)
 				reg18925 := PrimCons(reg18910, reg18924)
-				__ctx.Return(reg18925)
+				__e.Return(reg18925)
 				return
 			} else {
 				reg18926 := PrimIsPair(V804)
@@ -3185,10 +3185,10 @@ func init() {
 					reg18973 := PrimCons(reg18965, reg18972)
 					reg18974 := PrimCons(reg18962, reg18973)
 					reg18975 := PrimCons(reg18960, reg18974)
-					__ctx.Return(reg18975)
+					__e.Return(reg18975)
 					return
 				} else {
-					__ctx.Return(V804)
+					__e.Return(V804)
 					return
 				}
 			}
@@ -3196,7 +3196,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.put/get-macro", value: __defun__shen_4put_cget_1macro})
 
-	__defun__shen_4function_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4function_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V806 := __args[0]
 		_ = V806
 		reg18976 := PrimIsPair(V806)
@@ -3259,17 +3259,17 @@ func init() {
 			reg19002 := PrimHead(reg19001)
 			reg19003 := PrimTail(V806)
 			reg19004 := PrimHead(reg19003)
-			reg19005 := __e.Call(__defun__arity, reg19004)
-			__ctx.TailApply(__defun__shen_4function_1abstraction, reg19002, reg19005)
+			reg19005 := Call(__e, __defun__arity, reg19004)
+			__e.TailApply(__defun__shen_4function_1abstraction, reg19002, reg19005)
 			return
 		} else {
-			__ctx.Return(V806)
+			__e.Return(V806)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.function-macro", value: __defun__shen_4function_1macro})
 
-	__defun__shen_4function_1abstraction = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4function_1abstraction = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V809 := __args[0]
 		_ = V809
 		V810 := __args[1]
@@ -3279,9 +3279,9 @@ func init() {
 		if reg19008 == True {
 			reg19009 := MakeString(" has no lambda form\n")
 			reg19010 := MakeSymbol("shen.a")
-			reg19011 := __e.Call(__defun__shen_4app, V809, reg19009, reg19010)
+			reg19011 := Call(__e, __defun__shen_4app, V809, reg19009, reg19010)
 			reg19012 := PrimSimpleError(reg19011)
-			__ctx.Return(reg19012)
+			__e.Return(reg19012)
 			return
 		} else {
 			reg19013 := MakeNumber(-1)
@@ -3291,18 +3291,18 @@ func init() {
 				reg19016 := Nil
 				reg19017 := PrimCons(V809, reg19016)
 				reg19018 := PrimCons(reg19015, reg19017)
-				__ctx.Return(reg19018)
+				__e.Return(reg19018)
 				return
 			} else {
 				reg19019 := Nil
-				__ctx.TailApply(__defun__shen_4function_1abstraction_1help, V809, V810, reg19019)
+				__e.TailApply(__defun__shen_4function_1abstraction_1help, V809, V810, reg19019)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.function-abstraction", value: __defun__shen_4function_1abstraction})
 
-	__defun__shen_4function_1abstraction_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4function_1abstraction_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V814 := __args[0]
 		_ = V814
 		V815 := __args[1]
@@ -3313,11 +3313,11 @@ func init() {
 		reg19022 := PrimEqual(reg19021, V815)
 		if reg19022 == True {
 			reg19023 := PrimCons(V814, V816)
-			__ctx.Return(reg19023)
+			__e.Return(reg19023)
 			return
 		} else {
 			reg19024 := MakeSymbol("V")
-			reg19025 := __e.Call(__defun__gensym, reg19024)
+			reg19025 := Call(__e, __defun__gensym, reg19024)
 			X := reg19025
 			_ = X
 			reg19026 := MakeSymbol("/.")
@@ -3325,46 +3325,46 @@ func init() {
 			reg19028 := PrimNumberSubtract(V815, reg19027)
 			reg19029 := Nil
 			reg19030 := PrimCons(X, reg19029)
-			reg19031 := __e.Call(__defun__append, V816, reg19030)
-			reg19032 := __e.Call(__defun__shen_4function_1abstraction_1help, V814, reg19028, reg19031)
+			reg19031 := Call(__e, __defun__append, V816, reg19030)
+			reg19032 := Call(__e, __defun__shen_4function_1abstraction_1help, V814, reg19028, reg19031)
 			reg19033 := Nil
 			reg19034 := PrimCons(reg19032, reg19033)
 			reg19035 := PrimCons(X, reg19034)
 			reg19036 := PrimCons(reg19026, reg19035)
-			__ctx.Return(reg19036)
+			__e.Return(reg19036)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.function-abstraction-help", value: __defun__shen_4function_1abstraction_1help})
 
-	__defun__undefmacro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__undefmacro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V818 := __args[0]
 		_ = V818
 		reg19037 := MakeSymbol("shen.*macroreg*")
 		reg19038 := PrimValue(reg19037)
 		MacroReg := reg19038
 		_ = MacroReg
-		reg19039 := __e.Call(__defun__shen_4findpos, V818, MacroReg)
+		reg19039 := Call(__e, __defun__shen_4findpos, V818, MacroReg)
 		Pos := reg19039
 		_ = Pos
 		reg19040 := MakeSymbol("shen.*macroreg*")
-		reg19041 := __e.Call(__defun__remove, V818, MacroReg)
+		reg19041 := Call(__e, __defun__remove, V818, MacroReg)
 		reg19042 := PrimSet(reg19040, reg19041)
 		Remove1 := reg19042
 		_ = Remove1
 		reg19043 := MakeSymbol("*macros*")
 		reg19044 := MakeSymbol("*macros*")
 		reg19045 := PrimValue(reg19044)
-		reg19046 := __e.Call(__defun__shen_4remove_1nth, Pos, reg19045)
+		reg19046 := Call(__e, __defun__shen_4remove_1nth, Pos, reg19045)
 		reg19047 := PrimSet(reg19043, reg19046)
 		Remove2 := reg19047
 		_ = Remove2
-		__ctx.Return(V818)
+		__e.Return(V818)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "undefmacro", value: __defun__undefmacro})
 
-	__defun__shen_4findpos = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4findpos = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V828 := __args[0]
 		_ = V828
 		V829 := __args[1]
@@ -3374,9 +3374,9 @@ func init() {
 		if reg19049 == True {
 			reg19050 := MakeString(" is not a macro\n")
 			reg19051 := MakeSymbol("shen.a")
-			reg19052 := __e.Call(__defun__shen_4app, V828, reg19050, reg19051)
+			reg19052 := Call(__e, __defun__shen_4app, V828, reg19050, reg19051)
 			reg19053 := PrimSimpleError(reg19052)
-			__ctx.Return(reg19053)
+			__e.Return(reg19053)
 			return
 		} else {
 			reg19054 := PrimIsPair(V829)
@@ -3399,20 +3399,20 @@ func init() {
 			}
 			if reg19061 == True {
 				reg19062 := MakeNumber(1)
-				__ctx.Return(reg19062)
+				__e.Return(reg19062)
 				return
 			} else {
 				reg19063 := PrimIsPair(V829)
 				if reg19063 == True {
 					reg19064 := MakeNumber(1)
 					reg19065 := PrimTail(V829)
-					reg19066 := __e.Call(__defun__shen_4findpos, V828, reg19065)
+					reg19066 := Call(__e, __defun__shen_4findpos, V828, reg19065)
 					reg19067 := PrimNumberAdd(reg19064, reg19066)
-					__ctx.Return(reg19067)
+					__e.Return(reg19067)
 					return
 				} else {
 					reg19068 := MakeSymbol("shen.findpos")
-					__ctx.TailApply(__defun__shen_4f__error, reg19068)
+					__e.TailApply(__defun__shen_4f__error, reg19068)
 					return
 				}
 			}
@@ -3420,7 +3420,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.findpos", value: __defun__shen_4findpos})
 
-	__defun__shen_4remove_1nth = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4remove_1nth = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V834 := __args[0]
 		_ = V834
 		V835 := __args[1]
@@ -3445,7 +3445,7 @@ func init() {
 		}
 		if reg19077 == True {
 			reg19078 := PrimTail(V835)
-			__ctx.Return(reg19078)
+			__e.Return(reg19078)
 			return
 		} else {
 			reg19079 := PrimIsPair(V835)
@@ -3454,13 +3454,13 @@ func init() {
 				reg19081 := MakeNumber(1)
 				reg19082 := PrimNumberSubtract(V834, reg19081)
 				reg19083 := PrimTail(V835)
-				reg19084 := __e.Call(__defun__shen_4remove_1nth, reg19082, reg19083)
+				reg19084 := Call(__e, __defun__shen_4remove_1nth, reg19082, reg19083)
 				reg19085 := PrimCons(reg19080, reg19084)
-				__ctx.Return(reg19085)
+				__e.Return(reg19085)
 				return
 			} else {
 				reg19086 := MakeSymbol("shen.remove-nth")
-				__ctx.TailApply(__defun__shen_4f__error, reg19086)
+				__e.TailApply(__defun__shen_4f__error, reg19086)
 				return
 			}
 		}

--- a/cmd/shen/main.go
+++ b/cmd/shen/main.go
@@ -27,8 +27,8 @@ func main() {
 	e := kl.NewKLambda()
 	Regist(e)
 
-	e.Eval(kl.Cons(kl.MakeSymbol("shen.initialise"), kl.Nil))
-	e.Eval(kl.Cons(kl.MakeSymbol("shen.repl"), kl.Nil))
+	kl.Eval(e, kl.Cons(kl.MakeSymbol("shen.initialise"), kl.Nil))
+	kl.Eval(e, kl.Cons(kl.MakeSymbol("shen.repl"), kl.Nil))
 
 	// r := kl.NewSexpReader(os.Stdin, false)
 	// for i := 0; ; i++ {

--- a/cmd/shen/prolog.go
+++ b/cmd/shen/prolog.go
@@ -101,54 +101,54 @@ var __defun__shen_4insert_1prolog_1variables_1help Obj // shen.insert-prolog-var
 var __defun__shen_4initialise_1prolog Obj              // shen.initialise-prolog
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg10607 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg10607)
+		__e.Return(reg10607)
 		return
 	}, 0))
-	__defun__shen_4_5defprolog_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5defprolog_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V837 := __args[0]
 		_ = V837
-		reg10608 := __e.Call(__defun__shen_4_5predicate_d_6, V837)
+		reg10608 := Call(__e, __defun__shen_4_5predicate_d_6, V837)
 		Parse__shen_4_5predicate_d_6 := reg10608
 		_ = Parse__shen_4_5predicate_d_6
-		reg10609 := __e.Call(__defun__fail)
+		reg10609 := Call(__e, __defun__fail)
 		reg10610 := PrimEqual(reg10609, Parse__shen_4_5predicate_d_6)
 		reg10611 := PrimNot(reg10610)
 		if reg10611 == True {
-			reg10612 := __e.Call(__defun__shen_4_5clauses_d_6, Parse__shen_4_5predicate_d_6)
+			reg10612 := Call(__e, __defun__shen_4_5clauses_d_6, Parse__shen_4_5predicate_d_6)
 			Parse__shen_4_5clauses_d_6 := reg10612
 			_ = Parse__shen_4_5clauses_d_6
-			reg10613 := __e.Call(__defun__fail)
+			reg10613 := Call(__e, __defun__fail)
 			reg10614 := PrimEqual(reg10613, Parse__shen_4_5clauses_d_6)
 			reg10615 := PrimNot(reg10614)
 			if reg10615 == True {
 				reg10616 := PrimHead(Parse__shen_4_5clauses_d_6)
-				reg10617 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg10617 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					Parse__X := __args[0]
 					_ = Parse__X
-					reg10618 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5predicate_d_6)
-					__ctx.TailApply(__defun__shen_4insert_1predicate, reg10618, Parse__X)
+					reg10618 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5predicate_d_6)
+					__e.TailApply(__defun__shen_4insert_1predicate, reg10618, Parse__X)
 					return
 				}, 1)
-				reg10620 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5clauses_d_6)
-				reg10621 := __e.Call(__defun__map, reg10617, reg10620)
-				reg10622 := __e.Call(__defun__shen_4prolog_1_6shen, reg10621)
+				reg10620 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5clauses_d_6)
+				reg10621 := Call(__e, __defun__map, reg10617, reg10620)
+				reg10622 := Call(__e, __defun__shen_4prolog_1_6shen, reg10621)
 				reg10623 := PrimHead(reg10622)
-				__ctx.TailApply(__defun__shen_4pair, reg10616, reg10623)
+				__e.TailApply(__defun__shen_4pair, reg10616, reg10623)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<defprolog>", value: __defun__shen_4_5defprolog_6})
 
-	__defun__shen_4prolog_1error = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prolog_1error = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V846 := __args[0]
 		_ = V846
 		V847 := __args[1]
@@ -195,31 +195,31 @@ func init() {
 			reg10645 := MakeString(" here:\n\n ")
 			reg10646 := MakeNumber(50)
 			reg10647 := PrimHead(V847)
-			reg10648 := __e.Call(__defun__shen_4next_150, reg10646, reg10647)
+			reg10648 := Call(__e, __defun__shen_4next_150, reg10646, reg10647)
 			reg10649 := MakeString("\n")
 			reg10650 := MakeSymbol("shen.a")
-			reg10651 := __e.Call(__defun__shen_4app, reg10648, reg10649, reg10650)
+			reg10651 := Call(__e, __defun__shen_4app, reg10648, reg10649, reg10650)
 			reg10652 := PrimStringConcat(reg10645, reg10651)
 			reg10653 := MakeSymbol("shen.a")
-			reg10654 := __e.Call(__defun__shen_4app, V846, reg10652, reg10653)
+			reg10654 := Call(__e, __defun__shen_4app, V846, reg10652, reg10653)
 			reg10655 := PrimStringConcat(reg10644, reg10654)
 			reg10656 := PrimSimpleError(reg10655)
-			__ctx.Return(reg10656)
+			__e.Return(reg10656)
 			return
 		} else {
 			reg10657 := MakeString("prolog syntax error in ")
 			reg10658 := MakeString("\n")
 			reg10659 := MakeSymbol("shen.a")
-			reg10660 := __e.Call(__defun__shen_4app, V846, reg10658, reg10659)
+			reg10660 := Call(__e, __defun__shen_4app, V846, reg10658, reg10659)
 			reg10661 := PrimStringConcat(reg10657, reg10660)
 			reg10662 := PrimSimpleError(reg10661)
-			__ctx.Return(reg10662)
+			__e.Return(reg10662)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.prolog-error", value: __defun__shen_4prolog_1error})
 
-	__defun__shen_4next_150 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4next_150 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V854 := __args[0]
 		_ = V854
 		V855 := __args[1]
@@ -228,30 +228,30 @@ func init() {
 		reg10664 := PrimEqual(reg10663, V855)
 		if reg10664 == True {
 			reg10665 := MakeString("")
-			__ctx.Return(reg10665)
+			__e.Return(reg10665)
 			return
 		} else {
 			reg10666 := MakeNumber(0)
 			reg10667 := PrimEqual(reg10666, V854)
 			if reg10667 == True {
 				reg10668 := MakeString("")
-				__ctx.Return(reg10668)
+				__e.Return(reg10668)
 				return
 			} else {
 				reg10669 := PrimIsPair(V855)
 				if reg10669 == True {
 					reg10670 := PrimHead(V855)
-					reg10671 := __e.Call(__defun__shen_4decons_1string, reg10670)
+					reg10671 := Call(__e, __defun__shen_4decons_1string, reg10670)
 					reg10672 := MakeNumber(1)
 					reg10673 := PrimNumberSubtract(V854, reg10672)
 					reg10674 := PrimTail(V855)
-					reg10675 := __e.Call(__defun__shen_4next_150, reg10673, reg10674)
+					reg10675 := Call(__e, __defun__shen_4next_150, reg10673, reg10674)
 					reg10676 := PrimStringConcat(reg10671, reg10675)
-					__ctx.Return(reg10676)
+					__e.Return(reg10676)
 					return
 				} else {
 					reg10677 := MakeSymbol("shen.next-50")
-					__ctx.TailApply(__defun__shen_4f__error, reg10677)
+					__e.TailApply(__defun__shen_4f__error, reg10677)
 					return
 				}
 			}
@@ -259,7 +259,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.next-50", value: __defun__shen_4next_150})
 
-	__defun__shen_4decons_1string = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4decons_1string = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V857 := __args[0]
 		_ = V857
 		reg10679 := PrimIsPair(V857)
@@ -337,21 +337,21 @@ func init() {
 			reg10712 = reg10711
 		}
 		if reg10712 == True {
-			reg10713 := __e.Call(__defun__shen_4eval_1cons, V857)
+			reg10713 := Call(__e, __defun__shen_4eval_1cons, V857)
 			reg10714 := MakeString(" ")
 			reg10715 := MakeSymbol("shen.s")
-			__ctx.TailApply(__defun__shen_4app, reg10713, reg10714, reg10715)
+			__e.TailApply(__defun__shen_4app, reg10713, reg10714, reg10715)
 			return
 		} else {
 			reg10717 := MakeString(" ")
 			reg10718 := MakeSymbol("shen.r")
-			__ctx.TailApply(__defun__shen_4app, V857, reg10717, reg10718)
+			__e.TailApply(__defun__shen_4app, V857, reg10717, reg10718)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.decons-string", value: __defun__shen_4decons_1string})
 
-	__defun__shen_4insert_1predicate = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert_1predicate = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V860 := __args[0]
 		_ = V860
 		V861 := __args[1]
@@ -400,106 +400,106 @@ func init() {
 			reg10740 := PrimTail(V861)
 			reg10741 := PrimCons(reg10739, reg10740)
 			reg10742 := PrimCons(reg10738, reg10741)
-			__ctx.Return(reg10742)
+			__e.Return(reg10742)
 			return
 		} else {
 			reg10743 := MakeSymbol("shen.insert-predicate")
-			__ctx.TailApply(__defun__shen_4f__error, reg10743)
+			__e.TailApply(__defun__shen_4f__error, reg10743)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.insert-predicate", value: __defun__shen_4insert_1predicate})
 
-	__defun__shen_4_5predicate_d_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5predicate_d_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V863 := __args[0]
 		_ = V863
 		reg10745 := PrimHead(V863)
 		reg10746 := PrimIsPair(reg10745)
 		if reg10746 == True {
-			reg10747 := __e.Call(__defun__shen_4hdhd, V863)
+			reg10747 := Call(__e, __defun__shen_4hdhd, V863)
 			Parse__X := reg10747
 			_ = Parse__X
-			reg10748 := __e.Call(__defun__shen_4tlhd, V863)
-			reg10749 := __e.Call(__defun__shen_4hdtl, V863)
-			reg10750 := __e.Call(__defun__shen_4pair, reg10748, reg10749)
+			reg10748 := Call(__e, __defun__shen_4tlhd, V863)
+			reg10749 := Call(__e, __defun__shen_4hdtl, V863)
+			reg10750 := Call(__e, __defun__shen_4pair, reg10748, reg10749)
 			reg10751 := PrimHead(reg10750)
-			__ctx.TailApply(__defun__shen_4pair, reg10751, Parse__X)
+			__e.TailApply(__defun__shen_4pair, reg10751, Parse__X)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<predicate*>", value: __defun__shen_4_5predicate_d_6})
 
-	__defun__shen_4_5clauses_d_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5clauses_d_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V865 := __args[0]
 		_ = V865
-		reg10754 := __e.Call(__defun__shen_4_5clause_d_6, V865)
+		reg10754 := Call(__e, __defun__shen_4_5clause_d_6, V865)
 		Parse__shen_4_5clause_d_6 := reg10754
 		_ = Parse__shen_4_5clause_d_6
-		reg10755 := __e.Call(__defun__fail)
+		reg10755 := Call(__e, __defun__fail)
 		reg10756 := PrimEqual(reg10755, Parse__shen_4_5clause_d_6)
 		reg10757 := PrimNot(reg10756)
 		var reg10770 Obj
 		if reg10757 == True {
-			reg10758 := __e.Call(__defun__shen_4_5clauses_d_6, Parse__shen_4_5clause_d_6)
+			reg10758 := Call(__e, __defun__shen_4_5clauses_d_6, Parse__shen_4_5clause_d_6)
 			Parse__shen_4_5clauses_d_6 := reg10758
 			_ = Parse__shen_4_5clauses_d_6
-			reg10759 := __e.Call(__defun__fail)
+			reg10759 := Call(__e, __defun__fail)
 			reg10760 := PrimEqual(reg10759, Parse__shen_4_5clauses_d_6)
 			reg10761 := PrimNot(reg10760)
 			var reg10768 Obj
 			if reg10761 == True {
 				reg10762 := PrimHead(Parse__shen_4_5clauses_d_6)
-				reg10763 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5clause_d_6)
-				reg10764 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5clauses_d_6)
+				reg10763 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5clause_d_6)
+				reg10764 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5clauses_d_6)
 				reg10765 := PrimCons(reg10763, reg10764)
-				reg10766 := __e.Call(__defun__shen_4pair, reg10762, reg10765)
+				reg10766 := Call(__e, __defun__shen_4pair, reg10762, reg10765)
 				reg10768 = reg10766
 			} else {
-				reg10767 := __e.Call(__defun__fail)
+				reg10767 := Call(__e, __defun__fail)
 				reg10768 = reg10767
 			}
 			reg10770 = reg10768
 		} else {
-			reg10769 := __e.Call(__defun__fail)
+			reg10769 := Call(__e, __defun__fail)
 			reg10770 = reg10769
 		}
 		YaccParse := reg10770
 		_ = YaccParse
-		reg10771 := __e.Call(__defun__fail)
+		reg10771 := Call(__e, __defun__fail)
 		reg10772 := PrimEqual(YaccParse, reg10771)
 		if reg10772 == True {
-			reg10773 := __e.Call(__defun___5e_6, V865)
+			reg10773 := Call(__e, __defun___5e_6, V865)
 			Parse___5e_6 := reg10773
 			_ = Parse___5e_6
-			reg10774 := __e.Call(__defun__fail)
+			reg10774 := Call(__e, __defun__fail)
 			reg10775 := PrimEqual(reg10774, Parse___5e_6)
 			reg10776 := PrimNot(reg10775)
 			if reg10776 == True {
 				reg10777 := PrimHead(Parse___5e_6)
 				reg10778 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg10777, reg10778)
+				__e.TailApply(__defun__shen_4pair, reg10777, reg10778)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<clauses*>", value: __defun__shen_4_5clauses_d_6})
 
-	__defun__shen_4_5clause_d_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5clause_d_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V868 := __args[0]
 		_ = V868
-		reg10781 := __e.Call(__defun__shen_4_5head_d_6, V868)
+		reg10781 := Call(__e, __defun__shen_4_5head_d_6, V868)
 		Parse__shen_4_5head_d_6 := reg10781
 		_ = Parse__shen_4_5head_d_6
-		reg10782 := __e.Call(__defun__fail)
+		reg10782 := Call(__e, __defun__fail)
 		reg10783 := PrimEqual(reg10782, Parse__shen_4_5head_d_6)
 		reg10784 := PrimNot(reg10783)
 		if reg10784 == True {
@@ -508,7 +508,7 @@ func init() {
 			var reg10794 Obj
 			if reg10786 == True {
 				reg10787 := MakeSymbol("<--")
-				reg10788 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5head_d_6)
+				reg10788 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5head_d_6)
 				reg10789 := PrimEqual(reg10787, reg10788)
 				var reg10792 Obj
 				if reg10789 == True {
@@ -524,120 +524,120 @@ func init() {
 				reg10794 = reg10793
 			}
 			if reg10794 == True {
-				reg10795 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5head_d_6)
-				reg10796 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5head_d_6)
-				reg10797 := __e.Call(__defun__shen_4pair, reg10795, reg10796)
+				reg10795 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5head_d_6)
+				reg10796 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5head_d_6)
+				reg10797 := Call(__e, __defun__shen_4pair, reg10795, reg10796)
 				NewStream866 := reg10797
 				_ = NewStream866
-				reg10798 := __e.Call(__defun__shen_4_5body_d_6, NewStream866)
+				reg10798 := Call(__e, __defun__shen_4_5body_d_6, NewStream866)
 				Parse__shen_4_5body_d_6 := reg10798
 				_ = Parse__shen_4_5body_d_6
-				reg10799 := __e.Call(__defun__fail)
+				reg10799 := Call(__e, __defun__fail)
 				reg10800 := PrimEqual(reg10799, Parse__shen_4_5body_d_6)
 				reg10801 := PrimNot(reg10800)
 				if reg10801 == True {
-					reg10802 := __e.Call(__defun__shen_4_5end_d_6, Parse__shen_4_5body_d_6)
+					reg10802 := Call(__e, __defun__shen_4_5end_d_6, Parse__shen_4_5body_d_6)
 					Parse__shen_4_5end_d_6 := reg10802
 					_ = Parse__shen_4_5end_d_6
-					reg10803 := __e.Call(__defun__fail)
+					reg10803 := Call(__e, __defun__fail)
 					reg10804 := PrimEqual(reg10803, Parse__shen_4_5end_d_6)
 					reg10805 := PrimNot(reg10804)
 					if reg10805 == True {
 						reg10806 := PrimHead(Parse__shen_4_5end_d_6)
-						reg10807 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5head_d_6)
-						reg10808 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5body_d_6)
+						reg10807 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5head_d_6)
+						reg10808 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5body_d_6)
 						reg10809 := Nil
 						reg10810 := PrimCons(reg10808, reg10809)
 						reg10811 := PrimCons(reg10807, reg10810)
-						__ctx.TailApply(__defun__shen_4pair, reg10806, reg10811)
+						__e.TailApply(__defun__shen_4pair, reg10806, reg10811)
 						return
 					} else {
-						__ctx.TailApply(__defun__fail)
+						__e.TailApply(__defun__fail)
 						return
 					}
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<clause*>", value: __defun__shen_4_5clause_d_6})
 
-	__defun__shen_4_5head_d_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5head_d_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V870 := __args[0]
 		_ = V870
-		reg10817 := __e.Call(__defun__shen_4_5term_d_6, V870)
+		reg10817 := Call(__e, __defun__shen_4_5term_d_6, V870)
 		Parse__shen_4_5term_d_6 := reg10817
 		_ = Parse__shen_4_5term_d_6
-		reg10818 := __e.Call(__defun__fail)
+		reg10818 := Call(__e, __defun__fail)
 		reg10819 := PrimEqual(reg10818, Parse__shen_4_5term_d_6)
 		reg10820 := PrimNot(reg10819)
 		var reg10833 Obj
 		if reg10820 == True {
-			reg10821 := __e.Call(__defun__shen_4_5head_d_6, Parse__shen_4_5term_d_6)
+			reg10821 := Call(__e, __defun__shen_4_5head_d_6, Parse__shen_4_5term_d_6)
 			Parse__shen_4_5head_d_6 := reg10821
 			_ = Parse__shen_4_5head_d_6
-			reg10822 := __e.Call(__defun__fail)
+			reg10822 := Call(__e, __defun__fail)
 			reg10823 := PrimEqual(reg10822, Parse__shen_4_5head_d_6)
 			reg10824 := PrimNot(reg10823)
 			var reg10831 Obj
 			if reg10824 == True {
 				reg10825 := PrimHead(Parse__shen_4_5head_d_6)
-				reg10826 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5term_d_6)
-				reg10827 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5head_d_6)
+				reg10826 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5term_d_6)
+				reg10827 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5head_d_6)
 				reg10828 := PrimCons(reg10826, reg10827)
-				reg10829 := __e.Call(__defun__shen_4pair, reg10825, reg10828)
+				reg10829 := Call(__e, __defun__shen_4pair, reg10825, reg10828)
 				reg10831 = reg10829
 			} else {
-				reg10830 := __e.Call(__defun__fail)
+				reg10830 := Call(__e, __defun__fail)
 				reg10831 = reg10830
 			}
 			reg10833 = reg10831
 		} else {
-			reg10832 := __e.Call(__defun__fail)
+			reg10832 := Call(__e, __defun__fail)
 			reg10833 = reg10832
 		}
 		YaccParse := reg10833
 		_ = YaccParse
-		reg10834 := __e.Call(__defun__fail)
+		reg10834 := Call(__e, __defun__fail)
 		reg10835 := PrimEqual(YaccParse, reg10834)
 		if reg10835 == True {
-			reg10836 := __e.Call(__defun___5e_6, V870)
+			reg10836 := Call(__e, __defun___5e_6, V870)
 			Parse___5e_6 := reg10836
 			_ = Parse___5e_6
-			reg10837 := __e.Call(__defun__fail)
+			reg10837 := Call(__e, __defun__fail)
 			reg10838 := PrimEqual(reg10837, Parse___5e_6)
 			reg10839 := PrimNot(reg10838)
 			if reg10839 == True {
 				reg10840 := PrimHead(Parse___5e_6)
 				reg10841 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg10840, reg10841)
+				__e.TailApply(__defun__shen_4pair, reg10840, reg10841)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<head*>", value: __defun__shen_4_5head_d_6})
 
-	__defun__shen_4_5term_d_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5term_d_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V872 := __args[0]
 		_ = V872
 		reg10844 := PrimHead(V872)
 		reg10845 := PrimIsPair(reg10844)
 		if reg10845 == True {
-			reg10846 := __e.Call(__defun__shen_4hdhd, V872)
+			reg10846 := Call(__e, __defun__shen_4hdhd, V872)
 			Parse__X := reg10846
 			_ = Parse__X
 			reg10847 := MakeSymbol("<--")
@@ -645,7 +645,7 @@ func init() {
 			reg10849 := PrimNot(reg10848)
 			var reg10855 Obj
 			if reg10849 == True {
-				reg10850 := __e.Call(__defun__shen_4legitimate_1term_2, Parse__X)
+				reg10850 := Call(__e, __defun__shen_4legitimate_1term_2, Parse__X)
 				var reg10853 Obj
 				if reg10850 == True {
 					reg10851 := True
@@ -660,25 +660,25 @@ func init() {
 				reg10855 = reg10854
 			}
 			if reg10855 == True {
-				reg10856 := __e.Call(__defun__shen_4tlhd, V872)
-				reg10857 := __e.Call(__defun__shen_4hdtl, V872)
-				reg10858 := __e.Call(__defun__shen_4pair, reg10856, reg10857)
+				reg10856 := Call(__e, __defun__shen_4tlhd, V872)
+				reg10857 := Call(__e, __defun__shen_4hdtl, V872)
+				reg10858 := Call(__e, __defun__shen_4pair, reg10856, reg10857)
 				reg10859 := PrimHead(reg10858)
-				reg10860 := __e.Call(__defun__shen_4eval_1cons, Parse__X)
-				__ctx.TailApply(__defun__shen_4pair, reg10859, reg10860)
+				reg10860 := Call(__e, __defun__shen_4eval_1cons, Parse__X)
+				__e.TailApply(__defun__shen_4pair, reg10859, reg10860)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<term*>", value: __defun__shen_4_5term_d_6})
 
-	__defun__shen_4legitimate_1term_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4legitimate_1term_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V878 := __args[0]
 		_ = V878
 		reg10864 := PrimIsPair(V878)
@@ -758,24 +758,24 @@ func init() {
 		if reg10897 == True {
 			reg10898 := PrimTail(V878)
 			reg10899 := PrimHead(reg10898)
-			reg10900 := __e.Call(__defun__shen_4legitimate_1term_2, reg10899)
+			reg10900 := Call(__e, __defun__shen_4legitimate_1term_2, reg10899)
 			if reg10900 == True {
 				reg10901 := PrimTail(V878)
 				reg10902 := PrimTail(reg10901)
 				reg10903 := PrimHead(reg10902)
-				reg10904 := __e.Call(__defun__shen_4legitimate_1term_2, reg10903)
+				reg10904 := Call(__e, __defun__shen_4legitimate_1term_2, reg10903)
 				if reg10904 == True {
 					reg10905 := True
-					__ctx.Return(reg10905)
+					__e.Return(reg10905)
 					return
 				} else {
 					reg10906 := False
-					__ctx.Return(reg10906)
+					__e.Return(reg10906)
 					return
 				}
 			} else {
 				reg10907 := False
-				__ctx.Return(reg10907)
+				__e.Return(reg10907)
 				return
 			}
 		} else {
@@ -876,7 +876,7 @@ func init() {
 			if reg10951 == True {
 				reg10952 := PrimTail(V878)
 				reg10953 := PrimHead(reg10952)
-				__ctx.TailApply(__defun__shen_4legitimate_1term_2, reg10953)
+				__e.TailApply(__defun__shen_4legitimate_1term_2, reg10953)
 				return
 			} else {
 				reg10955 := PrimIsPair(V878)
@@ -976,17 +976,17 @@ func init() {
 				if reg10998 == True {
 					reg10999 := PrimTail(V878)
 					reg11000 := PrimHead(reg10999)
-					__ctx.TailApply(__defun__shen_4legitimate_1term_2, reg11000)
+					__e.TailApply(__defun__shen_4legitimate_1term_2, reg11000)
 					return
 				} else {
 					reg11002 := PrimIsPair(V878)
 					if reg11002 == True {
 						reg11003 := False
-						__ctx.Return(reg11003)
+						__e.Return(reg11003)
 						return
 					} else {
 						reg11004 := True
-						__ctx.Return(reg11004)
+						__e.Return(reg11004)
 						return
 					}
 				}
@@ -995,7 +995,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.legitimate-term?", value: __defun__shen_4legitimate_1term_2})
 
-	__defun__shen_4eval_1cons = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4eval_1cons = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V880 := __args[0]
 		_ = V880
 		reg11005 := PrimIsPair(V880)
@@ -1075,13 +1075,13 @@ func init() {
 		if reg11038 == True {
 			reg11039 := PrimTail(V880)
 			reg11040 := PrimHead(reg11039)
-			reg11041 := __e.Call(__defun__shen_4eval_1cons, reg11040)
+			reg11041 := Call(__e, __defun__shen_4eval_1cons, reg11040)
 			reg11042 := PrimTail(V880)
 			reg11043 := PrimTail(reg11042)
 			reg11044 := PrimHead(reg11043)
-			reg11045 := __e.Call(__defun__shen_4eval_1cons, reg11044)
+			reg11045 := Call(__e, __defun__shen_4eval_1cons, reg11044)
 			reg11046 := PrimCons(reg11041, reg11045)
-			__ctx.Return(reg11046)
+			__e.Return(reg11046)
 			return
 		} else {
 			reg11047 := PrimIsPair(V880)
@@ -1162,83 +1162,83 @@ func init() {
 				reg11081 := MakeSymbol("mode")
 				reg11082 := PrimTail(V880)
 				reg11083 := PrimHead(reg11082)
-				reg11084 := __e.Call(__defun__shen_4eval_1cons, reg11083)
+				reg11084 := Call(__e, __defun__shen_4eval_1cons, reg11083)
 				reg11085 := PrimTail(V880)
 				reg11086 := PrimTail(reg11085)
 				reg11087 := PrimCons(reg11084, reg11086)
 				reg11088 := PrimCons(reg11081, reg11087)
-				__ctx.Return(reg11088)
+				__e.Return(reg11088)
 				return
 			} else {
-				__ctx.Return(V880)
+				__e.Return(V880)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.eval-cons", value: __defun__shen_4eval_1cons})
 
-	__defun__shen_4_5body_d_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5body_d_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V882 := __args[0]
 		_ = V882
-		reg11089 := __e.Call(__defun__shen_4_5literal_d_6, V882)
+		reg11089 := Call(__e, __defun__shen_4_5literal_d_6, V882)
 		Parse__shen_4_5literal_d_6 := reg11089
 		_ = Parse__shen_4_5literal_d_6
-		reg11090 := __e.Call(__defun__fail)
+		reg11090 := Call(__e, __defun__fail)
 		reg11091 := PrimEqual(reg11090, Parse__shen_4_5literal_d_6)
 		reg11092 := PrimNot(reg11091)
 		var reg11105 Obj
 		if reg11092 == True {
-			reg11093 := __e.Call(__defun__shen_4_5body_d_6, Parse__shen_4_5literal_d_6)
+			reg11093 := Call(__e, __defun__shen_4_5body_d_6, Parse__shen_4_5literal_d_6)
 			Parse__shen_4_5body_d_6 := reg11093
 			_ = Parse__shen_4_5body_d_6
-			reg11094 := __e.Call(__defun__fail)
+			reg11094 := Call(__e, __defun__fail)
 			reg11095 := PrimEqual(reg11094, Parse__shen_4_5body_d_6)
 			reg11096 := PrimNot(reg11095)
 			var reg11103 Obj
 			if reg11096 == True {
 				reg11097 := PrimHead(Parse__shen_4_5body_d_6)
-				reg11098 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5literal_d_6)
-				reg11099 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5body_d_6)
+				reg11098 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5literal_d_6)
+				reg11099 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5body_d_6)
 				reg11100 := PrimCons(reg11098, reg11099)
-				reg11101 := __e.Call(__defun__shen_4pair, reg11097, reg11100)
+				reg11101 := Call(__e, __defun__shen_4pair, reg11097, reg11100)
 				reg11103 = reg11101
 			} else {
-				reg11102 := __e.Call(__defun__fail)
+				reg11102 := Call(__e, __defun__fail)
 				reg11103 = reg11102
 			}
 			reg11105 = reg11103
 		} else {
-			reg11104 := __e.Call(__defun__fail)
+			reg11104 := Call(__e, __defun__fail)
 			reg11105 = reg11104
 		}
 		YaccParse := reg11105
 		_ = YaccParse
-		reg11106 := __e.Call(__defun__fail)
+		reg11106 := Call(__e, __defun__fail)
 		reg11107 := PrimEqual(YaccParse, reg11106)
 		if reg11107 == True {
-			reg11108 := __e.Call(__defun___5e_6, V882)
+			reg11108 := Call(__e, __defun___5e_6, V882)
 			Parse___5e_6 := reg11108
 			_ = Parse___5e_6
-			reg11109 := __e.Call(__defun__fail)
+			reg11109 := Call(__e, __defun__fail)
 			reg11110 := PrimEqual(reg11109, Parse___5e_6)
 			reg11111 := PrimNot(reg11110)
 			if reg11111 == True {
 				reg11112 := PrimHead(Parse___5e_6)
 				reg11113 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg11112, reg11113)
+				__e.TailApply(__defun__shen_4pair, reg11112, reg11113)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<body*>", value: __defun__shen_4_5body_d_6})
 
-	__defun__shen_4_5literal_d_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5literal_d_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V885 := __args[0]
 		_ = V885
 		reg11116 := PrimHead(V885)
@@ -1246,7 +1246,7 @@ func init() {
 		var reg11125 Obj
 		if reg11117 == True {
 			reg11118 := MakeSymbol("!")
-			reg11119 := __e.Call(__defun__shen_4hdhd, V885)
+			reg11119 := Call(__e, __defun__shen_4hdhd, V885)
 			reg11120 := PrimEqual(reg11118, reg11119)
 			var reg11123 Obj
 			if reg11120 == True {
@@ -1263,9 +1263,9 @@ func init() {
 		}
 		var reg11138 Obj
 		if reg11125 == True {
-			reg11126 := __e.Call(__defun__shen_4tlhd, V885)
-			reg11127 := __e.Call(__defun__shen_4hdtl, V885)
-			reg11128 := __e.Call(__defun__shen_4pair, reg11126, reg11127)
+			reg11126 := Call(__e, __defun__shen_4tlhd, V885)
+			reg11127 := Call(__e, __defun__shen_4hdtl, V885)
+			reg11128 := Call(__e, __defun__shen_4pair, reg11126, reg11127)
 			NewStream883 := reg11128
 			_ = NewStream883
 			reg11129 := PrimHead(NewStream883)
@@ -1275,98 +1275,98 @@ func init() {
 			reg11133 := Nil
 			reg11134 := PrimCons(reg11132, reg11133)
 			reg11135 := PrimCons(reg11130, reg11134)
-			reg11136 := __e.Call(__defun__shen_4pair, reg11129, reg11135)
+			reg11136 := Call(__e, __defun__shen_4pair, reg11129, reg11135)
 			reg11138 = reg11136
 		} else {
-			reg11137 := __e.Call(__defun__fail)
+			reg11137 := Call(__e, __defun__fail)
 			reg11138 = reg11137
 		}
 		YaccParse := reg11138
 		_ = YaccParse
-		reg11139 := __e.Call(__defun__fail)
+		reg11139 := Call(__e, __defun__fail)
 		reg11140 := PrimEqual(YaccParse, reg11139)
 		if reg11140 == True {
 			reg11141 := PrimHead(V885)
 			reg11142 := PrimIsPair(reg11141)
 			if reg11142 == True {
-				reg11143 := __e.Call(__defun__shen_4hdhd, V885)
+				reg11143 := Call(__e, __defun__shen_4hdhd, V885)
 				Parse__X := reg11143
 				_ = Parse__X
 				reg11144 := PrimIsPair(Parse__X)
 				if reg11144 == True {
-					reg11145 := __e.Call(__defun__shen_4tlhd, V885)
-					reg11146 := __e.Call(__defun__shen_4hdtl, V885)
-					reg11147 := __e.Call(__defun__shen_4pair, reg11145, reg11146)
+					reg11145 := Call(__e, __defun__shen_4tlhd, V885)
+					reg11146 := Call(__e, __defun__shen_4hdtl, V885)
+					reg11147 := Call(__e, __defun__shen_4pair, reg11145, reg11146)
 					reg11148 := PrimHead(reg11147)
-					__ctx.TailApply(__defun__shen_4pair, reg11148, Parse__X)
+					__e.TailApply(__defun__shen_4pair, reg11148, Parse__X)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<literal*>", value: __defun__shen_4_5literal_d_6})
 
-	__defun__shen_4_5end_d_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5end_d_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V887 := __args[0]
 		_ = V887
 		reg11152 := PrimHead(V887)
 		reg11153 := PrimIsPair(reg11152)
 		if reg11153 == True {
-			reg11154 := __e.Call(__defun__shen_4hdhd, V887)
+			reg11154 := Call(__e, __defun__shen_4hdhd, V887)
 			Parse__X := reg11154
 			_ = Parse__X
 			reg11155 := MakeSymbol(";")
 			reg11156 := PrimEqual(Parse__X, reg11155)
 			if reg11156 == True {
-				reg11157 := __e.Call(__defun__shen_4tlhd, V887)
-				reg11158 := __e.Call(__defun__shen_4hdtl, V887)
-				reg11159 := __e.Call(__defun__shen_4pair, reg11157, reg11158)
+				reg11157 := Call(__e, __defun__shen_4tlhd, V887)
+				reg11158 := Call(__e, __defun__shen_4hdtl, V887)
+				reg11159 := Call(__e, __defun__shen_4pair, reg11157, reg11158)
 				reg11160 := PrimHead(reg11159)
-				__ctx.TailApply(__defun__shen_4pair, reg11160, Parse__X)
+				__e.TailApply(__defun__shen_4pair, reg11160, Parse__X)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<end*>", value: __defun__shen_4_5end_d_6})
 
-	__defun__cut = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__cut = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V891 := __args[0]
 		_ = V891
 		V892 := __args[1]
 		_ = V892
 		V893 := __args[2]
 		_ = V893
-		reg11164 := __e.Call(__defun__thaw, V893)
+		reg11164 := Call(__e, __defun__thaw, V893)
 		Result := reg11164
 		_ = Result
 		reg11165 := False
 		reg11166 := PrimEqual(Result, reg11165)
 		if reg11166 == True {
-			__ctx.Return(V891)
+			__e.Return(V891)
 			return
 		} else {
-			__ctx.Return(Result)
+			__e.Return(Result)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "cut", value: __defun__cut})
 
-	__defun__shen_4insert__modes = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert__modes = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V895 := __args[0]
 		_ = V895
 		reg11167 := PrimIsPair(V895)
@@ -1444,14 +1444,14 @@ func init() {
 			reg11200 = reg11199
 		}
 		if reg11200 == True {
-			__ctx.Return(V895)
+			__e.Return(V895)
 			return
 		} else {
 			reg11201 := Nil
 			reg11202 := PrimEqual(reg11201, V895)
 			if reg11202 == True {
 				reg11203 := Nil
-				__ctx.Return(reg11203)
+				__e.Return(reg11203)
 				return
 			} else {
 				reg11204 := PrimIsPair(V895)
@@ -1465,17 +1465,17 @@ func init() {
 					reg11211 := PrimCons(reg11205, reg11210)
 					reg11212 := MakeSymbol("mode")
 					reg11213 := PrimTail(V895)
-					reg11214 := __e.Call(__defun__shen_4insert__modes, reg11213)
+					reg11214 := Call(__e, __defun__shen_4insert__modes, reg11213)
 					reg11215 := MakeSymbol("-")
 					reg11216 := Nil
 					reg11217 := PrimCons(reg11215, reg11216)
 					reg11218 := PrimCons(reg11214, reg11217)
 					reg11219 := PrimCons(reg11212, reg11218)
 					reg11220 := PrimCons(reg11211, reg11219)
-					__ctx.Return(reg11220)
+					__e.Return(reg11220)
 					return
 				} else {
-					__ctx.Return(V895)
+					__e.Return(V895)
 					return
 				}
 			}
@@ -1483,51 +1483,51 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.insert_modes", value: __defun__shen_4insert__modes})
 
-	__defun__shen_4s_1prolog = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4s_1prolog = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V897 := __args[0]
 		_ = V897
-		reg11221 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg11221 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__eval, X)
+			__e.TailApply(__defun__eval, X)
 			return
 		}, 1)
-		reg11223 := __e.Call(__defun__shen_4prolog_1_6shen, V897)
-		__ctx.TailApply(__defun__map, reg11221, reg11223)
+		reg11223 := Call(__e, __defun__shen_4prolog_1_6shen, V897)
+		__e.TailApply(__defun__map, reg11221, reg11223)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.s-prolog", value: __defun__shen_4s_1prolog})
 
-	__defun__shen_4prolog_1_6shen = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prolog_1_6shen = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V899 := __args[0]
 		_ = V899
-		reg11225 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg11225 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4compile__prolog__procedure, X)
+			__e.TailApply(__defun__shen_4compile__prolog__procedure, X)
 			return
 		}, 1)
-		reg11227 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg11227 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4s_1prolog__clause, X)
+			__e.TailApply(__defun__shen_4s_1prolog__clause, X)
 			return
 		}, 1)
-		reg11229 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg11229 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4head__abstraction, X)
+			__e.TailApply(__defun__shen_4head__abstraction, X)
 			return
 		}, 1)
-		reg11231 := __e.Call(__defun__mapcan, reg11229, V899)
-		reg11232 := __e.Call(__defun__map, reg11227, reg11231)
-		reg11233 := __e.Call(__defun__shen_4group__clauses, reg11232)
-		__ctx.TailApply(__defun__map, reg11225, reg11233)
+		reg11231 := Call(__e, __defun__mapcan, reg11229, V899)
+		reg11232 := Call(__e, __defun__map, reg11227, reg11231)
+		reg11233 := Call(__e, __defun__shen_4group__clauses, reg11232)
+		__e.TailApply(__defun__map, reg11225, reg11233)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.prolog->shen", value: __defun__shen_4prolog_1_6shen})
 
-	__defun__shen_4s_1prolog__clause = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4s_1prolog__clause = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V901 := __args[0]
 		_ = V901
 		reg11235 := PrimIsPair(V901)
@@ -1608,31 +1608,31 @@ func init() {
 		if reg11269 == True {
 			reg11270 := PrimHead(V901)
 			reg11271 := MakeSymbol(":-")
-			reg11272 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg11272 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				__ctx.TailApply(__defun__shen_4s_1prolog__literal, X)
+				__e.TailApply(__defun__shen_4s_1prolog__literal, X)
 				return
 			}, 1)
 			reg11274 := PrimTail(V901)
 			reg11275 := PrimTail(reg11274)
 			reg11276 := PrimHead(reg11275)
-			reg11277 := __e.Call(__defun__map, reg11272, reg11276)
+			reg11277 := Call(__e, __defun__map, reg11272, reg11276)
 			reg11278 := Nil
 			reg11279 := PrimCons(reg11277, reg11278)
 			reg11280 := PrimCons(reg11271, reg11279)
 			reg11281 := PrimCons(reg11270, reg11280)
-			__ctx.Return(reg11281)
+			__e.Return(reg11281)
 			return
 		} else {
 			reg11282 := MakeSymbol("shen.s-prolog_clause")
-			__ctx.TailApply(__defun__shen_4f__error, reg11282)
+			__e.TailApply(__defun__shen_4f__error, reg11282)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.s-prolog_clause", value: __defun__shen_4s_1prolog__clause})
 
-	__defun__shen_4head__abstraction = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4head__abstraction = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V903 := __args[0]
 		_ = V903
 		reg11284 := PrimIsPair(V903)
@@ -1660,23 +1660,23 @@ func init() {
 						reg11298 := PrimEqual(reg11294, reg11297)
 						var reg11312 Obj
 						if reg11298 == True {
-							reg11299 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+							reg11299 := MakeNative(func(__e Evaluator, __args ...Obj) {
 								reg11300 := PrimHead(V903)
-								reg11301 := __e.Call(__defun__shen_4complexity__head, reg11300)
+								reg11301 := Call(__e, __defun__shen_4complexity__head, reg11300)
 								reg11302 := MakeSymbol("shen.*maxcomplexity*")
 								reg11303 := PrimValue(reg11302)
 								reg11304 := PrimLessThan(reg11301, reg11303)
-								__ctx.Return(reg11304)
+								__e.Return(reg11304)
 								return
 							}, 0)
-							reg11305 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+							reg11305 := MakeNative(func(__e Evaluator, __args ...Obj) {
 								__ := __args[0]
 								_ = __
 								reg11306 := False
-								__ctx.Return(reg11306)
+								__e.Return(reg11306)
 								return
 							}, 1)
-							reg11307 := __e.Try(reg11299).Catch(reg11305)
+							reg11307 := Try(__e, reg11299).Catch(reg11305)
 							var reg11310 Obj
 							if reg11307 == True {
 								reg11308 := True
@@ -1745,7 +1745,7 @@ func init() {
 		if reg11332 == True {
 			reg11333 := Nil
 			reg11334 := PrimCons(V903, reg11333)
-			__ctx.Return(reg11334)
+			__e.Return(reg11334)
 			return
 		} else {
 			reg11335 := PrimIsPair(V903)
@@ -1841,26 +1841,26 @@ func init() {
 				reg11376 = reg11375
 			}
 			if reg11376 == True {
-				reg11377 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg11377 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					Y := __args[0]
 					_ = Y
 					reg11378 := MakeSymbol("V")
-					__ctx.TailApply(__defun__gensym, reg11378)
+					__e.TailApply(__defun__gensym, reg11378)
 					return
 				}, 1)
 				reg11380 := PrimHead(V903)
 				reg11381 := PrimTail(reg11380)
-				reg11382 := __e.Call(__defun__map, reg11377, reg11381)
+				reg11382 := Call(__e, __defun__map, reg11377, reg11381)
 				Terms := reg11382
 				_ = Terms
 				reg11383 := PrimHead(V903)
 				reg11384 := PrimTail(reg11383)
-				reg11385 := __e.Call(__defun__shen_4remove__modes, reg11384)
-				reg11386 := __e.Call(__defun__shen_4rcons__form, reg11385)
+				reg11385 := Call(__e, __defun__shen_4remove__modes, reg11384)
+				reg11386 := Call(__e, __defun__shen_4rcons__form, reg11385)
 				XTerms := reg11386
 				_ = XTerms
 				reg11387 := MakeSymbol("unify")
-				reg11388 := __e.Call(__defun__shen_4cons__form, Terms)
+				reg11388 := Call(__e, __defun__shen_4cons__form, Terms)
 				reg11389 := Nil
 				reg11390 := PrimCons(XTerms, reg11389)
 				reg11391 := PrimCons(reg11388, reg11390)
@@ -1883,52 +1883,52 @@ func init() {
 				_ = Clause
 				reg11405 := Nil
 				reg11406 := PrimCons(Clause, reg11405)
-				__ctx.Return(reg11406)
+				__e.Return(reg11406)
 				return
 			} else {
 				reg11407 := MakeSymbol("shen.head_abstraction")
-				__ctx.TailApply(__defun__shen_4f__error, reg11407)
+				__e.TailApply(__defun__shen_4f__error, reg11407)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.head_abstraction", value: __defun__shen_4head__abstraction})
 
-	__defun__shen_4complexity__head = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4complexity__head = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V909 := __args[0]
 		_ = V909
 		reg11409 := PrimIsPair(V909)
 		if reg11409 == True {
-			reg11410 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg11410 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				__ctx.TailApply(__defun__shen_4complexity, X)
+				__e.TailApply(__defun__shen_4complexity, X)
 				return
 			}, 1)
 			reg11412 := PrimTail(V909)
-			reg11413 := __e.Call(__defun__map, reg11410, reg11412)
-			__ctx.TailApply(__defun__shen_4safe_1product, reg11413)
+			reg11413 := Call(__e, __defun__map, reg11410, reg11412)
+			__e.TailApply(__defun__shen_4safe_1product, reg11413)
 			return
 		} else {
 			reg11415 := MakeSymbol("shen.complexity_head")
-			__ctx.TailApply(__defun__shen_4f__error, reg11415)
+			__e.TailApply(__defun__shen_4f__error, reg11415)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.complexity_head", value: __defun__shen_4complexity__head})
 
-	__defun__shen_4safe_1multiply = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4safe_1multiply = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V912 := __args[0]
 		_ = V912
 		V913 := __args[1]
 		_ = V913
 		reg11417 := PrimNumberMultiply(V912, V913)
-		__ctx.Return(reg11417)
+		__e.Return(reg11417)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.safe-multiply", value: __defun__shen_4safe_1multiply})
 
-	__defun__shen_4complexity = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4complexity = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V922 := __args[0]
 		_ = V922
 		reg11418 := PrimIsPair(V922)
@@ -2107,7 +2107,7 @@ func init() {
 		if reg11500 == True {
 			reg11501 := PrimTail(V922)
 			reg11502 := PrimHead(reg11501)
-			__ctx.TailApply(__defun__shen_4complexity, reg11502)
+			__e.TailApply(__defun__shen_4complexity, reg11502)
 			return
 		} else {
 			reg11504 := PrimIsPair(V922)
@@ -2232,7 +2232,7 @@ func init() {
 				reg11562 := PrimTail(reg11561)
 				reg11563 := PrimCons(reg11560, reg11562)
 				reg11564 := PrimCons(reg11557, reg11563)
-				reg11565 := __e.Call(__defun__shen_4complexity, reg11564)
+				reg11565 := Call(__e, __defun__shen_4complexity, reg11564)
 				reg11566 := MakeSymbol("mode")
 				reg11567 := PrimTail(V922)
 				reg11568 := PrimHead(reg11567)
@@ -2241,9 +2241,9 @@ func init() {
 				reg11571 := PrimTail(reg11570)
 				reg11572 := PrimCons(reg11569, reg11571)
 				reg11573 := PrimCons(reg11566, reg11572)
-				reg11574 := __e.Call(__defun__shen_4complexity, reg11573)
-				reg11575 := __e.Call(__defun__shen_4safe_1multiply, reg11565, reg11574)
-				__ctx.TailApply(__defun__shen_4safe_1multiply, reg11556, reg11575)
+				reg11574 := Call(__e, __defun__shen_4complexity, reg11573)
+				reg11575 := Call(__e, __defun__shen_4safe_1multiply, reg11565, reg11574)
+				__e.TailApply(__defun__shen_4safe_1multiply, reg11556, reg11575)
 				return
 			} else {
 				reg11577 := PrimIsPair(V922)
@@ -2367,7 +2367,7 @@ func init() {
 					reg11634 := PrimTail(reg11633)
 					reg11635 := PrimCons(reg11632, reg11634)
 					reg11636 := PrimCons(reg11629, reg11635)
-					reg11637 := __e.Call(__defun__shen_4complexity, reg11636)
+					reg11637 := Call(__e, __defun__shen_4complexity, reg11636)
 					reg11638 := MakeSymbol("mode")
 					reg11639 := PrimTail(V922)
 					reg11640 := PrimHead(reg11639)
@@ -2376,8 +2376,8 @@ func init() {
 					reg11643 := PrimTail(reg11642)
 					reg11644 := PrimCons(reg11641, reg11643)
 					reg11645 := PrimCons(reg11638, reg11644)
-					reg11646 := __e.Call(__defun__shen_4complexity, reg11645)
-					__ctx.TailApply(__defun__shen_4safe_1multiply, reg11637, reg11646)
+					reg11646 := Call(__e, __defun__shen_4complexity, reg11645)
+					__e.TailApply(__defun__shen_4safe_1multiply, reg11637, reg11646)
 					return
 				} else {
 					reg11648 := PrimIsPair(V922)
@@ -2474,7 +2474,7 @@ func init() {
 					}
 					if reg11689 == True {
 						reg11690 := MakeNumber(1)
-						__ctx.Return(reg11690)
+						__e.Return(reg11690)
 						return
 					} else {
 						reg11691 := PrimIsPair(V922)
@@ -2573,7 +2573,7 @@ func init() {
 						}
 						if reg11734 == True {
 							reg11735 := MakeNumber(2)
-							__ctx.Return(reg11735)
+							__e.Return(reg11735)
 							return
 						} else {
 							reg11736 := PrimIsPair(V922)
@@ -2672,7 +2672,7 @@ func init() {
 							}
 							if reg11779 == True {
 								reg11780 := MakeNumber(1)
-								__ctx.Return(reg11780)
+								__e.Return(reg11780)
 								return
 							} else {
 								reg11781 := MakeSymbol("mode")
@@ -2681,7 +2681,7 @@ func init() {
 								reg11784 := PrimCons(reg11782, reg11783)
 								reg11785 := PrimCons(V922, reg11784)
 								reg11786 := PrimCons(reg11781, reg11785)
-								__ctx.TailApply(__defun__shen_4complexity, reg11786)
+								__e.TailApply(__defun__shen_4complexity, reg11786)
 								return
 							}
 						}
@@ -2692,33 +2692,33 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.complexity", value: __defun__shen_4complexity})
 
-	__defun__shen_4safe_1product = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4safe_1product = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V924 := __args[0]
 		_ = V924
 		reg11788 := Nil
 		reg11789 := PrimEqual(reg11788, V924)
 		if reg11789 == True {
 			reg11790 := MakeNumber(1)
-			__ctx.Return(reg11790)
+			__e.Return(reg11790)
 			return
 		} else {
 			reg11791 := PrimIsPair(V924)
 			if reg11791 == True {
 				reg11792 := PrimHead(V924)
 				reg11793 := PrimTail(V924)
-				reg11794 := __e.Call(__defun__shen_4safe_1product, reg11793)
-				__ctx.TailApply(__defun__shen_4safe_1multiply, reg11792, reg11794)
+				reg11794 := Call(__e, __defun__shen_4safe_1product, reg11793)
+				__e.TailApply(__defun__shen_4safe_1multiply, reg11792, reg11794)
 				return
 			} else {
 				reg11796 := MakeSymbol("shen.safe-product")
-				__ctx.TailApply(__defun__shen_4f__error, reg11796)
+				__e.TailApply(__defun__shen_4f__error, reg11796)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.safe-product", value: __defun__shen_4safe_1product})
 
-	__defun__shen_4s_1prolog__literal = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4s_1prolog__literal = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V926 := __args[0]
 		_ = V926
 		reg11798 := PrimIsPair(V926)
@@ -2803,12 +2803,12 @@ func init() {
 			reg11836 := PrimTail(reg11835)
 			reg11837 := PrimHead(reg11836)
 			reg11838 := MakeSymbol("ProcessN")
-			reg11839 := __e.Call(__defun__shen_4insert_1deref, reg11837, reg11838)
+			reg11839 := Call(__e, __defun__shen_4insert_1deref, reg11837, reg11838)
 			reg11840 := Nil
 			reg11841 := PrimCons(reg11839, reg11840)
 			reg11842 := PrimCons(reg11834, reg11841)
 			reg11843 := PrimCons(reg11832, reg11842)
-			__ctx.Return(reg11843)
+			__e.Return(reg11843)
 			return
 		} else {
 			reg11844 := PrimIsPair(V926)
@@ -2871,11 +2871,11 @@ func init() {
 				reg11870 := PrimTail(V926)
 				reg11871 := PrimHead(reg11870)
 				reg11872 := MakeSymbol("ProcessN")
-				reg11873 := __e.Call(__defun__shen_4insert_1deref, reg11871, reg11872)
+				reg11873 := Call(__e, __defun__shen_4insert_1deref, reg11871, reg11872)
 				reg11874 := Nil
 				reg11875 := PrimCons(reg11873, reg11874)
 				reg11876 := PrimCons(reg11869, reg11875)
-				__ctx.Return(reg11876)
+				__e.Return(reg11876)
 				return
 			} else {
 				reg11877 := PrimIsPair(V926)
@@ -2960,12 +2960,12 @@ func init() {
 					reg11915 := PrimTail(reg11914)
 					reg11916 := PrimHead(reg11915)
 					reg11917 := MakeSymbol("ProcessN")
-					reg11918 := __e.Call(__defun__shen_4insert_1lazyderef, reg11916, reg11917)
+					reg11918 := Call(__e, __defun__shen_4insert_1lazyderef, reg11916, reg11917)
 					reg11919 := Nil
 					reg11920 := PrimCons(reg11918, reg11919)
 					reg11921 := PrimCons(reg11913, reg11920)
 					reg11922 := PrimCons(reg11911, reg11921)
-					__ctx.Return(reg11922)
+					__e.Return(reg11922)
 					return
 				} else {
 					reg11923 := PrimIsPair(V926)
@@ -3028,20 +3028,20 @@ func init() {
 						reg11949 := PrimTail(V926)
 						reg11950 := PrimHead(reg11949)
 						reg11951 := MakeSymbol("ProcessN")
-						reg11952 := __e.Call(__defun__shen_4insert_1lazyderef, reg11950, reg11951)
+						reg11952 := Call(__e, __defun__shen_4insert_1lazyderef, reg11950, reg11951)
 						reg11953 := Nil
 						reg11954 := PrimCons(reg11952, reg11953)
 						reg11955 := PrimCons(reg11948, reg11954)
-						__ctx.Return(reg11955)
+						__e.Return(reg11955)
 						return
 					} else {
 						reg11956 := PrimIsPair(V926)
 						if reg11956 == True {
-							__ctx.Return(V926)
+							__e.Return(V926)
 							return
 						} else {
 							reg11957 := MakeSymbol("shen.s-prolog_literal")
-							__ctx.TailApply(__defun__shen_4f__error, reg11957)
+							__e.TailApply(__defun__shen_4f__error, reg11957)
 							return
 						}
 					}
@@ -3051,7 +3051,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.s-prolog_literal", value: __defun__shen_4s_1prolog__literal})
 
-	__defun__shen_4insert_1deref = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert_1deref = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V933 := __args[0]
 		_ = V933
 		V934 := __args[1]
@@ -3063,7 +3063,7 @@ func init() {
 			reg11962 := PrimCons(V934, reg11961)
 			reg11963 := PrimCons(V933, reg11962)
 			reg11964 := PrimCons(reg11960, reg11963)
-			__ctx.Return(reg11964)
+			__e.Return(reg11964)
 			return
 		} else {
 			reg11965 := PrimIsPair(V933)
@@ -3147,12 +3147,12 @@ func init() {
 				reg12002 := PrimTail(V933)
 				reg12003 := PrimTail(reg12002)
 				reg12004 := PrimHead(reg12003)
-				reg12005 := __e.Call(__defun__shen_4insert_1deref, reg12004, V934)
+				reg12005 := Call(__e, __defun__shen_4insert_1deref, reg12004, V934)
 				reg12006 := Nil
 				reg12007 := PrimCons(reg12005, reg12006)
 				reg12008 := PrimCons(reg12001, reg12007)
 				reg12009 := PrimCons(reg11999, reg12008)
-				__ctx.Return(reg12009)
+				__e.Return(reg12009)
 				return
 			} else {
 				reg12010 := PrimIsPair(V933)
@@ -3256,31 +3256,31 @@ func init() {
 					reg12057 := PrimTail(V933)
 					reg12058 := PrimTail(reg12057)
 					reg12059 := PrimHead(reg12058)
-					reg12060 := __e.Call(__defun__shen_4insert_1deref, reg12059, V934)
+					reg12060 := Call(__e, __defun__shen_4insert_1deref, reg12059, V934)
 					reg12061 := PrimTail(V933)
 					reg12062 := PrimTail(reg12061)
 					reg12063 := PrimTail(reg12062)
 					reg12064 := PrimHead(reg12063)
-					reg12065 := __e.Call(__defun__shen_4insert_1deref, reg12064, V934)
+					reg12065 := Call(__e, __defun__shen_4insert_1deref, reg12064, V934)
 					reg12066 := Nil
 					reg12067 := PrimCons(reg12065, reg12066)
 					reg12068 := PrimCons(reg12060, reg12067)
 					reg12069 := PrimCons(reg12056, reg12068)
 					reg12070 := PrimCons(reg12054, reg12069)
-					__ctx.Return(reg12070)
+					__e.Return(reg12070)
 					return
 				} else {
 					reg12071 := PrimIsPair(V933)
 					if reg12071 == True {
 						reg12072 := PrimHead(V933)
-						reg12073 := __e.Call(__defun__shen_4insert_1deref, reg12072, V934)
+						reg12073 := Call(__e, __defun__shen_4insert_1deref, reg12072, V934)
 						reg12074 := PrimTail(V933)
-						reg12075 := __e.Call(__defun__shen_4insert_1deref, reg12074, V934)
+						reg12075 := Call(__e, __defun__shen_4insert_1deref, reg12074, V934)
 						reg12076 := PrimCons(reg12073, reg12075)
-						__ctx.Return(reg12076)
+						__e.Return(reg12076)
 						return
 					} else {
-						__ctx.Return(V933)
+						__e.Return(V933)
 						return
 					}
 				}
@@ -3289,7 +3289,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.insert-deref", value: __defun__shen_4insert_1deref})
 
-	__defun__shen_4insert_1lazyderef = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert_1lazyderef = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V941 := __args[0]
 		_ = V941
 		V942 := __args[1]
@@ -3301,7 +3301,7 @@ func init() {
 			reg12080 := PrimCons(V942, reg12079)
 			reg12081 := PrimCons(V941, reg12080)
 			reg12082 := PrimCons(reg12078, reg12081)
-			__ctx.Return(reg12082)
+			__e.Return(reg12082)
 			return
 		} else {
 			reg12083 := PrimIsPair(V941)
@@ -3385,12 +3385,12 @@ func init() {
 				reg12120 := PrimTail(V941)
 				reg12121 := PrimTail(reg12120)
 				reg12122 := PrimHead(reg12121)
-				reg12123 := __e.Call(__defun__shen_4insert_1lazyderef, reg12122, V942)
+				reg12123 := Call(__e, __defun__shen_4insert_1lazyderef, reg12122, V942)
 				reg12124 := Nil
 				reg12125 := PrimCons(reg12123, reg12124)
 				reg12126 := PrimCons(reg12119, reg12125)
 				reg12127 := PrimCons(reg12117, reg12126)
-				__ctx.Return(reg12127)
+				__e.Return(reg12127)
 				return
 			} else {
 				reg12128 := PrimIsPair(V941)
@@ -3494,31 +3494,31 @@ func init() {
 					reg12175 := PrimTail(V941)
 					reg12176 := PrimTail(reg12175)
 					reg12177 := PrimHead(reg12176)
-					reg12178 := __e.Call(__defun__shen_4insert_1lazyderef, reg12177, V942)
+					reg12178 := Call(__e, __defun__shen_4insert_1lazyderef, reg12177, V942)
 					reg12179 := PrimTail(V941)
 					reg12180 := PrimTail(reg12179)
 					reg12181 := PrimTail(reg12180)
 					reg12182 := PrimHead(reg12181)
-					reg12183 := __e.Call(__defun__shen_4insert_1lazyderef, reg12182, V942)
+					reg12183 := Call(__e, __defun__shen_4insert_1lazyderef, reg12182, V942)
 					reg12184 := Nil
 					reg12185 := PrimCons(reg12183, reg12184)
 					reg12186 := PrimCons(reg12178, reg12185)
 					reg12187 := PrimCons(reg12174, reg12186)
 					reg12188 := PrimCons(reg12172, reg12187)
-					__ctx.Return(reg12188)
+					__e.Return(reg12188)
 					return
 				} else {
 					reg12189 := PrimIsPair(V941)
 					if reg12189 == True {
 						reg12190 := PrimHead(V941)
-						reg12191 := __e.Call(__defun__shen_4insert_1lazyderef, reg12190, V942)
+						reg12191 := Call(__e, __defun__shen_4insert_1lazyderef, reg12190, V942)
 						reg12192 := PrimTail(V941)
-						reg12193 := __e.Call(__defun__shen_4insert_1lazyderef, reg12192, V942)
+						reg12193 := Call(__e, __defun__shen_4insert_1lazyderef, reg12192, V942)
 						reg12194 := PrimCons(reg12191, reg12193)
-						__ctx.Return(reg12194)
+						__e.Return(reg12194)
 						return
 					} else {
-						__ctx.Return(V941)
+						__e.Return(V941)
 						return
 					}
 				}
@@ -3527,45 +3527,45 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.insert-lazyderef", value: __defun__shen_4insert_1lazyderef})
 
-	__defun__shen_4group__clauses = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4group__clauses = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V944 := __args[0]
 		_ = V944
 		reg12195 := Nil
 		reg12196 := PrimEqual(reg12195, V944)
 		if reg12196 == True {
 			reg12197 := Nil
-			__ctx.Return(reg12197)
+			__e.Return(reg12197)
 			return
 		} else {
 			reg12198 := PrimIsPair(V944)
 			if reg12198 == True {
-				reg12199 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg12199 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					X := __args[0]
 					_ = X
 					reg12200 := PrimHead(V944)
-					__ctx.TailApply(__defun__shen_4same__predicate_2, reg12200, X)
+					__e.TailApply(__defun__shen_4same__predicate_2, reg12200, X)
 					return
 				}, 1)
-				reg12202 := __e.Call(__defun__shen_4collect, reg12199, V944)
+				reg12202 := Call(__e, __defun__shen_4collect, reg12199, V944)
 				Group := reg12202
 				_ = Group
-				reg12203 := __e.Call(__defun__difference, V944, Group)
+				reg12203 := Call(__e, __defun__difference, V944, Group)
 				Rest := reg12203
 				_ = Rest
-				reg12204 := __e.Call(__defun__shen_4group__clauses, Rest)
+				reg12204 := Call(__e, __defun__shen_4group__clauses, Rest)
 				reg12205 := PrimCons(Group, reg12204)
-				__ctx.Return(reg12205)
+				__e.Return(reg12205)
 				return
 			} else {
 				reg12206 := MakeSymbol("shen.group_clauses")
-				__ctx.TailApply(__defun__shen_4f__error, reg12206)
+				__e.TailApply(__defun__shen_4f__error, reg12206)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.group_clauses", value: __defun__shen_4group__clauses})
 
-	__defun__shen_4collect = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4collect = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V949 := __args[0]
 		_ = V949
 		V950 := __args[1]
@@ -3574,35 +3574,35 @@ func init() {
 		reg12209 := PrimEqual(reg12208, V950)
 		if reg12209 == True {
 			reg12210 := Nil
-			__ctx.Return(reg12210)
+			__e.Return(reg12210)
 			return
 		} else {
 			reg12211 := PrimIsPair(V950)
 			if reg12211 == True {
 				reg12212 := PrimHead(V950)
-				reg12213 := __e.Call(V949, reg12212)
+				reg12213 := Call(__e, V949, reg12212)
 				if reg12213 == True {
 					reg12214 := PrimHead(V950)
 					reg12215 := PrimTail(V950)
-					reg12216 := __e.Call(__defun__shen_4collect, V949, reg12215)
+					reg12216 := Call(__e, __defun__shen_4collect, V949, reg12215)
 					reg12217 := PrimCons(reg12214, reg12216)
-					__ctx.Return(reg12217)
+					__e.Return(reg12217)
 					return
 				} else {
 					reg12218 := PrimTail(V950)
-					__ctx.TailApply(__defun__shen_4collect, V949, reg12218)
+					__e.TailApply(__defun__shen_4collect, V949, reg12218)
 					return
 				}
 			} else {
 				reg12220 := MakeSymbol("shen.collect")
-				__ctx.TailApply(__defun__shen_4f__error, reg12220)
+				__e.TailApply(__defun__shen_4f__error, reg12220)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.collect", value: __defun__shen_4collect})
 
-	__defun__shen_4same__predicate_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4same__predicate_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V969 := __args[0]
 		_ = V969
 		V970 := __args[1]
@@ -3664,31 +3664,31 @@ func init() {
 			reg12245 := PrimHead(V970)
 			reg12246 := PrimHead(reg12245)
 			reg12247 := PrimEqual(reg12244, reg12246)
-			__ctx.Return(reg12247)
+			__e.Return(reg12247)
 			return
 		} else {
 			reg12248 := MakeSymbol("shen.same_predicate?")
-			__ctx.TailApply(__defun__shen_4f__error, reg12248)
+			__e.TailApply(__defun__shen_4f__error, reg12248)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.same_predicate?", value: __defun__shen_4same__predicate_2})
 
-	__defun__shen_4compile__prolog__procedure = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4compile__prolog__procedure = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V972 := __args[0]
 		_ = V972
-		reg12250 := __e.Call(__defun__shen_4procedure__name, V972)
+		reg12250 := Call(__e, __defun__shen_4procedure__name, V972)
 		F := reg12250
 		_ = F
-		reg12251 := __e.Call(__defun__shen_4clauses_1to_1shen, F, V972)
+		reg12251 := Call(__e, __defun__shen_4clauses_1to_1shen, F, V972)
 		Shen := reg12251
 		_ = Shen
-		__ctx.Return(Shen)
+		__e.Return(Shen)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.compile_prolog_procedure", value: __defun__shen_4compile__prolog__procedure})
 
-	__defun__shen_4procedure__name = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4procedure__name = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V986 := __args[0]
 		_ = V986
 		reg12252 := PrimIsPair(V986)
@@ -3731,61 +3731,61 @@ func init() {
 			reg12268 := PrimHead(V986)
 			reg12269 := PrimHead(reg12268)
 			reg12270 := PrimHead(reg12269)
-			__ctx.Return(reg12270)
+			__e.Return(reg12270)
 			return
 		} else {
 			reg12271 := MakeSymbol("shen.procedure_name")
-			__ctx.TailApply(__defun__shen_4f__error, reg12271)
+			__e.TailApply(__defun__shen_4f__error, reg12271)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.procedure_name", value: __defun__shen_4procedure__name})
 
-	__defun__shen_4clauses_1to_1shen = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4clauses_1to_1shen = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V989 := __args[0]
 		_ = V989
 		V990 := __args[1]
 		_ = V990
-		reg12273 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg12273 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4linearise_1clause, X)
+			__e.TailApply(__defun__shen_4linearise_1clause, X)
 			return
 		}, 1)
-		reg12275 := __e.Call(__defun__map, reg12273, V990)
+		reg12275 := Call(__e, __defun__map, reg12273, V990)
 		Linear := reg12275
 		_ = Linear
-		reg12276 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg12276 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__head, X)
+			__e.TailApply(__defun__head, X)
 			return
 		}, 1)
-		reg12278 := __e.Call(__defun__map, reg12276, V990)
-		reg12279 := __e.Call(__defun__shen_4prolog_1aritycheck, V989, reg12278)
+		reg12278 := Call(__e, __defun__map, reg12276, V990)
+		reg12279 := Call(__e, __defun__shen_4prolog_1aritycheck, V989, reg12278)
 		Arity := reg12279
 		_ = Arity
-		reg12280 := __e.Call(__defun__shen_4parameters, Arity)
+		reg12280 := Call(__e, __defun__shen_4parameters, Arity)
 		Parameters := reg12280
 		_ = Parameters
-		reg12281 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg12281 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4aum, X, Parameters)
+			__e.TailApply(__defun__shen_4aum, X, Parameters)
 			return
 		}, 1)
-		reg12283 := __e.Call(__defun__map, reg12281, Linear)
+		reg12283 := Call(__e, __defun__map, reg12281, Linear)
 		AUM__instructions := reg12283
 		_ = AUM__instructions
-		reg12284 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg12284 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4aum__to__shen, X)
+			__e.TailApply(__defun__shen_4aum__to__shen, X)
 			return
 		}, 1)
-		reg12286 := __e.Call(__defun__map, reg12284, AUM__instructions)
-		reg12287 := __e.Call(__defun__shen_4nest_1disjunct, reg12286)
-		reg12288 := __e.Call(__defun__shen_4catch_1cut, reg12287)
+		reg12286 := Call(__e, __defun__map, reg12284, AUM__instructions)
+		reg12287 := Call(__e, __defun__shen_4nest_1disjunct, reg12286)
+		reg12288 := Call(__e, __defun__shen_4catch_1cut, reg12287)
 		Code := reg12288
 		_ = Code
 		reg12289 := MakeSymbol("define")
@@ -3798,25 +3798,25 @@ func init() {
 		reg12296 := Nil
 		reg12297 := PrimCons(Code, reg12296)
 		reg12298 := PrimCons(reg12295, reg12297)
-		reg12299 := __e.Call(__defun__append, reg12294, reg12298)
-		reg12300 := __e.Call(__defun__append, Parameters, reg12299)
+		reg12299 := Call(__e, __defun__append, reg12294, reg12298)
+		reg12300 := Call(__e, __defun__append, Parameters, reg12299)
 		reg12301 := PrimCons(V989, reg12300)
 		reg12302 := PrimCons(reg12289, reg12301)
 		ShenDef := reg12302
 		_ = ShenDef
-		__ctx.Return(ShenDef)
+		__e.Return(ShenDef)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.clauses-to-shen", value: __defun__shen_4clauses_1to_1shen})
 
-	__defun__shen_4catch_1cut = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4catch_1cut = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V992 := __args[0]
 		_ = V992
 		reg12303 := MakeSymbol("cut")
-		reg12304 := __e.Call(__defun__shen_4occurs_2, reg12303, V992)
+		reg12304 := Call(__e, __defun__shen_4occurs_2, reg12303, V992)
 		reg12305 := PrimNot(reg12304)
 		if reg12305 == True {
-			__ctx.Return(V992)
+			__e.Return(V992)
 			return
 		} else {
 			reg12306 := MakeSymbol("let")
@@ -3835,25 +3835,25 @@ func init() {
 			reg12319 := PrimCons(reg12310, reg12318)
 			reg12320 := PrimCons(reg12307, reg12319)
 			reg12321 := PrimCons(reg12306, reg12320)
-			__ctx.Return(reg12321)
+			__e.Return(reg12321)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.catch-cut", value: __defun__shen_4catch_1cut})
 
-	__defun__shen_4catchpoint = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4catchpoint = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg12322 := MakeSymbol("shen.*catch*")
 		reg12323 := MakeNumber(1)
 		reg12324 := MakeSymbol("shen.*catch*")
 		reg12325 := PrimValue(reg12324)
 		reg12326 := PrimNumberAdd(reg12323, reg12325)
 		reg12327 := PrimSet(reg12322, reg12326)
-		__ctx.Return(reg12327)
+		__e.Return(reg12327)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.catchpoint", value: __defun__shen_4catchpoint})
 
-	__defun__shen_4cutpoint = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4cutpoint = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1000 := __args[0]
 		_ = V1000
 		V1001 := __args[1]
@@ -3861,16 +3861,16 @@ func init() {
 		reg12328 := PrimEqual(V1001, V1000)
 		if reg12328 == True {
 			reg12329 := False
-			__ctx.Return(reg12329)
+			__e.Return(reg12329)
 			return
 		} else {
-			__ctx.Return(V1001)
+			__e.Return(V1001)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.cutpoint", value: __defun__shen_4cutpoint})
 
-	__defun__shen_4nest_1disjunct = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4nest_1disjunct = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1003 := __args[0]
 		_ = V1003
 		reg12330 := PrimIsPair(V1003)
@@ -3894,26 +3894,26 @@ func init() {
 		}
 		if reg12338 == True {
 			reg12339 := PrimHead(V1003)
-			__ctx.Return(reg12339)
+			__e.Return(reg12339)
 			return
 		} else {
 			reg12340 := PrimIsPair(V1003)
 			if reg12340 == True {
 				reg12341 := PrimHead(V1003)
 				reg12342 := PrimTail(V1003)
-				reg12343 := __e.Call(__defun__shen_4nest_1disjunct, reg12342)
-				__ctx.TailApply(__defun__shen_4lisp_1or, reg12341, reg12343)
+				reg12343 := Call(__e, __defun__shen_4nest_1disjunct, reg12342)
+				__e.TailApply(__defun__shen_4lisp_1or, reg12341, reg12343)
 				return
 			} else {
 				reg12345 := MakeSymbol("shen.nest-disjunct")
-				__ctx.TailApply(__defun__shen_4f__error, reg12345)
+				__e.TailApply(__defun__shen_4f__error, reg12345)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.nest-disjunct", value: __defun__shen_4nest_1disjunct})
 
-	__defun__shen_4lisp_1or = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lisp_1or = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1006 := __args[0]
 		_ = V1006
 		V1007 := __args[1]
@@ -3939,12 +3939,12 @@ func init() {
 		reg12365 := PrimCons(V1006, reg12364)
 		reg12366 := PrimCons(reg12348, reg12365)
 		reg12367 := PrimCons(reg12347, reg12366)
-		__ctx.Return(reg12367)
+		__e.Return(reg12367)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.lisp-or", value: __defun__shen_4lisp_1or})
 
-	__defun__shen_4prolog_1aritycheck = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prolog_1aritycheck = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1012 := __args[0]
 		_ = V1012
 		V1013 := __args[1]
@@ -3970,10 +3970,10 @@ func init() {
 		}
 		if reg12376 == True {
 			reg12377 := PrimHead(V1013)
-			reg12378 := __e.Call(__defun__length, reg12377)
+			reg12378 := Call(__e, __defun__length, reg12377)
 			reg12379 := MakeNumber(1)
 			reg12380 := PrimNumberSubtract(reg12378, reg12379)
-			__ctx.Return(reg12380)
+			__e.Return(reg12380)
 			return
 		} else {
 			reg12381 := PrimIsPair(V1013)
@@ -3996,14 +3996,14 @@ func init() {
 			}
 			if reg12388 == True {
 				reg12389 := PrimHead(V1013)
-				reg12390 := __e.Call(__defun__length, reg12389)
+				reg12390 := Call(__e, __defun__length, reg12389)
 				reg12391 := PrimTail(V1013)
 				reg12392 := PrimHead(reg12391)
-				reg12393 := __e.Call(__defun__length, reg12392)
+				reg12393 := Call(__e, __defun__length, reg12392)
 				reg12394 := PrimEqual(reg12390, reg12393)
 				if reg12394 == True {
 					reg12395 := PrimTail(V1013)
-					__ctx.TailApply(__defun__shen_4prolog_1aritycheck, V1012, reg12395)
+					__e.TailApply(__defun__shen_4prolog_1aritycheck, V1012, reg12395)
 					return
 				} else {
 					reg12397 := MakeString("arity error in prolog procedure ")
@@ -4011,22 +4011,22 @@ func init() {
 					reg12399 := PrimCons(V1012, reg12398)
 					reg12400 := MakeString("\n")
 					reg12401 := MakeSymbol("shen.a")
-					reg12402 := __e.Call(__defun__shen_4app, reg12399, reg12400, reg12401)
+					reg12402 := Call(__e, __defun__shen_4app, reg12399, reg12400, reg12401)
 					reg12403 := PrimStringConcat(reg12397, reg12402)
 					reg12404 := PrimSimpleError(reg12403)
-					__ctx.Return(reg12404)
+					__e.Return(reg12404)
 					return
 				}
 			} else {
 				reg12405 := MakeSymbol("shen.prolog-aritycheck")
-				__ctx.TailApply(__defun__shen_4f__error, reg12405)
+				__e.TailApply(__defun__shen_4f__error, reg12405)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.prolog-aritycheck", value: __defun__shen_4prolog_1aritycheck})
 
-	__defun__shen_4linearise_1clause = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4linearise_1clause = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1015 := __args[0]
 		_ = V1015
 		reg12407 := PrimIsPair(V1015)
@@ -4109,20 +4109,20 @@ func init() {
 			reg12443 := PrimTail(V1015)
 			reg12444 := PrimTail(reg12443)
 			reg12445 := PrimCons(reg12442, reg12444)
-			reg12446 := __e.Call(__defun__shen_4linearise, reg12445)
+			reg12446 := Call(__e, __defun__shen_4linearise, reg12445)
 			Linear := reg12446
 			_ = Linear
-			__ctx.TailApply(__defun__shen_4clause__form, Linear)
+			__e.TailApply(__defun__shen_4clause__form, Linear)
 			return
 		} else {
 			reg12448 := MakeSymbol("shen.linearise-clause")
-			__ctx.TailApply(__defun__shen_4f__error, reg12448)
+			__e.TailApply(__defun__shen_4f__error, reg12448)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.linearise-clause", value: __defun__shen_4linearise_1clause})
 
-	__defun__shen_4clause__form = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4clause__form = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1017 := __args[0]
 		_ = V1017
 		reg12450 := PrimIsPair(V1017)
@@ -4164,51 +4164,51 @@ func init() {
 		}
 		if reg12466 == True {
 			reg12467 := PrimHead(V1017)
-			reg12468 := __e.Call(__defun__shen_4explicit__modes, reg12467)
+			reg12468 := Call(__e, __defun__shen_4explicit__modes, reg12467)
 			reg12469 := MakeSymbol(":-")
 			reg12470 := PrimTail(V1017)
 			reg12471 := PrimHead(reg12470)
-			reg12472 := __e.Call(__defun__shen_4cf__help, reg12471)
+			reg12472 := Call(__e, __defun__shen_4cf__help, reg12471)
 			reg12473 := Nil
 			reg12474 := PrimCons(reg12472, reg12473)
 			reg12475 := PrimCons(reg12469, reg12474)
 			reg12476 := PrimCons(reg12468, reg12475)
-			__ctx.Return(reg12476)
+			__e.Return(reg12476)
 			return
 		} else {
 			reg12477 := MakeSymbol("shen.clause_form")
-			__ctx.TailApply(__defun__shen_4f__error, reg12477)
+			__e.TailApply(__defun__shen_4f__error, reg12477)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.clause_form", value: __defun__shen_4clause__form})
 
-	__defun__shen_4explicit__modes = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4explicit__modes = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1019 := __args[0]
 		_ = V1019
 		reg12479 := PrimIsPair(V1019)
 		if reg12479 == True {
 			reg12480 := PrimHead(V1019)
-			reg12481 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg12481 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				__ctx.TailApply(__defun__shen_4em__help, X)
+				__e.TailApply(__defun__shen_4em__help, X)
 				return
 			}, 1)
 			reg12483 := PrimTail(V1019)
-			reg12484 := __e.Call(__defun__map, reg12481, reg12483)
+			reg12484 := Call(__e, __defun__map, reg12481, reg12483)
 			reg12485 := PrimCons(reg12480, reg12484)
-			__ctx.Return(reg12485)
+			__e.Return(reg12485)
 			return
 		} else {
 			reg12486 := MakeSymbol("shen.explicit_modes")
-			__ctx.TailApply(__defun__shen_4f__error, reg12486)
+			__e.TailApply(__defun__shen_4f__error, reg12486)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.explicit_modes", value: __defun__shen_4explicit__modes})
 
-	__defun__shen_4em__help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4em__help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1021 := __args[0]
 		_ = V1021
 		reg12488 := PrimIsPair(V1021)
@@ -4286,7 +4286,7 @@ func init() {
 			reg12521 = reg12520
 		}
 		if reg12521 == True {
-			__ctx.Return(V1021)
+			__e.Return(V1021)
 			return
 		} else {
 			reg12522 := MakeSymbol("mode")
@@ -4295,13 +4295,13 @@ func init() {
 			reg12525 := PrimCons(reg12523, reg12524)
 			reg12526 := PrimCons(V1021, reg12525)
 			reg12527 := PrimCons(reg12522, reg12526)
-			__ctx.Return(reg12527)
+			__e.Return(reg12527)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.em_help", value: __defun__shen_4em__help})
 
-	__defun__shen_4cf__help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4cf__help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1023 := __args[0]
 		_ = V1023
 		reg12528 := PrimIsPair(V1023)
@@ -4495,18 +4495,18 @@ func init() {
 			reg12620 := PrimTail(V1023)
 			reg12621 := PrimTail(reg12620)
 			reg12622 := PrimHead(reg12621)
-			reg12623 := __e.Call(__defun__shen_4cf__help, reg12622)
+			reg12623 := Call(__e, __defun__shen_4cf__help, reg12622)
 			reg12624 := PrimCons(reg12619, reg12623)
-			__ctx.Return(reg12624)
+			__e.Return(reg12624)
 			return
 		} else {
-			__ctx.Return(V1023)
+			__e.Return(V1023)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.cf_help", value: __defun__shen_4cf__help})
 
-	__defun__occurs_1check = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__occurs_1check = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1029 := __args[0]
 		_ = V1029
 		reg12625 := MakeSymbol("+")
@@ -4515,7 +4515,7 @@ func init() {
 			reg12627 := MakeSymbol("shen.*occurs*")
 			reg12628 := True
 			reg12629 := PrimSet(reg12627, reg12628)
-			__ctx.Return(reg12629)
+			__e.Return(reg12629)
 			return
 		} else {
 			reg12630 := MakeSymbol("-")
@@ -4524,19 +4524,19 @@ func init() {
 				reg12632 := MakeSymbol("shen.*occurs*")
 				reg12633 := False
 				reg12634 := PrimSet(reg12632, reg12633)
-				__ctx.Return(reg12634)
+				__e.Return(reg12634)
 				return
 			} else {
 				reg12635 := MakeString("occurs-check expects + or -\n")
 				reg12636 := PrimSimpleError(reg12635)
-				__ctx.Return(reg12636)
+				__e.Return(reg12636)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "occurs-check", value: __defun__occurs_1check})
 
-	__defun__shen_4aum = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4aum = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1032 := __args[0]
 		_ = V1032
 		V1033 := __args[1]
@@ -4642,60 +4642,60 @@ func init() {
 			reg12684 := PrimTail(V1032)
 			reg12685 := PrimTail(reg12684)
 			reg12686 := PrimHead(reg12685)
-			reg12687 := __e.Call(__defun__shen_4continuation__call, reg12683, reg12686)
+			reg12687 := Call(__e, __defun__shen_4continuation__call, reg12683, reg12686)
 			reg12688 := Nil
 			reg12689 := PrimCons(reg12687, reg12688)
 			reg12690 := PrimCons(reg12681, reg12689)
 			reg12691 := PrimCons(reg12679, reg12690)
-			reg12692 := __e.Call(__defun__shen_4make__mu__application, reg12691, V1033)
+			reg12692 := Call(__e, __defun__shen_4make__mu__application, reg12691, V1033)
 			MuApplication := reg12692
 			_ = MuApplication
 			reg12693 := MakeSymbol("+")
-			__ctx.TailApply(__defun__shen_4mu__reduction, MuApplication, reg12693)
+			__e.TailApply(__defun__shen_4mu__reduction, MuApplication, reg12693)
 			return
 		} else {
 			reg12695 := MakeSymbol("shen.aum")
-			__ctx.TailApply(__defun__shen_4f__error, reg12695)
+			__e.TailApply(__defun__shen_4f__error, reg12695)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.aum", value: __defun__shen_4aum})
 
-	__defun__shen_4continuation__call = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4continuation__call = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1036 := __args[0]
 		_ = V1036
 		V1037 := __args[1]
 		_ = V1037
 		reg12697 := MakeSymbol("ProcessN")
-		reg12698 := __e.Call(__defun__shen_4extract__vars, V1036)
+		reg12698 := Call(__e, __defun__shen_4extract__vars, V1036)
 		reg12699 := PrimCons(reg12697, reg12698)
 		VTerms := reg12699
 		_ = VTerms
-		reg12700 := __e.Call(__defun__shen_4extract__vars, V1037)
+		reg12700 := Call(__e, __defun__shen_4extract__vars, V1037)
 		VBody := reg12700
 		_ = VBody
 		reg12701 := MakeSymbol("Throwcontrol")
-		reg12702 := __e.Call(__defun__difference, VBody, VTerms)
-		reg12703 := __e.Call(__defun__remove, reg12701, reg12702)
+		reg12702 := Call(__e, __defun__difference, VBody, VTerms)
+		reg12703 := Call(__e, __defun__remove, reg12701, reg12702)
 		Free := reg12703
 		_ = Free
-		__ctx.TailApply(__defun__shen_4cc__help, Free, V1037)
+		__e.TailApply(__defun__shen_4cc__help, Free, V1037)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.continuation_call", value: __defun__shen_4continuation__call})
 
-	__defun__remove = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__remove = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1040 := __args[0]
 		_ = V1040
 		V1041 := __args[1]
 		_ = V1041
 		reg12705 := Nil
-		__ctx.TailApply(__defun__shen_4remove_1h, V1040, V1041, reg12705)
+		__e.TailApply(__defun__shen_4remove_1h, V1040, V1041, reg12705)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "remove", value: __defun__remove})
 
-	__defun__shen_4remove_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4remove_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1048 := __args[0]
 		_ = V1048
 		V1049 := __args[1]
@@ -4705,7 +4705,7 @@ func init() {
 		reg12707 := Nil
 		reg12708 := PrimEqual(reg12707, V1049)
 		if reg12708 == True {
-			__ctx.TailApply(__defun__reverse, V1050)
+			__e.TailApply(__defun__reverse, V1050)
 			return
 		} else {
 			reg12710 := PrimIsPair(V1049)
@@ -4729,7 +4729,7 @@ func init() {
 			if reg12717 == True {
 				reg12718 := PrimHead(V1049)
 				reg12719 := PrimTail(V1049)
-				__ctx.TailApply(__defun__shen_4remove_1h, reg12718, reg12719, V1050)
+				__e.TailApply(__defun__shen_4remove_1h, reg12718, reg12719, V1050)
 				return
 			} else {
 				reg12721 := PrimIsPair(V1049)
@@ -4737,11 +4737,11 @@ func init() {
 					reg12722 := PrimTail(V1049)
 					reg12723 := PrimHead(V1049)
 					reg12724 := PrimCons(reg12723, V1050)
-					__ctx.TailApply(__defun__shen_4remove_1h, V1048, reg12722, reg12724)
+					__e.TailApply(__defun__shen_4remove_1h, V1048, reg12722, reg12724)
 					return
 				} else {
 					reg12726 := MakeSymbol("shen.remove-h")
-					__ctx.TailApply(__defun__shen_4f__error, reg12726)
+					__e.TailApply(__defun__shen_4f__error, reg12726)
 					return
 				}
 			}
@@ -4749,7 +4749,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.remove-h", value: __defun__shen_4remove_1h})
 
-	__defun__shen_4cc__help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4cc__help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1053 := __args[0]
 		_ = V1053
 		V1054 := __args[1]
@@ -4781,7 +4781,7 @@ func init() {
 			reg12741 := PrimCons(reg12739, reg12740)
 			reg12742 := PrimCons(reg12738, reg12741)
 			reg12743 := PrimCons(reg12737, reg12742)
-			__ctx.Return(reg12743)
+			__e.Return(reg12743)
 			return
 		} else {
 			reg12744 := Nil
@@ -4809,7 +4809,7 @@ func init() {
 				reg12765 := PrimCons(reg12748, reg12764)
 				reg12766 := PrimCons(reg12747, reg12765)
 				reg12767 := PrimCons(reg12746, reg12766)
-				__ctx.Return(reg12767)
+				__e.Return(reg12767)
 				return
 			} else {
 				reg12768 := Nil
@@ -4823,7 +4823,7 @@ func init() {
 					reg12775 := PrimCons(reg12772, reg12774)
 					reg12776 := PrimCons(reg12771, reg12775)
 					reg12777 := PrimCons(reg12770, reg12776)
-					__ctx.Return(reg12777)
+					__e.Return(reg12777)
 					return
 				} else {
 					reg12778 := MakeSymbol("shen.rename")
@@ -4849,7 +4849,7 @@ func init() {
 					reg12798 := PrimCons(reg12780, reg12797)
 					reg12799 := PrimCons(reg12779, reg12798)
 					reg12800 := PrimCons(reg12778, reg12799)
-					__ctx.Return(reg12800)
+					__e.Return(reg12800)
 					return
 				}
 			}
@@ -4857,7 +4857,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.cc_help", value: __defun__shen_4cc__help})
 
-	__defun__shen_4make__mu__application = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4make__mu__application = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1057 := __args[0]
 		_ = V1057
 		V1058 := __args[1]
@@ -4976,7 +4976,7 @@ func init() {
 			reg12851 := PrimTail(V1057)
 			reg12852 := PrimTail(reg12851)
 			reg12853 := PrimHead(reg12852)
-			__ctx.Return(reg12853)
+			__e.Return(reg12853)
 			return
 		} else {
 			reg12854 := PrimIsPair(V1057)
@@ -5101,7 +5101,7 @@ func init() {
 				reg12912 := PrimCons(reg12909, reg12911)
 				reg12913 := PrimCons(reg12906, reg12912)
 				reg12914 := PrimTail(V1058)
-				reg12915 := __e.Call(__defun__shen_4make__mu__application, reg12913, reg12914)
+				reg12915 := Call(__e, __defun__shen_4make__mu__application, reg12913, reg12914)
 				reg12916 := Nil
 				reg12917 := PrimCons(reg12915, reg12916)
 				reg12918 := PrimCons(reg12905, reg12917)
@@ -5110,18 +5110,18 @@ func init() {
 				reg12921 := Nil
 				reg12922 := PrimCons(reg12920, reg12921)
 				reg12923 := PrimCons(reg12919, reg12922)
-				__ctx.Return(reg12923)
+				__e.Return(reg12923)
 				return
 			} else {
 				reg12924 := MakeSymbol("shen.make_mu_application")
-				__ctx.TailApply(__defun__shen_4f__error, reg12924)
+				__e.TailApply(__defun__shen_4f__error, reg12924)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.make_mu_application", value: __defun__shen_4make__mu__application})
 
-	__defun__shen_4mu__reduction = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4mu__reduction = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1067 := __args[0]
 		_ = V1067
 		V1068 := __args[1]
@@ -5381,7 +5381,7 @@ func init() {
 			reg13057 := PrimTail(reg13056)
 			reg13058 := PrimTail(reg13057)
 			reg13059 := PrimHead(reg13058)
-			__ctx.TailApply(__defun__shen_4mu__reduction, reg13053, reg13059)
+			__e.TailApply(__defun__shen_4mu__reduction, reg13053, reg13059)
 			return
 		} else {
 			reg13061 := PrimIsPair(V1067)
@@ -5540,7 +5540,7 @@ func init() {
 				reg13133 := PrimTail(reg13132)
 				reg13134 := PrimTail(reg13133)
 				reg13135 := PrimHead(reg13134)
-				__ctx.TailApply(__defun__shen_4mu__reduction, reg13135, V1068)
+				__e.TailApply(__defun__shen_4mu__reduction, reg13135, V1068)
 				return
 			} else {
 				reg13137 := PrimIsPair(V1067)
@@ -5590,7 +5590,7 @@ func init() {
 												reg13165 := PrimHead(reg13164)
 												reg13166 := PrimTail(V1067)
 												reg13167 := PrimHead(reg13166)
-												reg13168 := __e.Call(__defun__shen_4ephemeral__variable_2, reg13165, reg13167)
+												reg13168 := Call(__e, __defun__shen_4ephemeral__variable_2, reg13165, reg13167)
 												var reg13171 Obj
 												if reg13168 == True {
 													reg13169 := True
@@ -5705,8 +5705,8 @@ func init() {
 					reg13215 := PrimTail(reg13214)
 					reg13216 := PrimTail(reg13215)
 					reg13217 := PrimHead(reg13216)
-					reg13218 := __e.Call(__defun__shen_4mu__reduction, reg13217, V1068)
-					__ctx.TailApply(__defun__subst, reg13210, reg13213, reg13218)
+					reg13218 := Call(__e, __defun__shen_4mu__reduction, reg13217, V1068)
+					__e.TailApply(__defun__subst, reg13210, reg13213, reg13218)
 					return
 				} else {
 					reg13220 := PrimIsPair(V1067)
@@ -5872,7 +5872,7 @@ func init() {
 						reg13299 := PrimTail(reg13298)
 						reg13300 := PrimTail(reg13299)
 						reg13301 := PrimHead(reg13300)
-						reg13302 := __e.Call(__defun__shen_4mu__reduction, reg13301, V1068)
+						reg13302 := Call(__e, __defun__shen_4mu__reduction, reg13301, V1068)
 						reg13303 := Nil
 						reg13304 := PrimCons(reg13302, reg13303)
 						reg13305 := PrimCons(reg13297, reg13304)
@@ -5880,7 +5880,7 @@ func init() {
 						reg13307 := PrimCons(reg13294, reg13306)
 						reg13308 := PrimCons(reg13293, reg13307)
 						reg13309 := PrimCons(reg13290, reg13308)
-						__ctx.Return(reg13309)
+						__e.Return(reg13309)
 						return
 					} else {
 						reg13310 := PrimIsPair(V1067)
@@ -5932,7 +5932,7 @@ func init() {
 															reg13338 := PrimHead(V1067)
 															reg13339 := PrimTail(reg13338)
 															reg13340 := PrimHead(reg13339)
-															reg13341 := __e.Call(__defun__shen_4prolog__constant_2, reg13340)
+															reg13341 := Call(__e, __defun__shen_4prolog__constant_2, reg13340)
 															var reg13344 Obj
 															if reg13341 == True {
 																reg13342 := True
@@ -6052,7 +6052,7 @@ func init() {
 						}
 						if reg13386 == True {
 							reg13387 := MakeSymbol("V")
-							reg13388 := __e.Call(__defun__gensym, reg13387)
+							reg13388 := Call(__e, __defun__gensym, reg13387)
 							Z := reg13388
 							_ = Z
 							reg13389 := MakeSymbol("let")
@@ -6086,7 +6086,7 @@ func init() {
 							reg13417 := PrimTail(reg13416)
 							reg13418 := PrimHead(reg13417)
 							reg13419 := MakeSymbol("-")
-							reg13420 := __e.Call(__defun__shen_4mu__reduction, reg13418, reg13419)
+							reg13420 := Call(__e, __defun__shen_4mu__reduction, reg13418, reg13419)
 							reg13421 := MakeSymbol("shen.else")
 							reg13422 := MakeSymbol("shen.failed!")
 							reg13423 := Nil
@@ -6103,7 +6103,7 @@ func init() {
 							reg13434 := PrimCons(reg13390, reg13433)
 							reg13435 := PrimCons(Z, reg13434)
 							reg13436 := PrimCons(reg13389, reg13435)
-							__ctx.Return(reg13436)
+							__e.Return(reg13436)
 							return
 						} else {
 							reg13437 := PrimIsPair(V1067)
@@ -6155,7 +6155,7 @@ func init() {
 																reg13465 := PrimHead(V1067)
 																reg13466 := PrimTail(reg13465)
 																reg13467 := PrimHead(reg13466)
-																reg13468 := __e.Call(__defun__shen_4prolog__constant_2, reg13467)
+																reg13468 := Call(__e, __defun__shen_4prolog__constant_2, reg13467)
 																var reg13471 Obj
 																if reg13468 == True {
 																	reg13469 := True
@@ -6275,7 +6275,7 @@ func init() {
 							}
 							if reg13513 == True {
 								reg13514 := MakeSymbol("V")
-								reg13515 := __e.Call(__defun__gensym, reg13514)
+								reg13515 := Call(__e, __defun__gensym, reg13514)
 								Z := reg13515
 								_ = Z
 								reg13516 := MakeSymbol("let")
@@ -6309,7 +6309,7 @@ func init() {
 								reg13544 := PrimTail(reg13543)
 								reg13545 := PrimHead(reg13544)
 								reg13546 := MakeSymbol("+")
-								reg13547 := __e.Call(__defun__shen_4mu__reduction, reg13545, reg13546)
+								reg13547 := Call(__e, __defun__shen_4mu__reduction, reg13545, reg13546)
 								reg13548 := MakeSymbol("shen.else")
 								reg13549 := MakeSymbol("if")
 								reg13550 := MakeSymbol("is")
@@ -6332,7 +6332,7 @@ func init() {
 								reg13567 := PrimTail(reg13566)
 								reg13568 := PrimHead(reg13567)
 								reg13569 := MakeSymbol("+")
-								reg13570 := __e.Call(__defun__shen_4mu__reduction, reg13568, reg13569)
+								reg13570 := Call(__e, __defun__shen_4mu__reduction, reg13568, reg13569)
 								reg13571 := Nil
 								reg13572 := PrimCons(reg13570, reg13571)
 								reg13573 := PrimCons(reg13564, reg13572)
@@ -6363,7 +6363,7 @@ func init() {
 								reg13598 := PrimCons(reg13517, reg13597)
 								reg13599 := PrimCons(Z, reg13598)
 								reg13600 := PrimCons(reg13516, reg13599)
-								__ctx.Return(reg13600)
+								__e.Return(reg13600)
 								return
 							} else {
 								reg13601 := PrimIsPair(V1067)
@@ -6535,7 +6535,7 @@ func init() {
 								}
 								if reg13677 == True {
 									reg13678 := MakeSymbol("V")
-									reg13679 := __e.Call(__defun__gensym, reg13678)
+									reg13679 := Call(__e, __defun__gensym, reg13678)
 									Z := reg13679
 									_ = Z
 									reg13680 := MakeSymbol("let")
@@ -6604,7 +6604,7 @@ func init() {
 									reg13743 := PrimCons(reg13741, reg13742)
 									reg13744 := PrimCons(reg13733, reg13743)
 									reg13745 := MakeSymbol("-")
-									reg13746 := __e.Call(__defun__shen_4mu__reduction, reg13744, reg13745)
+									reg13746 := Call(__e, __defun__shen_4mu__reduction, reg13744, reg13745)
 									reg13747 := MakeSymbol("shen.else")
 									reg13748 := MakeSymbol("shen.failed!")
 									reg13749 := Nil
@@ -6621,7 +6621,7 @@ func init() {
 									reg13760 := PrimCons(reg13681, reg13759)
 									reg13761 := PrimCons(Z, reg13760)
 									reg13762 := PrimCons(reg13680, reg13761)
-									__ctx.Return(reg13762)
+									__e.Return(reg13762)
 									return
 								} else {
 									reg13763 := PrimIsPair(V1067)
@@ -6793,7 +6793,7 @@ func init() {
 									}
 									if reg13839 == True {
 										reg13840 := MakeSymbol("V")
-										reg13841 := __e.Call(__defun__gensym, reg13840)
+										reg13841 := Call(__e, __defun__gensym, reg13840)
 										Z := reg13841
 										_ = Z
 										reg13842 := MakeSymbol("let")
@@ -6862,7 +6862,7 @@ func init() {
 										reg13905 := PrimCons(reg13903, reg13904)
 										reg13906 := PrimCons(reg13895, reg13905)
 										reg13907 := MakeSymbol("+")
-										reg13908 := __e.Call(__defun__shen_4mu__reduction, reg13906, reg13907)
+										reg13908 := Call(__e, __defun__shen_4mu__reduction, reg13906, reg13907)
 										reg13909 := MakeSymbol("shen.else")
 										reg13910 := MakeSymbol("if")
 										reg13911 := MakeSymbol("is")
@@ -6881,7 +6881,7 @@ func init() {
 										reg13924 := PrimHead(V1067)
 										reg13925 := PrimTail(reg13924)
 										reg13926 := PrimHead(reg13925)
-										reg13927 := __e.Call(__defun__shen_4extract__vars, reg13926)
+										reg13927 := Call(__e, __defun__shen_4extract__vars, reg13926)
 										reg13928 := MakeSymbol("and")
 										reg13929 := MakeSymbol("shen.then")
 										reg13930 := MakeSymbol("bind")
@@ -6889,15 +6889,15 @@ func init() {
 										reg13932 := PrimHead(V1067)
 										reg13933 := PrimTail(reg13932)
 										reg13934 := PrimHead(reg13933)
-										reg13935 := __e.Call(__defun__shen_4remove__modes, reg13934)
-										reg13936 := __e.Call(__defun__shen_4rcons__form, reg13935)
+										reg13935 := Call(__e, __defun__shen_4remove__modes, reg13934)
+										reg13936 := Call(__e, __defun__shen_4rcons__form, reg13935)
 										reg13937 := MakeSymbol("in")
 										reg13938 := PrimHead(V1067)
 										reg13939 := PrimTail(reg13938)
 										reg13940 := PrimTail(reg13939)
 										reg13941 := PrimHead(reg13940)
 										reg13942 := MakeSymbol("+")
-										reg13943 := __e.Call(__defun__shen_4mu__reduction, reg13941, reg13942)
+										reg13943 := Call(__e, __defun__shen_4mu__reduction, reg13941, reg13942)
 										reg13944 := Nil
 										reg13945 := PrimCons(reg13943, reg13944)
 										reg13946 := PrimCons(reg13937, reg13945)
@@ -6937,10 +6937,10 @@ func init() {
 										reg13980 := PrimCons(reg13843, reg13979)
 										reg13981 := PrimCons(Z, reg13980)
 										reg13982 := PrimCons(reg13842, reg13981)
-										__ctx.Return(reg13982)
+										__e.Return(reg13982)
 										return
 									} else {
-										__ctx.Return(V1067)
+										__e.Return(V1067)
 										return
 									}
 								}
@@ -6953,30 +6953,30 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.mu_reduction", value: __defun__shen_4mu__reduction})
 
-	__defun__shen_4rcons__form = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4rcons__form = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1070 := __args[0]
 		_ = V1070
 		reg13983 := PrimIsPair(V1070)
 		if reg13983 == True {
 			reg13984 := MakeSymbol("cons")
 			reg13985 := PrimHead(V1070)
-			reg13986 := __e.Call(__defun__shen_4rcons__form, reg13985)
+			reg13986 := Call(__e, __defun__shen_4rcons__form, reg13985)
 			reg13987 := PrimTail(V1070)
-			reg13988 := __e.Call(__defun__shen_4rcons__form, reg13987)
+			reg13988 := Call(__e, __defun__shen_4rcons__form, reg13987)
 			reg13989 := Nil
 			reg13990 := PrimCons(reg13988, reg13989)
 			reg13991 := PrimCons(reg13986, reg13990)
 			reg13992 := PrimCons(reg13984, reg13991)
-			__ctx.Return(reg13992)
+			__e.Return(reg13992)
 			return
 		} else {
-			__ctx.Return(V1070)
+			__e.Return(V1070)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.rcons_form", value: __defun__shen_4rcons__form})
 
-	__defun__shen_4remove__modes = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4remove__modes = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1072 := __args[0]
 		_ = V1072
 		reg13993 := PrimIsPair(V1072)
@@ -7076,7 +7076,7 @@ func init() {
 		if reg14036 == True {
 			reg14037 := PrimTail(V1072)
 			reg14038 := PrimHead(reg14037)
-			__ctx.TailApply(__defun__shen_4remove__modes, reg14038)
+			__e.TailApply(__defun__shen_4remove__modes, reg14038)
 			return
 		} else {
 			reg14040 := PrimIsPair(V1072)
@@ -7176,20 +7176,20 @@ func init() {
 			if reg14083 == True {
 				reg14084 := PrimTail(V1072)
 				reg14085 := PrimHead(reg14084)
-				__ctx.TailApply(__defun__shen_4remove__modes, reg14085)
+				__e.TailApply(__defun__shen_4remove__modes, reg14085)
 				return
 			} else {
 				reg14087 := PrimIsPair(V1072)
 				if reg14087 == True {
 					reg14088 := PrimHead(V1072)
-					reg14089 := __e.Call(__defun__shen_4remove__modes, reg14088)
+					reg14089 := Call(__e, __defun__shen_4remove__modes, reg14088)
 					reg14090 := PrimTail(V1072)
-					reg14091 := __e.Call(__defun__shen_4remove__modes, reg14090)
+					reg14091 := Call(__e, __defun__shen_4remove__modes, reg14090)
 					reg14092 := PrimCons(reg14089, reg14091)
-					__ctx.Return(reg14092)
+					__e.Return(reg14092)
 					return
 				} else {
-					__ctx.Return(V1072)
+					__e.Return(V1072)
 					return
 				}
 			}
@@ -7197,7 +7197,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.remove_modes", value: __defun__shen_4remove__modes})
 
-	__defun__shen_4ephemeral__variable_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4ephemeral__variable_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1075 := __args[0]
 		_ = V1075
 		V1076 := __args[1]
@@ -7207,38 +7207,38 @@ func init() {
 			reg14094 := PrimIsVariable(V1076)
 			if reg14094 == True {
 				reg14095 := True
-				__ctx.Return(reg14095)
+				__e.Return(reg14095)
 				return
 			} else {
 				reg14096 := False
-				__ctx.Return(reg14096)
+				__e.Return(reg14096)
 				return
 			}
 		} else {
 			reg14097 := False
-			__ctx.Return(reg14097)
+			__e.Return(reg14097)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.ephemeral_variable?", value: __defun__shen_4ephemeral__variable_2})
 
-	__defun__shen_4prolog__constant_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prolog__constant_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1086 := __args[0]
 		_ = V1086
 		reg14098 := PrimIsPair(V1086)
 		if reg14098 == True {
 			reg14099 := False
-			__ctx.Return(reg14099)
+			__e.Return(reg14099)
 			return
 		} else {
 			reg14100 := True
-			__ctx.Return(reg14100)
+			__e.Return(reg14100)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.prolog_constant?", value: __defun__shen_4prolog__constant_2})
 
-	__defun__shen_4aum__to__shen = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4aum__to__shen = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1088 := __args[0]
 		_ = V1088
 		reg14101 := PrimIsPair(V1088)
@@ -7428,20 +7428,20 @@ func init() {
 			reg14194 := PrimTail(reg14193)
 			reg14195 := PrimTail(reg14194)
 			reg14196 := PrimHead(reg14195)
-			reg14197 := __e.Call(__defun__shen_4aum__to__shen, reg14196)
+			reg14197 := Call(__e, __defun__shen_4aum__to__shen, reg14196)
 			reg14198 := PrimTail(V1088)
 			reg14199 := PrimTail(reg14198)
 			reg14200 := PrimTail(reg14199)
 			reg14201 := PrimTail(reg14200)
 			reg14202 := PrimTail(reg14201)
 			reg14203 := PrimHead(reg14202)
-			reg14204 := __e.Call(__defun__shen_4aum__to__shen, reg14203)
+			reg14204 := Call(__e, __defun__shen_4aum__to__shen, reg14203)
 			reg14205 := Nil
 			reg14206 := PrimCons(reg14204, reg14205)
 			reg14207 := PrimCons(reg14197, reg14206)
 			reg14208 := PrimCons(reg14192, reg14207)
 			reg14209 := PrimCons(reg14190, reg14208)
-			__ctx.Return(reg14209)
+			__e.Return(reg14209)
 			return
 		} else {
 			reg14210 := PrimIsPair(V1088)
@@ -7626,13 +7626,13 @@ func init() {
 				reg14298 := PrimTail(reg14297)
 				reg14299 := PrimTail(reg14298)
 				reg14300 := PrimHead(reg14299)
-				reg14301 := __e.Call(__defun__shen_4aum__to__shen, reg14300)
+				reg14301 := Call(__e, __defun__shen_4aum__to__shen, reg14300)
 				reg14302 := MakeSymbol("ProcessN")
 				reg14303 := Nil
 				reg14304 := PrimCons(reg14302, reg14303)
 				reg14305 := PrimCons(reg14301, reg14304)
 				reg14306 := PrimCons(reg14295, reg14305)
-				__ctx.Return(reg14306)
+				__e.Return(reg14306)
 				return
 			} else {
 				reg14307 := PrimIsPair(V1088)
@@ -7818,25 +7818,25 @@ func init() {
 					reg14396 := MakeSymbol("if")
 					reg14397 := PrimTail(V1088)
 					reg14398 := PrimHead(reg14397)
-					reg14399 := __e.Call(__defun__shen_4aum__to__shen, reg14398)
+					reg14399 := Call(__e, __defun__shen_4aum__to__shen, reg14398)
 					reg14400 := PrimTail(V1088)
 					reg14401 := PrimTail(reg14400)
 					reg14402 := PrimTail(reg14401)
 					reg14403 := PrimHead(reg14402)
-					reg14404 := __e.Call(__defun__shen_4aum__to__shen, reg14403)
+					reg14404 := Call(__e, __defun__shen_4aum__to__shen, reg14403)
 					reg14405 := PrimTail(V1088)
 					reg14406 := PrimTail(reg14405)
 					reg14407 := PrimTail(reg14406)
 					reg14408 := PrimTail(reg14407)
 					reg14409 := PrimTail(reg14408)
 					reg14410 := PrimHead(reg14409)
-					reg14411 := __e.Call(__defun__shen_4aum__to__shen, reg14410)
+					reg14411 := Call(__e, __defun__shen_4aum__to__shen, reg14410)
 					reg14412 := Nil
 					reg14413 := PrimCons(reg14411, reg14412)
 					reg14414 := PrimCons(reg14404, reg14413)
 					reg14415 := PrimCons(reg14399, reg14414)
 					reg14416 := PrimCons(reg14396, reg14415)
-					__ctx.Return(reg14416)
+					__e.Return(reg14416)
 					return
 				} else {
 					reg14417 := PrimIsPair(V1088)
@@ -7981,7 +7981,7 @@ func init() {
 						reg14485 := Nil
 						reg14486 := PrimCons(reg14484, reg14485)
 						reg14487 := PrimCons(reg14483, reg14486)
-						__ctx.Return(reg14487)
+						__e.Return(reg14487)
 						return
 					} else {
 						reg14488 := PrimIsPair(V1088)
@@ -8169,7 +8169,7 @@ func init() {
 							reg14579 := Nil
 							reg14580 := PrimCons(reg14578, reg14579)
 							reg14581 := PrimCons(reg14577, reg14580)
-							__ctx.Return(reg14581)
+							__e.Return(reg14581)
 							return
 						} else {
 							reg14582 := PrimIsPair(V1088)
@@ -8494,7 +8494,7 @@ func init() {
 								reg14750 := PrimTail(reg14749)
 								reg14751 := PrimTail(reg14750)
 								reg14752 := PrimHead(reg14751)
-								__ctx.TailApply(__defun__shen_4aum__to__shen, reg14752)
+								__e.TailApply(__defun__shen_4aum__to__shen, reg14752)
 								return
 							} else {
 								reg14754 := PrimIsPair(V1088)
@@ -8842,13 +8842,13 @@ func init() {
 									reg14945 := PrimCons(reg14930, reg14944)
 									reg14946 := PrimCons(reg14929, reg14945)
 									reg14947 := PrimCons(reg14928, reg14946)
-									reg14948 := __e.Call(__defun__shen_4aum__to__shen, reg14947)
+									reg14948 := Call(__e, __defun__shen_4aum__to__shen, reg14947)
 									reg14949 := Nil
 									reg14950 := PrimCons(reg14948, reg14949)
 									reg14951 := PrimCons(reg14927, reg14950)
 									reg14952 := PrimCons(reg14922, reg14951)
 									reg14953 := PrimCons(reg14916, reg14952)
-									__ctx.Return(reg14953)
+									__e.Return(reg14953)
 									return
 								} else {
 									reg14954 := PrimIsPair(V1088)
@@ -9039,7 +9039,7 @@ func init() {
 										reg15048 := PrimTail(reg15047)
 										reg15049 := PrimTail(reg15048)
 										reg15050 := PrimHead(reg15049)
-										reg15051 := __e.Call(__defun__shen_4chwild, reg15050)
+										reg15051 := Call(__e, __defun__shen_4chwild, reg15050)
 										reg15052 := MakeSymbol("ProcessN")
 										reg15053 := Nil
 										reg15054 := PrimCons(reg15052, reg15053)
@@ -9054,7 +9054,7 @@ func init() {
 										reg15063 := PrimTail(reg15062)
 										reg15064 := PrimTail(reg15063)
 										reg15065 := PrimHead(reg15064)
-										reg15066 := __e.Call(__defun__shen_4aum__to__shen, reg15065)
+										reg15066 := Call(__e, __defun__shen_4aum__to__shen, reg15065)
 										reg15067 := MakeSymbol("do")
 										reg15068 := MakeSymbol("shen.unbindv")
 										reg15069 := PrimTail(V1088)
@@ -9078,7 +9078,7 @@ func init() {
 										reg15087 := PrimCons(reg15085, reg15086)
 										reg15088 := PrimCons(reg15057, reg15087)
 										reg15089 := PrimCons(reg15043, reg15088)
-										__ctx.Return(reg15089)
+										__e.Return(reg15089)
 										return
 									} else {
 										reg15090 := PrimIsPair(V1088)
@@ -9250,14 +9250,14 @@ func init() {
 											reg15175 := PrimCons(reg15173, reg15174)
 											reg15176 := PrimCons(reg15172, reg15175)
 											reg15177 := PrimCons(reg15167, reg15176)
-											__ctx.Return(reg15177)
+											__e.Return(reg15177)
 											return
 										} else {
 											reg15178 := MakeSymbol("shen.failed!")
 											reg15179 := PrimEqual(reg15178, V1088)
 											if reg15179 == True {
 												reg15180 := False
-												__ctx.Return(reg15180)
+												__e.Return(reg15180)
 												return
 											} else {
 												reg15181 := PrimIsPair(V1088)
@@ -9399,7 +9399,7 @@ func init() {
 													reg15246 := PrimTail(reg15245)
 													reg15247 := PrimTail(reg15246)
 													reg15248 := PrimCons(reg15244, reg15247)
-													__ctx.Return(reg15248)
+													__e.Return(reg15248)
 													return
 												} else {
 													reg15249 := PrimIsPair(V1088)
@@ -9541,7 +9541,7 @@ func init() {
 														reg15314 := PrimTail(reg15313)
 														reg15315 := PrimTail(reg15314)
 														reg15316 := PrimCons(reg15312, reg15315)
-														__ctx.Return(reg15316)
+														__e.Return(reg15316)
 														return
 													} else {
 														reg15317 := PrimIsPair(V1088)
@@ -9671,7 +9671,7 @@ func init() {
 															reg15380 := PrimCons(reg15378, reg15379)
 															reg15381 := PrimCons(reg15373, reg15380)
 															reg15382 := PrimCons(reg15370, reg15381)
-															__ctx.Return(reg15382)
+															__e.Return(reg15382)
 															return
 														} else {
 															reg15383 := PrimIsPair(V1088)
@@ -9816,18 +9816,18 @@ func init() {
 																reg15451 := PrimTail(reg15450)
 																reg15452 := PrimTail(reg15451)
 																reg15453 := PrimHead(reg15452)
-																reg15454 := __e.Call(__defun__shen_4chwild, reg15453)
+																reg15454 := Call(__e, __defun__shen_4chwild, reg15453)
 																reg15455 := MakeSymbol("ProcessN")
 																reg15456 := MakeSymbol("Continuation")
-																reg15457 := __e.Call(__defun__shen_4call__the__continuation, reg15454, reg15455, reg15456)
+																reg15457 := Call(__e, __defun__shen_4call__the__continuation, reg15454, reg15455, reg15456)
 																reg15458 := Nil
 																reg15459 := PrimCons(reg15457, reg15458)
 																reg15460 := PrimCons(reg15449, reg15459)
 																reg15461 := PrimCons(reg15446, reg15460)
-																__ctx.Return(reg15461)
+																__e.Return(reg15461)
 																return
 															} else {
-																__ctx.Return(V1088)
+																__e.Return(V1088)
 																return
 															}
 														}
@@ -9846,7 +9846,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.aum_to_shen", value: __defun__shen_4aum__to__shen})
 
-	__defun__shen_4chwild = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4chwild = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1090 := __args[0]
 		_ = V1090
 		reg15462 := MakeSymbol("_")
@@ -9857,28 +9857,28 @@ func init() {
 			reg15466 := Nil
 			reg15467 := PrimCons(reg15465, reg15466)
 			reg15468 := PrimCons(reg15464, reg15467)
-			__ctx.Return(reg15468)
+			__e.Return(reg15468)
 			return
 		} else {
 			reg15469 := PrimIsPair(V1090)
 			if reg15469 == True {
-				reg15470 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg15470 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					Z := __args[0]
 					_ = Z
-					__ctx.TailApply(__defun__shen_4chwild, Z)
+					__e.TailApply(__defun__shen_4chwild, Z)
 					return
 				}, 1)
-				__ctx.TailApply(__defun__map, reg15470, V1090)
+				__e.TailApply(__defun__map, reg15470, V1090)
 				return
 			} else {
-				__ctx.Return(V1090)
+				__e.Return(V1090)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.chwild", value: __defun__shen_4chwild})
 
-	__defun__shen_4newpv = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4newpv = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1092 := __args[0]
 		_ = V1092
 		reg15473 := MakeSymbol("shen.*varcounter*")
@@ -9898,11 +9898,11 @@ func init() {
 		reg15483 := PrimVectorGet(reg15482, V1092)
 		Vector := reg15483
 		_ = Vector
-		reg15484 := __e.Call(__defun__limit, Vector)
+		reg15484 := Call(__e, __defun__limit, Vector)
 		reg15485 := PrimEqual(Count_71, reg15484)
 		var reg15488 Obj
 		if reg15485 == True {
-			reg15486 := __e.Call(__defun__shen_4resizeprocessvector, V1092, Count_71)
+			reg15486 := Call(__e, __defun__shen_4resizeprocessvector, V1092, Count_71)
 			reg15488 = reg15486
 		} else {
 			reg15487 := MakeSymbol("shen.skip")
@@ -9910,12 +9910,12 @@ func init() {
 		}
 		ResizeVectorIfNeeded := reg15488
 		_ = ResizeVectorIfNeeded
-		__ctx.TailApply(__defun__shen_4mk_1pvar, Count_71)
+		__e.TailApply(__defun__shen_4mk_1pvar, Count_71)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.newpv", value: __defun__shen_4newpv})
 
-	__defun__shen_4resizeprocessvector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4resizeprocessvector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1095 := __args[0]
 		_ = V1095
 		V1096 := __args[1]
@@ -9927,18 +9927,18 @@ func init() {
 		_ = Vector
 		reg15493 := PrimNumberAdd(V1096, V1096)
 		reg15494 := MakeSymbol("shen.-null-")
-		reg15495 := __e.Call(__defun__shen_4resize_1vector, Vector, reg15493, reg15494)
+		reg15495 := Call(__e, __defun__shen_4resize_1vector, Vector, reg15493, reg15494)
 		BigVector := reg15495
 		_ = BigVector
 		reg15496 := MakeSymbol("shen.*prologvectors*")
 		reg15497 := PrimValue(reg15496)
 		reg15498 := PrimVectorSet(reg15497, V1095, BigVector)
-		__ctx.Return(reg15498)
+		__e.Return(reg15498)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.resizeprocessvector", value: __defun__shen_4resizeprocessvector})
 
-	__defun__shen_4resize_1vector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4resize_1vector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1100 := __args[0]
 		_ = V1100
 		V1101 := __args[1]
@@ -9952,13 +9952,13 @@ func init() {
 		reg15503 := PrimVectorSet(reg15501, reg15502, V1101)
 		BigVector := reg15503
 		_ = BigVector
-		reg15504 := __e.Call(__defun__limit, V1100)
-		__ctx.TailApply(__defun__shen_4copy_1vector, V1100, BigVector, reg15504, V1101, V1102)
+		reg15504 := Call(__e, __defun__limit, V1100)
+		__e.TailApply(__defun__shen_4copy_1vector, V1100, BigVector, reg15504, V1101, V1102)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.resize-vector", value: __defun__shen_4resize_1vector})
 
-	__defun__shen_4copy_1vector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4copy_1vector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1108 := __args[0]
 		_ = V1108
 		V1109 := __args[1]
@@ -9976,13 +9976,13 @@ func init() {
 		reg15510 := MakeNumber(1)
 		reg15511 := MakeNumber(1)
 		reg15512 := PrimNumberAdd(reg15511, V1110)
-		reg15513 := __e.Call(__defun__shen_4copy_1vector_1stage_11, reg15510, V1108, V1109, reg15512)
-		__ctx.TailApply(__defun__shen_4copy_1vector_1stage_12, reg15507, reg15509, V1112, reg15513)
+		reg15513 := Call(__e, __defun__shen_4copy_1vector_1stage_11, reg15510, V1108, V1109, reg15512)
+		__e.TailApply(__defun__shen_4copy_1vector_1stage_12, reg15507, reg15509, V1112, reg15513)
 		return
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.copy-vector", value: __defun__shen_4copy_1vector})
 
-	__defun__shen_4copy_1vector_1stage_11 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4copy_1vector_1stage_11 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1120 := __args[0]
 		_ = V1120
 		V1121 := __args[1]
@@ -9993,20 +9993,20 @@ func init() {
 		_ = V1123
 		reg15515 := PrimEqual(V1123, V1120)
 		if reg15515 == True {
-			__ctx.Return(V1122)
+			__e.Return(V1122)
 			return
 		} else {
 			reg15516 := MakeNumber(1)
 			reg15517 := PrimNumberAdd(reg15516, V1120)
 			reg15518 := PrimVectorGet(V1121, V1120)
 			reg15519 := PrimVectorSet(V1122, V1120, reg15518)
-			__ctx.TailApply(__defun__shen_4copy_1vector_1stage_11, reg15517, V1121, reg15519, V1123)
+			__e.TailApply(__defun__shen_4copy_1vector_1stage_11, reg15517, V1121, reg15519, V1123)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.copy-vector-stage-1", value: __defun__shen_4copy_1vector_1stage_11})
 
-	__defun__shen_4copy_1vector_1stage_12 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4copy_1vector_1stage_12 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1131 := __args[0]
 		_ = V1131
 		V1132 := __args[1]
@@ -10017,19 +10017,19 @@ func init() {
 		_ = V1134
 		reg15521 := PrimEqual(V1132, V1131)
 		if reg15521 == True {
-			__ctx.Return(V1134)
+			__e.Return(V1134)
 			return
 		} else {
 			reg15522 := MakeNumber(1)
 			reg15523 := PrimNumberAdd(V1131, reg15522)
 			reg15524 := PrimVectorSet(V1134, V1131, V1133)
-			__ctx.TailApply(__defun__shen_4copy_1vector_1stage_12, reg15523, V1132, V1133, reg15524)
+			__e.TailApply(__defun__shen_4copy_1vector_1stage_12, reg15523, V1132, V1133, reg15524)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.copy-vector-stage-2", value: __defun__shen_4copy_1vector_1stage_12})
 
-	__defun__shen_4mk_1pvar = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4mk_1pvar = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1136 := __args[0]
 		_ = V1136
 		reg15526 := MakeNumber(2)
@@ -10039,50 +10039,50 @@ func init() {
 		reg15530 := PrimVectorSet(reg15527, reg15528, reg15529)
 		reg15531 := MakeNumber(1)
 		reg15532 := PrimVectorSet(reg15530, reg15531, V1136)
-		__ctx.Return(reg15532)
+		__e.Return(reg15532)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.mk-pvar", value: __defun__shen_4mk_1pvar})
 
-	__defun__shen_4pvar_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4pvar_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1138 := __args[0]
 		_ = V1138
 		reg15533 := PrimIsVector(V1138)
 		if reg15533 == True {
-			reg15534 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg15534 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg15535 := MakeNumber(0)
 				reg15536 := PrimVectorGet(V1138, reg15535)
-				__ctx.Return(reg15536)
+				__e.Return(reg15536)
 				return
 			}, 0)
-			reg15537 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg15537 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg15538 := MakeSymbol("shen.not-pvar")
-				__ctx.Return(reg15538)
+				__e.Return(reg15538)
 				return
 			}, 1)
-			reg15539 := __e.Try(reg15534).Catch(reg15537)
+			reg15539 := Try(__e, reg15534).Catch(reg15537)
 			reg15540 := MakeSymbol("shen.pvar")
 			reg15541 := PrimEqual(reg15539, reg15540)
 			if reg15541 == True {
 				reg15542 := True
-				__ctx.Return(reg15542)
+				__e.Return(reg15542)
 				return
 			} else {
 				reg15543 := False
-				__ctx.Return(reg15543)
+				__e.Return(reg15543)
 				return
 			}
 		} else {
 			reg15544 := False
-			__ctx.Return(reg15544)
+			__e.Return(reg15544)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.pvar?", value: __defun__shen_4pvar_2})
 
-	__defun__shen_4bindv = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4bindv = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1142 := __args[0]
 		_ = V1142
 		V1143 := __args[1]
@@ -10097,12 +10097,12 @@ func init() {
 		reg15548 := MakeNumber(1)
 		reg15549 := PrimVectorGet(V1142, reg15548)
 		reg15550 := PrimVectorSet(Vector, reg15549, V1143)
-		__ctx.Return(reg15550)
+		__e.Return(reg15550)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.bindv", value: __defun__shen_4bindv})
 
-	__defun__shen_4unbindv = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4unbindv = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1147 := __args[0]
 		_ = V1147
 		V1148 := __args[1]
@@ -10116,24 +10116,24 @@ func init() {
 		reg15555 := PrimVectorGet(V1147, reg15554)
 		reg15556 := MakeSymbol("shen.-null-")
 		reg15557 := PrimVectorSet(Vector, reg15555, reg15556)
-		__ctx.Return(reg15557)
+		__e.Return(reg15557)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.unbindv", value: __defun__shen_4unbindv})
 
-	__defun__shen_4incinfs = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4incinfs = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg15558 := MakeSymbol("shen.*infs*")
 		reg15559 := MakeNumber(1)
 		reg15560 := MakeSymbol("shen.*infs*")
 		reg15561 := PrimValue(reg15560)
 		reg15562 := PrimNumberAdd(reg15559, reg15561)
 		reg15563 := PrimSet(reg15558, reg15562)
-		__ctx.Return(reg15563)
+		__e.Return(reg15563)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.incinfs", value: __defun__shen_4incinfs})
 
-	__defun__shen_4call__the__continuation = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4call__the__continuation = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1152 := __args[0]
 		_ = V1152
 		V1153 := __args[1]
@@ -10184,9 +10184,9 @@ func init() {
 			reg15584 := Nil
 			reg15585 := PrimCons(V1154, reg15584)
 			reg15586 := PrimCons(V1153, reg15585)
-			reg15587 := __e.Call(__defun__append, reg15583, reg15586)
+			reg15587 := Call(__e, __defun__append, reg15583, reg15586)
 			reg15588 := PrimCons(reg15581, reg15587)
-			__ctx.Return(reg15588)
+			__e.Return(reg15588)
 			return
 		} else {
 			reg15589 := PrimIsPair(V1152)
@@ -10209,7 +10209,7 @@ func init() {
 			}
 			if reg15596 == True {
 				reg15597 := PrimTail(V1152)
-				reg15598 := __e.Call(__defun__shen_4newcontinuation, reg15597, V1153, V1154)
+				reg15598 := Call(__e, __defun__shen_4newcontinuation, reg15597, V1153, V1154)
 				NewContinuation := reg15598
 				_ = NewContinuation
 				reg15599 := PrimHead(V1152)
@@ -10219,20 +10219,20 @@ func init() {
 				reg15603 := Nil
 				reg15604 := PrimCons(NewContinuation, reg15603)
 				reg15605 := PrimCons(V1153, reg15604)
-				reg15606 := __e.Call(__defun__append, reg15602, reg15605)
+				reg15606 := Call(__e, __defun__append, reg15602, reg15605)
 				reg15607 := PrimCons(reg15600, reg15606)
-				__ctx.Return(reg15607)
+				__e.Return(reg15607)
 				return
 			} else {
 				reg15608 := MakeSymbol("shen.call_the_continuation")
-				__ctx.TailApply(__defun__shen_4f__error, reg15608)
+				__e.TailApply(__defun__shen_4f__error, reg15608)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.call_the_continuation", value: __defun__shen_4call__the__continuation})
 
-	__defun__shen_4newcontinuation = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4newcontinuation = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1158 := __args[0]
 		_ = V1158
 		V1159 := __args[1]
@@ -10242,7 +10242,7 @@ func init() {
 		reg15610 := Nil
 		reg15611 := PrimEqual(reg15610, V1158)
 		if reg15611 == True {
-			__ctx.Return(V1160)
+			__e.Return(V1160)
 			return
 		} else {
 			reg15612 := PrimIsPair(V1158)
@@ -10270,39 +10270,39 @@ func init() {
 				reg15623 := PrimHead(V1158)
 				reg15624 := PrimTail(reg15623)
 				reg15625 := PrimTail(V1158)
-				reg15626 := __e.Call(__defun__shen_4newcontinuation, reg15625, V1159, V1160)
+				reg15626 := Call(__e, __defun__shen_4newcontinuation, reg15625, V1159, V1160)
 				reg15627 := Nil
 				reg15628 := PrimCons(reg15626, reg15627)
 				reg15629 := PrimCons(V1159, reg15628)
-				reg15630 := __e.Call(__defun__append, reg15624, reg15629)
+				reg15630 := Call(__e, __defun__append, reg15624, reg15629)
 				reg15631 := PrimCons(reg15622, reg15630)
 				reg15632 := Nil
 				reg15633 := PrimCons(reg15631, reg15632)
 				reg15634 := PrimCons(reg15620, reg15633)
-				__ctx.Return(reg15634)
+				__e.Return(reg15634)
 				return
 			} else {
 				reg15635 := MakeSymbol("shen.newcontinuation")
-				__ctx.TailApply(__defun__shen_4f__error, reg15635)
+				__e.TailApply(__defun__shen_4f__error, reg15635)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.newcontinuation", value: __defun__shen_4newcontinuation})
 
-	__defun__return = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__return = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1168 := __args[0]
 		_ = V1168
 		V1169 := __args[1]
 		_ = V1169
 		V1170 := __args[2]
 		_ = V1170
-		__ctx.TailApply(__defun__shen_4deref, V1168, V1169)
+		__e.TailApply(__defun__shen_4deref, V1168, V1169)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "return", value: __defun__return})
 
-	__defun__shen_4measure_ereturn = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4measure_ereturn = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1178 := __args[0]
 		_ = V1178
 		V1179 := __args[1]
@@ -10313,16 +10313,16 @@ func init() {
 		reg15639 := PrimValue(reg15638)
 		reg15640 := MakeString(" inferences\n")
 		reg15641 := MakeSymbol("shen.a")
-		reg15642 := __e.Call(__defun__shen_4app, reg15639, reg15640, reg15641)
-		reg15643 := __e.Call(__defun__stoutput)
-		reg15644 := __e.Call(__defun__shen_4prhush, reg15642, reg15643)
+		reg15642 := Call(__e, __defun__shen_4app, reg15639, reg15640, reg15641)
+		reg15643 := Call(__e, __defun__stoutput)
+		reg15644 := Call(__e, __defun__shen_4prhush, reg15642, reg15643)
 		_ = reg15644
-		__ctx.TailApply(__defun__shen_4deref, V1178, V1179)
+		__e.TailApply(__defun__shen_4deref, V1178, V1179)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.measure&return", value: __defun__shen_4measure_ereturn})
 
-	__defun__unify = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__unify = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1185 := __args[0]
 		_ = V1185
 		V1186 := __args[1]
@@ -10331,14 +10331,14 @@ func init() {
 		_ = V1187
 		V1188 := __args[3]
 		_ = V1188
-		reg15646 := __e.Call(__defun__shen_4lazyderef, V1185, V1187)
-		reg15647 := __e.Call(__defun__shen_4lazyderef, V1186, V1187)
-		__ctx.TailApply(__defun__shen_4lzy_a, reg15646, reg15647, V1187, V1188)
+		reg15646 := Call(__e, __defun__shen_4lazyderef, V1185, V1187)
+		reg15647 := Call(__e, __defun__shen_4lazyderef, V1186, V1187)
+		__e.TailApply(__defun__shen_4lzy_a, reg15646, reg15647, V1187, V1188)
 		return
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "unify", value: __defun__unify})
 
-	__defun__shen_4lzy_a = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lzy_a = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1210 := __args[0]
 		_ = V1210
 		V1211 := __args[1]
@@ -10349,17 +10349,17 @@ func init() {
 		_ = V1213
 		reg15649 := PrimEqual(V1211, V1210)
 		if reg15649 == True {
-			__ctx.TailApply(__defun__thaw, V1213)
+			__e.TailApply(__defun__thaw, V1213)
 			return
 		} else {
-			reg15651 := __e.Call(__defun__shen_4pvar_2, V1210)
+			reg15651 := Call(__e, __defun__shen_4pvar_2, V1210)
 			if reg15651 == True {
-				__ctx.TailApply(__defun__bind, V1210, V1211, V1212, V1213)
+				__e.TailApply(__defun__bind, V1210, V1211, V1212, V1213)
 				return
 			} else {
-				reg15653 := __e.Call(__defun__shen_4pvar_2, V1211)
+				reg15653 := Call(__e, __defun__shen_4pvar_2, V1211)
 				if reg15653 == True {
-					__ctx.TailApply(__defun__bind, V1211, V1210, V1212, V1213)
+					__e.TailApply(__defun__bind, V1211, V1210, V1212, V1213)
 					return
 				} else {
 					reg15655 := PrimIsPair(V1210)
@@ -10381,22 +10381,22 @@ func init() {
 					}
 					if reg15661 == True {
 						reg15662 := PrimHead(V1210)
-						reg15663 := __e.Call(__defun__shen_4lazyderef, reg15662, V1212)
+						reg15663 := Call(__e, __defun__shen_4lazyderef, reg15662, V1212)
 						reg15664 := PrimHead(V1211)
-						reg15665 := __e.Call(__defun__shen_4lazyderef, reg15664, V1212)
-						reg15666 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+						reg15665 := Call(__e, __defun__shen_4lazyderef, reg15664, V1212)
+						reg15666 := MakeNative(func(__e Evaluator, __args ...Obj) {
 							reg15667 := PrimTail(V1210)
-							reg15668 := __e.Call(__defun__shen_4lazyderef, reg15667, V1212)
+							reg15668 := Call(__e, __defun__shen_4lazyderef, reg15667, V1212)
 							reg15669 := PrimTail(V1211)
-							reg15670 := __e.Call(__defun__shen_4lazyderef, reg15669, V1212)
-							__ctx.TailApply(__defun__shen_4lzy_a, reg15668, reg15670, V1212, V1213)
+							reg15670 := Call(__e, __defun__shen_4lazyderef, reg15669, V1212)
+							__e.TailApply(__defun__shen_4lzy_a, reg15668, reg15670, V1212, V1213)
 							return
 						}, 0)
-						__ctx.TailApply(__defun__shen_4lzy_a, reg15663, reg15665, V1212, reg15666)
+						__e.TailApply(__defun__shen_4lzy_a, reg15663, reg15665, V1212, reg15666)
 						return
 					} else {
 						reg15673 := False
-						__ctx.Return(reg15673)
+						__e.Return(reg15673)
 						return
 					}
 				}
@@ -10405,7 +10405,7 @@ func init() {
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.lzy=", value: __defun__shen_4lzy_a})
 
-	__defun__shen_4deref = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4deref = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1216 := __args[0]
 		_ = V1216
 		V1217 := __args[1]
@@ -10413,62 +10413,62 @@ func init() {
 		reg15674 := PrimIsPair(V1216)
 		if reg15674 == True {
 			reg15675 := PrimHead(V1216)
-			reg15676 := __e.Call(__defun__shen_4deref, reg15675, V1217)
+			reg15676 := Call(__e, __defun__shen_4deref, reg15675, V1217)
 			reg15677 := PrimTail(V1216)
-			reg15678 := __e.Call(__defun__shen_4deref, reg15677, V1217)
+			reg15678 := Call(__e, __defun__shen_4deref, reg15677, V1217)
 			reg15679 := PrimCons(reg15676, reg15678)
-			__ctx.Return(reg15679)
+			__e.Return(reg15679)
 			return
 		} else {
-			reg15680 := __e.Call(__defun__shen_4pvar_2, V1216)
+			reg15680 := Call(__e, __defun__shen_4pvar_2, V1216)
 			if reg15680 == True {
-				reg15681 := __e.Call(__defun__shen_4valvector, V1216, V1217)
+				reg15681 := Call(__e, __defun__shen_4valvector, V1216, V1217)
 				Value := reg15681
 				_ = Value
 				reg15682 := MakeSymbol("shen.-null-")
 				reg15683 := PrimEqual(Value, reg15682)
 				if reg15683 == True {
-					__ctx.Return(V1216)
+					__e.Return(V1216)
 					return
 				} else {
-					__ctx.TailApply(__defun__shen_4deref, Value, V1217)
+					__e.TailApply(__defun__shen_4deref, Value, V1217)
 					return
 				}
 			} else {
-				__ctx.Return(V1216)
+				__e.Return(V1216)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.deref", value: __defun__shen_4deref})
 
-	__defun__shen_4lazyderef = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lazyderef = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1220 := __args[0]
 		_ = V1220
 		V1221 := __args[1]
 		_ = V1221
-		reg15685 := __e.Call(__defun__shen_4pvar_2, V1220)
+		reg15685 := Call(__e, __defun__shen_4pvar_2, V1220)
 		if reg15685 == True {
-			reg15686 := __e.Call(__defun__shen_4valvector, V1220, V1221)
+			reg15686 := Call(__e, __defun__shen_4valvector, V1220, V1221)
 			Value := reg15686
 			_ = Value
 			reg15687 := MakeSymbol("shen.-null-")
 			reg15688 := PrimEqual(Value, reg15687)
 			if reg15688 == True {
-				__ctx.Return(V1220)
+				__e.Return(V1220)
 				return
 			} else {
-				__ctx.TailApply(__defun__shen_4lazyderef, Value, V1221)
+				__e.TailApply(__defun__shen_4lazyderef, Value, V1221)
 				return
 			}
 		} else {
-			__ctx.Return(V1220)
+			__e.Return(V1220)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.lazyderef", value: __defun__shen_4lazyderef})
 
-	__defun__shen_4valvector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4valvector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1224 := __args[0]
 		_ = V1224
 		V1225 := __args[1]
@@ -10479,12 +10479,12 @@ func init() {
 		reg15693 := MakeNumber(1)
 		reg15694 := PrimVectorGet(V1224, reg15693)
 		reg15695 := PrimVectorGet(reg15692, reg15694)
-		__ctx.Return(reg15695)
+		__e.Return(reg15695)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.valvector", value: __defun__shen_4valvector})
 
-	__defun__unify_b = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__unify_b = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1230 := __args[0]
 		_ = V1230
 		V1231 := __args[1]
@@ -10493,14 +10493,14 @@ func init() {
 		_ = V1232
 		V1233 := __args[3]
 		_ = V1233
-		reg15696 := __e.Call(__defun__shen_4lazyderef, V1230, V1232)
-		reg15697 := __e.Call(__defun__shen_4lazyderef, V1231, V1232)
-		__ctx.TailApply(__defun__shen_4lzy_a_b, reg15696, reg15697, V1232, V1233)
+		reg15696 := Call(__e, __defun__shen_4lazyderef, V1230, V1232)
+		reg15697 := Call(__e, __defun__shen_4lazyderef, V1231, V1232)
+		__e.TailApply(__defun__shen_4lzy_a_b, reg15696, reg15697, V1232, V1233)
 		return
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "unify!", value: __defun__unify_b})
 
-	__defun__shen_4lzy_a_b = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lzy_a_b = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1255 := __args[0]
 		_ = V1255
 		V1256 := __args[1]
@@ -10511,14 +10511,14 @@ func init() {
 		_ = V1258
 		reg15699 := PrimEqual(V1256, V1255)
 		if reg15699 == True {
-			__ctx.TailApply(__defun__thaw, V1258)
+			__e.TailApply(__defun__thaw, V1258)
 			return
 		} else {
-			reg15701 := __e.Call(__defun__shen_4pvar_2, V1255)
+			reg15701 := Call(__e, __defun__shen_4pvar_2, V1255)
 			var reg15709 Obj
 			if reg15701 == True {
-				reg15702 := __e.Call(__defun__shen_4deref, V1256, V1257)
-				reg15703 := __e.Call(__defun__shen_4occurs_2, V1255, reg15702)
+				reg15702 := Call(__e, __defun__shen_4deref, V1256, V1257)
+				reg15703 := Call(__e, __defun__shen_4occurs_2, V1255, reg15702)
 				reg15704 := PrimNot(reg15703)
 				var reg15707 Obj
 				if reg15704 == True {
@@ -10534,14 +10534,14 @@ func init() {
 				reg15709 = reg15708
 			}
 			if reg15709 == True {
-				__ctx.TailApply(__defun__bind, V1255, V1256, V1257, V1258)
+				__e.TailApply(__defun__bind, V1255, V1256, V1257, V1258)
 				return
 			} else {
-				reg15711 := __e.Call(__defun__shen_4pvar_2, V1256)
+				reg15711 := Call(__e, __defun__shen_4pvar_2, V1256)
 				var reg15719 Obj
 				if reg15711 == True {
-					reg15712 := __e.Call(__defun__shen_4deref, V1255, V1257)
-					reg15713 := __e.Call(__defun__shen_4occurs_2, V1256, reg15712)
+					reg15712 := Call(__e, __defun__shen_4deref, V1255, V1257)
+					reg15713 := Call(__e, __defun__shen_4occurs_2, V1256, reg15712)
 					reg15714 := PrimNot(reg15713)
 					var reg15717 Obj
 					if reg15714 == True {
@@ -10557,7 +10557,7 @@ func init() {
 					reg15719 = reg15718
 				}
 				if reg15719 == True {
-					__ctx.TailApply(__defun__bind, V1256, V1255, V1257, V1258)
+					__e.TailApply(__defun__bind, V1256, V1255, V1257, V1258)
 					return
 				} else {
 					reg15721 := PrimIsPair(V1255)
@@ -10579,22 +10579,22 @@ func init() {
 					}
 					if reg15727 == True {
 						reg15728 := PrimHead(V1255)
-						reg15729 := __e.Call(__defun__shen_4lazyderef, reg15728, V1257)
+						reg15729 := Call(__e, __defun__shen_4lazyderef, reg15728, V1257)
 						reg15730 := PrimHead(V1256)
-						reg15731 := __e.Call(__defun__shen_4lazyderef, reg15730, V1257)
-						reg15732 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+						reg15731 := Call(__e, __defun__shen_4lazyderef, reg15730, V1257)
+						reg15732 := MakeNative(func(__e Evaluator, __args ...Obj) {
 							reg15733 := PrimTail(V1255)
-							reg15734 := __e.Call(__defun__shen_4lazyderef, reg15733, V1257)
+							reg15734 := Call(__e, __defun__shen_4lazyderef, reg15733, V1257)
 							reg15735 := PrimTail(V1256)
-							reg15736 := __e.Call(__defun__shen_4lazyderef, reg15735, V1257)
-							__ctx.TailApply(__defun__shen_4lzy_a_b, reg15734, reg15736, V1257, V1258)
+							reg15736 := Call(__e, __defun__shen_4lazyderef, reg15735, V1257)
+							__e.TailApply(__defun__shen_4lzy_a_b, reg15734, reg15736, V1257, V1258)
 							return
 						}, 0)
-						__ctx.TailApply(__defun__shen_4lzy_a_b, reg15729, reg15731, V1257, reg15732)
+						__e.TailApply(__defun__shen_4lzy_a_b, reg15729, reg15731, V1257, reg15732)
 						return
 					} else {
 						reg15739 := False
-						__ctx.Return(reg15739)
+						__e.Return(reg15739)
 						return
 					}
 				}
@@ -10603,7 +10603,7 @@ func init() {
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.lzy=!", value: __defun__shen_4lzy_a_b})
 
-	__defun__shen_4occurs_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4occurs_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1270 := __args[0]
 		_ = V1270
 		V1271 := __args[1]
@@ -10611,40 +10611,40 @@ func init() {
 		reg15740 := PrimEqual(V1271, V1270)
 		if reg15740 == True {
 			reg15741 := True
-			__ctx.Return(reg15741)
+			__e.Return(reg15741)
 			return
 		} else {
 			reg15742 := PrimIsPair(V1271)
 			if reg15742 == True {
 				reg15743 := PrimHead(V1271)
-				reg15744 := __e.Call(__defun__shen_4occurs_2, V1270, reg15743)
+				reg15744 := Call(__e, __defun__shen_4occurs_2, V1270, reg15743)
 				if reg15744 == True {
 					reg15745 := True
-					__ctx.Return(reg15745)
+					__e.Return(reg15745)
 					return
 				} else {
 					reg15746 := PrimTail(V1271)
-					reg15747 := __e.Call(__defun__shen_4occurs_2, V1270, reg15746)
+					reg15747 := Call(__e, __defun__shen_4occurs_2, V1270, reg15746)
 					if reg15747 == True {
 						reg15748 := True
-						__ctx.Return(reg15748)
+						__e.Return(reg15748)
 						return
 					} else {
 						reg15749 := False
-						__ctx.Return(reg15749)
+						__e.Return(reg15749)
 						return
 					}
 				}
 			} else {
 				reg15750 := False
-				__ctx.Return(reg15750)
+				__e.Return(reg15750)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.occurs?", value: __defun__shen_4occurs_2})
 
-	__defun__identical = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__identical = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1276 := __args[0]
 		_ = V1276
 		V1277 := __args[1]
@@ -10653,14 +10653,14 @@ func init() {
 		_ = V1278
 		V1279 := __args[3]
 		_ = V1279
-		reg15751 := __e.Call(__defun__shen_4lazyderef, V1276, V1278)
-		reg15752 := __e.Call(__defun__shen_4lazyderef, V1277, V1278)
-		__ctx.TailApply(__defun__shen_4lzy_a_a, reg15751, reg15752, V1278, V1279)
+		reg15751 := Call(__e, __defun__shen_4lazyderef, V1276, V1278)
+		reg15752 := Call(__e, __defun__shen_4lazyderef, V1277, V1278)
+		__e.TailApply(__defun__shen_4lzy_a_a, reg15751, reg15752, V1278, V1279)
 		return
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "identical", value: __defun__identical})
 
-	__defun__shen_4lzy_a_a = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lzy_a_a = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1301 := __args[0]
 		_ = V1301
 		V1302 := __args[1]
@@ -10671,7 +10671,7 @@ func init() {
 		_ = V1304
 		reg15754 := PrimEqual(V1302, V1301)
 		if reg15754 == True {
-			__ctx.TailApply(__defun__thaw, V1304)
+			__e.TailApply(__defun__thaw, V1304)
 			return
 		} else {
 			reg15756 := PrimIsPair(V1301)
@@ -10693,27 +10693,27 @@ func init() {
 			}
 			if reg15762 == True {
 				reg15763 := PrimHead(V1301)
-				reg15764 := __e.Call(__defun__shen_4lazyderef, reg15763, V1303)
+				reg15764 := Call(__e, __defun__shen_4lazyderef, reg15763, V1303)
 				reg15765 := PrimHead(V1302)
-				reg15766 := __e.Call(__defun__shen_4lazyderef, reg15765, V1303)
-				reg15767 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg15766 := Call(__e, __defun__shen_4lazyderef, reg15765, V1303)
+				reg15767 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					reg15768 := PrimTail(V1301)
 					reg15769 := PrimTail(V1302)
-					__ctx.TailApply(__defun__shen_4lzy_a_a, reg15768, reg15769, V1303, V1304)
+					__e.TailApply(__defun__shen_4lzy_a_a, reg15768, reg15769, V1303, V1304)
 					return
 				}, 0)
-				__ctx.TailApply(__defun__shen_4lzy_a_a, reg15764, reg15766, V1303, reg15767)
+				__e.TailApply(__defun__shen_4lzy_a_a, reg15764, reg15766, V1303, reg15767)
 				return
 			} else {
 				reg15772 := False
-				__ctx.Return(reg15772)
+				__e.Return(reg15772)
 				return
 			}
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.lzy==", value: __defun__shen_4lzy_a_a})
 
-	__defun__shen_4pvar = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4pvar = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1306 := __args[0]
 		_ = V1306
 		reg15773 := MakeString("Var")
@@ -10721,14 +10721,14 @@ func init() {
 		reg15775 := PrimVectorGet(V1306, reg15774)
 		reg15776 := MakeString("")
 		reg15777 := MakeSymbol("shen.a")
-		reg15778 := __e.Call(__defun__shen_4app, reg15775, reg15776, reg15777)
+		reg15778 := Call(__e, __defun__shen_4app, reg15775, reg15776, reg15777)
 		reg15779 := PrimStringConcat(reg15773, reg15778)
-		__ctx.Return(reg15779)
+		__e.Return(reg15779)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.pvar", value: __defun__shen_4pvar})
 
-	__defun__bind = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__bind = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1311 := __args[0]
 		_ = V1311
 		V1312 := __args[1]
@@ -10737,19 +10737,19 @@ func init() {
 		_ = V1313
 		V1314 := __args[3]
 		_ = V1314
-		reg15780 := __e.Call(__defun__shen_4bindv, V1311, V1312, V1313)
+		reg15780 := Call(__e, __defun__shen_4bindv, V1311, V1312, V1313)
 		_ = reg15780
-		reg15781 := __e.Call(__defun__thaw, V1314)
+		reg15781 := Call(__e, __defun__thaw, V1314)
 		Result := reg15781
 		_ = Result
-		reg15782 := __e.Call(__defun__shen_4unbindv, V1311, V1313)
+		reg15782 := Call(__e, __defun__shen_4unbindv, V1311, V1313)
 		_ = reg15782
-		__ctx.Return(Result)
+		__e.Return(Result)
 		return
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "bind", value: __defun__bind})
 
-	__defun__fwhen = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__fwhen = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1332 := __args[0]
 		_ = V1332
 		V1333 := __args[1]
@@ -10759,30 +10759,30 @@ func init() {
 		reg15783 := True
 		reg15784 := PrimEqual(reg15783, V1332)
 		if reg15784 == True {
-			__ctx.TailApply(__defun__thaw, V1334)
+			__e.TailApply(__defun__thaw, V1334)
 			return
 		} else {
 			reg15786 := False
 			reg15787 := PrimEqual(reg15786, V1332)
 			if reg15787 == True {
 				reg15788 := False
-				__ctx.Return(reg15788)
+				__e.Return(reg15788)
 				return
 			} else {
 				reg15789 := MakeString("fwhen expects a boolean: not ")
 				reg15790 := MakeString("%")
 				reg15791 := MakeSymbol("shen.s")
-				reg15792 := __e.Call(__defun__shen_4app, V1332, reg15790, reg15791)
+				reg15792 := Call(__e, __defun__shen_4app, V1332, reg15790, reg15791)
 				reg15793 := PrimStringConcat(reg15789, reg15792)
 				reg15794 := PrimSimpleError(reg15793)
-				__ctx.Return(reg15794)
+				__e.Return(reg15794)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "fwhen", value: __defun__fwhen})
 
-	__defun__call = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__call = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1350 := __args[0]
 		_ = V1350
 		V1351 := __args[1]
@@ -10792,27 +10792,27 @@ func init() {
 		reg15795 := PrimIsPair(V1350)
 		if reg15795 == True {
 			reg15796 := PrimHead(V1350)
-			reg15797 := __e.Call(__defun__shen_4lazyderef, reg15796, V1351)
-			reg15798 := __e.Call(__defun__function, reg15797)
+			reg15797 := Call(__e, __defun__shen_4lazyderef, reg15796, V1351)
+			reg15798 := Call(__e, __defun__function, reg15797)
 			reg15799 := PrimTail(V1350)
-			__ctx.TailApply(__defun__shen_4call_1help, reg15798, reg15799, V1351, V1352)
+			__e.TailApply(__defun__shen_4call_1help, reg15798, reg15799, V1351, V1352)
 			return
 		} else {
-			reg15801 := __e.Call(__defun__shen_4pvar_2, V1350)
+			reg15801 := Call(__e, __defun__shen_4pvar_2, V1350)
 			if reg15801 == True {
-				reg15802 := __e.Call(__defun__shen_4lazyderef, V1350, V1351)
-				__ctx.TailApply(__defun__call, reg15802, V1351, V1352)
+				reg15802 := Call(__e, __defun__shen_4lazyderef, V1350, V1351)
+				__e.TailApply(__defun__call, reg15802, V1351, V1352)
 				return
 			} else {
 				reg15804 := False
-				__ctx.Return(reg15804)
+				__e.Return(reg15804)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "call", value: __defun__call})
 
-	__defun__shen_4call_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4call_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1357 := __args[0]
 		_ = V1357
 		V1358 := __args[1]
@@ -10824,26 +10824,26 @@ func init() {
 		reg15805 := Nil
 		reg15806 := PrimEqual(reg15805, V1358)
 		if reg15806 == True {
-			__ctx.TailApply(V1357, V1359, V1360)
+			__e.TailApply(V1357, V1359, V1360)
 			return
 		} else {
 			reg15808 := PrimIsPair(V1358)
 			if reg15808 == True {
 				reg15809 := PrimHead(V1358)
-				reg15810 := __e.Call(V1357, reg15809)
+				reg15810 := Call(__e, V1357, reg15809)
 				reg15811 := PrimTail(V1358)
-				__ctx.TailApply(__defun__shen_4call_1help, reg15810, reg15811, V1359, V1360)
+				__e.TailApply(__defun__shen_4call_1help, reg15810, reg15811, V1359, V1360)
 				return
 			} else {
 				reg15813 := MakeSymbol("shen.call-help")
-				__ctx.TailApply(__defun__shen_4f__error, reg15813)
+				__e.TailApply(__defun__shen_4f__error, reg15813)
 				return
 			}
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.call-help", value: __defun__shen_4call_1help})
 
-	__defun__shen_4intprolog = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4intprolog = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1362 := __args[0]
 		_ = V1362
 		reg15815 := PrimIsPair(V1362)
@@ -10865,7 +10865,7 @@ func init() {
 			reg15822 = reg15821
 		}
 		if reg15822 == True {
-			reg15823 := __e.Call(__defun__shen_4start_1new_1prolog_1process)
+			reg15823 := Call(__e, __defun__shen_4start_1new_1prolog_1process)
 			ProcessN := reg15823
 			_ = ProcessN
 			reg15824 := PrimHead(V1362)
@@ -10876,18 +10876,18 @@ func init() {
 			reg15829 := Nil
 			reg15830 := PrimCons(reg15828, reg15829)
 			reg15831 := PrimCons(reg15827, reg15830)
-			reg15832 := __e.Call(__defun__shen_4insert_1prolog_1variables, reg15831, ProcessN)
-			__ctx.TailApply(__defun__shen_4intprolog_1help, reg15825, reg15832, ProcessN)
+			reg15832 := Call(__e, __defun__shen_4insert_1prolog_1variables, reg15831, ProcessN)
+			__e.TailApply(__defun__shen_4intprolog_1help, reg15825, reg15832, ProcessN)
 			return
 		} else {
 			reg15834 := MakeSymbol("shen.intprolog")
-			__ctx.TailApply(__defun__shen_4f__error, reg15834)
+			__e.TailApply(__defun__shen_4f__error, reg15834)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.intprolog", value: __defun__shen_4intprolog})
 
-	__defun__shen_4intprolog_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4intprolog_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1366 := __args[0]
 		_ = V1366
 		V1367 := __args[1]
@@ -10935,17 +10935,17 @@ func init() {
 			reg15853 := PrimHead(V1367)
 			reg15854 := PrimTail(V1367)
 			reg15855 := PrimHead(reg15854)
-			__ctx.TailApply(__defun__shen_4intprolog_1help_1help, V1366, reg15853, reg15855, V1368)
+			__e.TailApply(__defun__shen_4intprolog_1help_1help, V1366, reg15853, reg15855, V1368)
 			return
 		} else {
 			reg15857 := MakeSymbol("shen.intprolog-help")
-			__ctx.TailApply(__defun__shen_4f__error, reg15857)
+			__e.TailApply(__defun__shen_4f__error, reg15857)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.intprolog-help", value: __defun__shen_4intprolog_1help})
 
-	__defun__shen_4intprolog_1help_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4intprolog_1help_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1373 := __args[0]
 		_ = V1373
 		V1374 := __args[1]
@@ -10957,30 +10957,30 @@ func init() {
 		reg15859 := Nil
 		reg15860 := PrimEqual(reg15859, V1374)
 		if reg15860 == True {
-			reg15861 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-				__ctx.TailApply(__defun__shen_4call_1rest, V1375, V1376)
+			reg15861 := MakeNative(func(__e Evaluator, __args ...Obj) {
+				__e.TailApply(__defun__shen_4call_1rest, V1375, V1376)
 				return
 			}, 0)
-			__ctx.TailApply(V1373, V1376, reg15861)
+			__e.TailApply(V1373, V1376, reg15861)
 			return
 		} else {
 			reg15864 := PrimIsPair(V1374)
 			if reg15864 == True {
 				reg15865 := PrimHead(V1374)
-				reg15866 := __e.Call(V1373, reg15865)
+				reg15866 := Call(__e, V1373, reg15865)
 				reg15867 := PrimTail(V1374)
-				__ctx.TailApply(__defun__shen_4intprolog_1help_1help, reg15866, reg15867, V1375, V1376)
+				__e.TailApply(__defun__shen_4intprolog_1help_1help, reg15866, reg15867, V1375, V1376)
 				return
 			} else {
 				reg15869 := MakeSymbol("shen.intprolog-help-help")
-				__ctx.TailApply(__defun__shen_4f__error, reg15869)
+				__e.TailApply(__defun__shen_4f__error, reg15869)
 				return
 			}
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.intprolog-help-help", value: __defun__shen_4intprolog_1help_1help})
 
-	__defun__shen_4call_1rest = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4call_1rest = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1381 := __args[0]
 		_ = V1381
 		V1382 := __args[1]
@@ -10989,7 +10989,7 @@ func init() {
 		reg15874 := PrimEqual(reg15873, V1381)
 		if reg15874 == True {
 			reg15875 := True
-			__ctx.Return(reg15875)
+			__e.Return(reg15875)
 			return
 		} else {
 			reg15876 := PrimIsPair(V1381)
@@ -11036,14 +11036,14 @@ func init() {
 				reg15894 := PrimHead(V1381)
 				reg15895 := PrimTail(reg15894)
 				reg15896 := PrimHead(reg15895)
-				reg15897 := __e.Call(f15871, reg15896)
+				reg15897 := Call(__e, f15871, reg15896)
 				reg15898 := PrimHead(V1381)
 				reg15899 := PrimTail(reg15898)
 				reg15900 := PrimTail(reg15899)
 				reg15901 := PrimCons(reg15897, reg15900)
 				reg15902 := PrimTail(V1381)
 				reg15903 := PrimCons(reg15901, reg15902)
-				__ctx.TailApply(__defun__shen_4call_1rest, reg15903, V1382)
+				__e.TailApply(__defun__shen_4call_1rest, reg15903, V1382)
 				return
 			} else {
 				reg15905 := PrimIsPair(V1381)
@@ -11088,16 +11088,16 @@ func init() {
 					reg15923 := PrimHead(reg15922)
 					f15872 := reg15923
 					_ = f15872
-					reg15924 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg15924 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						reg15925 := PrimTail(V1381)
-						__ctx.TailApply(__defun__shen_4call_1rest, reg15925, V1382)
+						__e.TailApply(__defun__shen_4call_1rest, reg15925, V1382)
 						return
 					}, 0)
-					__ctx.TailApply(f15872, V1382, reg15924)
+					__e.TailApply(f15872, V1382, reg15924)
 					return
 				} else {
 					reg15928 := MakeSymbol("shen.call-rest")
-					__ctx.TailApply(__defun__shen_4f__error, reg15928)
+					__e.TailApply(__defun__shen_4f__error, reg15928)
 					return
 				}
 			}
@@ -11105,7 +11105,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.call-rest", value: __defun__shen_4call_1rest})
 
-	__defun__shen_4start_1new_1prolog_1process = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4start_1new_1prolog_1process = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg15930 := MakeSymbol("shen.*process-counter*")
 		reg15931 := MakeNumber(1)
 		reg15932 := MakeSymbol("shen.*process-counter*")
@@ -11114,23 +11114,23 @@ func init() {
 		reg15935 := PrimSet(reg15930, reg15934)
 		IncrementProcessCounter := reg15935
 		_ = IncrementProcessCounter
-		__ctx.TailApply(__defun__shen_4initialise_1prolog, IncrementProcessCounter)
+		__e.TailApply(__defun__shen_4initialise_1prolog, IncrementProcessCounter)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.start-new-prolog-process", value: __defun__shen_4start_1new_1prolog_1process})
 
-	__defun__shen_4insert_1prolog_1variables = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert_1prolog_1variables = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1385 := __args[0]
 		_ = V1385
 		V1386 := __args[1]
 		_ = V1386
-		reg15937 := __e.Call(__defun__shen_4flatten, V1385)
-		__ctx.TailApply(__defun__shen_4insert_1prolog_1variables_1help, V1385, reg15937, V1386)
+		reg15937 := Call(__e, __defun__shen_4flatten, V1385)
+		__e.TailApply(__defun__shen_4insert_1prolog_1variables_1help, V1385, reg15937, V1386)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.insert-prolog-variables", value: __defun__shen_4insert_1prolog_1variables})
 
-	__defun__shen_4insert_1prolog_1variables_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert_1prolog_1variables_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1394 := __args[0]
 		_ = V1394
 		V1395 := __args[1]
@@ -11140,7 +11140,7 @@ func init() {
 		reg15939 := Nil
 		reg15940 := PrimEqual(reg15939, V1395)
 		if reg15940 == True {
-			__ctx.Return(V1394)
+			__e.Return(V1394)
 			return
 		} else {
 			reg15941 := PrimIsPair(V1395)
@@ -11162,29 +11162,29 @@ func init() {
 				reg15948 = reg15947
 			}
 			if reg15948 == True {
-				reg15949 := __e.Call(__defun__shen_4newpv, V1396)
+				reg15949 := Call(__e, __defun__shen_4newpv, V1396)
 				V := reg15949
 				_ = V
 				reg15950 := PrimHead(V1395)
-				reg15951 := __e.Call(__defun__subst, V, reg15950, V1394)
+				reg15951 := Call(__e, __defun__subst, V, reg15950, V1394)
 				XV_cY := reg15951
 				_ = XV_cY
 				reg15952 := PrimHead(V1395)
 				reg15953 := PrimTail(V1395)
-				reg15954 := __e.Call(__defun__remove, reg15952, reg15953)
+				reg15954 := Call(__e, __defun__remove, reg15952, reg15953)
 				Z_1Y := reg15954
 				_ = Z_1Y
-				__ctx.TailApply(__defun__shen_4insert_1prolog_1variables_1help, XV_cY, Z_1Y, V1396)
+				__e.TailApply(__defun__shen_4insert_1prolog_1variables_1help, XV_cY, Z_1Y, V1396)
 				return
 			} else {
 				reg15956 := PrimIsPair(V1395)
 				if reg15956 == True {
 					reg15957 := PrimTail(V1395)
-					__ctx.TailApply(__defun__shen_4insert_1prolog_1variables_1help, V1394, reg15957, V1396)
+					__e.TailApply(__defun__shen_4insert_1prolog_1variables_1help, V1394, reg15957, V1396)
 					return
 				} else {
 					reg15959 := MakeSymbol("shen.insert-prolog-variables-help")
-					__ctx.TailApply(__defun__shen_4f__error, reg15959)
+					__e.TailApply(__defun__shen_4f__error, reg15959)
 					return
 				}
 			}
@@ -11192,17 +11192,17 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.insert-prolog-variables-help", value: __defun__shen_4insert_1prolog_1variables_1help})
 
-	__defun__shen_4initialise_1prolog = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4initialise_1prolog = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1398 := __args[0]
 		_ = V1398
 		reg15961 := MakeSymbol("shen.*prologvectors*")
 		reg15962 := PrimValue(reg15961)
 		reg15963 := MakeNumber(10)
-		reg15964 := __e.Call(__defun__vector, reg15963)
+		reg15964 := Call(__e, __defun__vector, reg15963)
 		reg15965 := MakeNumber(1)
 		reg15966 := MakeNumber(10)
 		reg15967 := MakeSymbol("shen.-null-")
-		reg15968 := __e.Call(__defun__shen_4fillvector, reg15964, reg15965, reg15966, reg15967)
+		reg15968 := Call(__e, __defun__shen_4fillvector, reg15964, reg15965, reg15966, reg15967)
 		reg15969 := PrimVectorSet(reg15962, V1398, reg15968)
 		Vector := reg15969
 		_ = Vector
@@ -11212,7 +11212,7 @@ func init() {
 		reg15973 := PrimVectorSet(reg15971, V1398, reg15972)
 		Counter := reg15973
 		_ = Counter
-		__ctx.Return(V1398)
+		__e.Return(V1398)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.initialise-prolog", value: __defun__shen_4initialise_1prolog})

--- a/cmd/shen/reader.go
+++ b/cmd/shen/reader.go
@@ -91,50 +91,50 @@ var __defun__shen_4internal_1symbols Obj           // shen.internal-symbols
 var __defun__shen_4packageh Obj                    // shen.packageh
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg8356 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg8356)
+		__e.Return(reg8356)
 		return
 	}, 0))
-	__defun__shen_4read_1char_1code = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4read_1char_1code = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1400 := __args[0]
 		_ = V1400
 		reg8357 := PrimReadByte(V1400)
-		__ctx.Return(reg8357)
+		__e.Return(reg8357)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.read-char-code", value: __defun__shen_4read_1char_1code})
 
-	__defun__read_1file_1as_1bytelist = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__read_1file_1as_1bytelist = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1402 := __args[0]
 		_ = V1402
-		reg8358 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg8358 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			S := __args[0]
 			_ = S
 			reg8359 := PrimReadByte(S)
-			__ctx.Return(reg8359)
+			__e.Return(reg8359)
 			return
 		}, 1)
-		__ctx.TailApply(__defun__shen_4read_1file_1as_1Xlist, V1402, reg8358)
+		__e.TailApply(__defun__shen_4read_1file_1as_1Xlist, V1402, reg8358)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "read-file-as-bytelist", value: __defun__read_1file_1as_1bytelist})
 
-	__defun__shen_4read_1file_1as_1charlist = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4read_1file_1as_1charlist = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1404 := __args[0]
 		_ = V1404
-		reg8361 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg8361 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			S := __args[0]
 			_ = S
-			__ctx.TailApply(__defun__shen_4read_1char_1code, S)
+			__e.TailApply(__defun__shen_4read_1char_1code, S)
 			return
 		}, 1)
-		__ctx.TailApply(__defun__shen_4read_1file_1as_1Xlist, V1404, reg8361)
+		__e.TailApply(__defun__shen_4read_1file_1as_1Xlist, V1404, reg8361)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.read-file-as-charlist", value: __defun__shen_4read_1file_1as_1charlist})
 
-	__defun__shen_4read_1file_1as_1Xlist = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4read_1file_1as_1Xlist = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1407 := __args[0]
 		_ = V1407
 		V1408 := __args[1]
@@ -143,22 +143,22 @@ func init() {
 		reg8365 := PrimOpenStream(V1407, reg8364)
 		Stream := reg8365
 		_ = Stream
-		reg8366 := __e.Call(V1408, Stream)
+		reg8366 := Call(__e, V1408, Stream)
 		X := reg8366
 		_ = X
 		reg8367 := Nil
-		reg8368 := __e.Call(__defun__shen_4read_1file_1as_1Xlist_1help, Stream, V1408, X, reg8367)
+		reg8368 := Call(__e, __defun__shen_4read_1file_1as_1Xlist_1help, Stream, V1408, X, reg8367)
 		Xs := reg8368
 		_ = Xs
 		reg8369 := PrimCloseStream(Stream)
 		Close := reg8369
 		_ = Close
-		__ctx.TailApply(__defun__reverse, Xs)
+		__e.TailApply(__defun__reverse, Xs)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.read-file-as-Xlist", value: __defun__shen_4read_1file_1as_1Xlist})
 
-	__defun__shen_4read_1file_1as_1Xlist_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4read_1file_1as_1Xlist_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1413 := __args[0]
 		_ = V1413
 		V1414 := __args[1]
@@ -170,32 +170,32 @@ func init() {
 		reg8371 := MakeNumber(-1)
 		reg8372 := PrimEqual(reg8371, V1415)
 		if reg8372 == True {
-			__ctx.Return(V1416)
+			__e.Return(V1416)
 			return
 		} else {
-			reg8373 := __e.Call(V1414, V1413)
+			reg8373 := Call(__e, V1414, V1413)
 			reg8374 := PrimCons(V1415, V1416)
-			__ctx.TailApply(__defun__shen_4read_1file_1as_1Xlist_1help, V1413, V1414, reg8373, reg8374)
+			__e.TailApply(__defun__shen_4read_1file_1as_1Xlist_1help, V1413, V1414, reg8373, reg8374)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.read-file-as-Xlist-help", value: __defun__shen_4read_1file_1as_1Xlist_1help})
 
-	__defun__read_1file_1as_1string = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__read_1file_1as_1string = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1418 := __args[0]
 		_ = V1418
 		reg8376 := MakeSymbol("in")
 		reg8377 := PrimOpenStream(V1418, reg8376)
 		Stream := reg8377
 		_ = Stream
-		reg8378 := __e.Call(__defun__shen_4read_1char_1code, Stream)
+		reg8378 := Call(__e, __defun__shen_4read_1char_1code, Stream)
 		reg8379 := MakeString("")
-		__ctx.TailApply(__defun__shen_4rfas_1h, Stream, reg8378, reg8379)
+		__e.TailApply(__defun__shen_4rfas_1h, Stream, reg8378, reg8379)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "read-file-as-string", value: __defun__read_1file_1as_1string})
 
-	__defun__shen_4rfas_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4rfas_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1422 := __args[0]
 		_ = V1422
 		V1423 := __args[1]
@@ -207,76 +207,76 @@ func init() {
 		if reg8382 == True {
 			reg8383 := PrimCloseStream(V1422)
 			_ = reg8383
-			__ctx.Return(V1424)
+			__e.Return(V1424)
 			return
 		} else {
-			reg8384 := __e.Call(__defun__shen_4read_1char_1code, V1422)
+			reg8384 := Call(__e, __defun__shen_4read_1char_1code, V1422)
 			reg8385 := PrimNumberToString(V1423)
 			reg8386 := PrimStringConcat(V1424, reg8385)
-			__ctx.TailApply(__defun__shen_4rfas_1h, V1422, reg8384, reg8386)
+			__e.TailApply(__defun__shen_4rfas_1h, V1422, reg8384, reg8386)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.rfas-h", value: __defun__shen_4rfas_1h})
 
-	__defun__input = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__input = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1426 := __args[0]
 		_ = V1426
-		reg8388 := __e.Call(__defun__read, V1426)
+		reg8388 := Call(__e, __defun__read, V1426)
 		reg8389 := PrimEvalKL(__e, reg8388)
-		__ctx.Return(reg8389)
+		__e.Return(reg8389)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "input", value: __defun__input})
 
-	__defun__input_7 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__input_7 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1429 := __args[0]
 		_ = V1429
 		V1430 := __args[1]
 		_ = V1430
-		reg8390 := __e.Call(__defun__shen_4monotype, V1429)
+		reg8390 := Call(__e, __defun__shen_4monotype, V1429)
 		Mono_2 := reg8390
 		_ = Mono_2
-		reg8391 := __e.Call(__defun__read, V1430)
+		reg8391 := Call(__e, __defun__read, V1430)
 		Input := reg8391
 		_ = Input
 		reg8392 := False
-		reg8393 := __e.Call(__defun__shen_4demodulate, V1429)
-		reg8394 := __e.Call(__defun__shen_4typecheck, Input, reg8393)
+		reg8393 := Call(__e, __defun__shen_4demodulate, V1429)
+		reg8394 := Call(__e, __defun__shen_4typecheck, Input, reg8393)
 		reg8395 := PrimEqual(reg8392, reg8394)
 		if reg8395 == True {
 			reg8396 := MakeString("type error: ")
 			reg8397 := MakeString(" is not of type ")
 			reg8398 := MakeString("\n")
 			reg8399 := MakeSymbol("shen.r")
-			reg8400 := __e.Call(__defun__shen_4app, V1429, reg8398, reg8399)
+			reg8400 := Call(__e, __defun__shen_4app, V1429, reg8398, reg8399)
 			reg8401 := PrimStringConcat(reg8397, reg8400)
 			reg8402 := MakeSymbol("shen.r")
-			reg8403 := __e.Call(__defun__shen_4app, Input, reg8401, reg8402)
+			reg8403 := Call(__e, __defun__shen_4app, Input, reg8401, reg8402)
 			reg8404 := PrimStringConcat(reg8396, reg8403)
 			reg8405 := PrimSimpleError(reg8404)
-			__ctx.Return(reg8405)
+			__e.Return(reg8405)
 			return
 		} else {
 			reg8406 := PrimEvalKL(__e, Input)
-			__ctx.Return(reg8406)
+			__e.Return(reg8406)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "input+", value: __defun__input_7})
 
-	__defun__shen_4monotype = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4monotype = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1432 := __args[0]
 		_ = V1432
 		reg8407 := PrimIsPair(V1432)
 		if reg8407 == True {
-			reg8408 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg8408 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Z := __args[0]
 				_ = Z
-				__ctx.TailApply(__defun__shen_4monotype, Z)
+				__e.TailApply(__defun__shen_4monotype, Z)
 				return
 			}, 1)
-			__ctx.TailApply(__defun__map, reg8408, V1432)
+			__e.TailApply(__defun__map, reg8408, V1432)
 			return
 		} else {
 			reg8411 := PrimIsVariable(V1432)
@@ -284,40 +284,40 @@ func init() {
 				reg8412 := MakeString("input+ expects a monotype: not ")
 				reg8413 := MakeString("\n")
 				reg8414 := MakeSymbol("shen.a")
-				reg8415 := __e.Call(__defun__shen_4app, V1432, reg8413, reg8414)
+				reg8415 := Call(__e, __defun__shen_4app, V1432, reg8413, reg8414)
 				reg8416 := PrimStringConcat(reg8412, reg8415)
 				reg8417 := PrimSimpleError(reg8416)
-				__ctx.Return(reg8417)
+				__e.Return(reg8417)
 				return
 			} else {
-				__ctx.Return(V1432)
+				__e.Return(V1432)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.monotype", value: __defun__shen_4monotype})
 
-	__defun__read = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__read = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1434 := __args[0]
 		_ = V1434
-		reg8418 := __e.Call(__defun__shen_4read_1char_1code, V1434)
+		reg8418 := Call(__e, __defun__shen_4read_1char_1code, V1434)
 		reg8419 := Nil
-		reg8420 := __e.Call(__defun__shen_4read_1loop, V1434, reg8418, reg8419)
+		reg8420 := Call(__e, __defun__shen_4read_1loop, V1434, reg8418, reg8419)
 		reg8421 := PrimHead(reg8420)
-		__ctx.Return(reg8421)
+		__e.Return(reg8421)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "read", value: __defun__read})
 
-	__defun__it = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__it = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg8422 := MakeSymbol("shen.*it*")
 		reg8423 := PrimValue(reg8422)
-		__ctx.Return(reg8423)
+		__e.Return(reg8423)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "it", value: __defun__it})
 
-	__defun__shen_4read_1loop = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4read_1loop = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1442 := __args[0]
 		_ = V1442
 		V1443 := __args[1]
@@ -329,59 +329,59 @@ func init() {
 		if reg8425 == True {
 			reg8426 := MakeString("read aborted")
 			reg8427 := PrimSimpleError(reg8426)
-			__ctx.Return(reg8427)
+			__e.Return(reg8427)
 			return
 		} else {
 			reg8428 := MakeNumber(-1)
 			reg8429 := PrimEqual(reg8428, V1443)
 			if reg8429 == True {
-				reg8430 := __e.Call(__defun__empty_2, V1444)
+				reg8430 := Call(__e, __defun__empty_2, V1444)
 				if reg8430 == True {
 					reg8431 := MakeString("error: empty stream")
 					reg8432 := PrimSimpleError(reg8431)
-					__ctx.Return(reg8432)
+					__e.Return(reg8432)
 					return
 				} else {
-					reg8433 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg8433 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						X := __args[0]
 						_ = X
-						__ctx.TailApply(__defun__shen_4_5st__input_6, X)
+						__e.TailApply(__defun__shen_4_5st__input_6, X)
 						return
 					}, 1)
-					reg8435 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg8435 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						E := __args[0]
 						_ = E
-						__ctx.Return(E)
+						__e.Return(E)
 						return
 					}, 1)
-					__ctx.TailApply(__defun__compile, reg8433, V1444, reg8435)
+					__e.TailApply(__defun__compile, reg8433, V1444, reg8435)
 					return
 				}
 			} else {
-				reg8437 := __e.Call(__defun__shen_4terminator_2, V1443)
+				reg8437 := Call(__e, __defun__shen_4terminator_2, V1443)
 				if reg8437 == True {
 					reg8438 := Nil
 					reg8439 := PrimCons(V1443, reg8438)
-					reg8440 := __e.Call(__defun__append, V1444, reg8439)
+					reg8440 := Call(__e, __defun__append, V1444, reg8439)
 					AllChars := reg8440
 					_ = AllChars
-					reg8441 := __e.Call(__defun__shen_4record_1it, AllChars)
+					reg8441 := Call(__e, __defun__shen_4record_1it, AllChars)
 					It := reg8441
 					_ = It
-					reg8442 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg8442 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						X := __args[0]
 						_ = X
-						__ctx.TailApply(__defun__shen_4_5st__input_6, X)
+						__e.TailApply(__defun__shen_4_5st__input_6, X)
 						return
 					}, 1)
-					reg8444 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg8444 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						E := __args[0]
 						_ = E
 						reg8445 := MakeSymbol("shen.nextbyte")
-						__ctx.Return(reg8445)
+						__e.Return(reg8445)
 						return
 					}, 1)
-					reg8446 := __e.Call(__defun__compile, reg8442, AllChars, reg8444)
+					reg8446 := Call(__e, __defun__compile, reg8442, AllChars, reg8444)
 					Read := reg8446
 					_ = Read
 					reg8447 := MakeSymbol("shen.nextbyte")
@@ -391,7 +391,7 @@ func init() {
 						reg8449 := True
 						reg8454 = reg8449
 					} else {
-						reg8450 := __e.Call(__defun__empty_2, Read)
+						reg8450 := Call(__e, __defun__empty_2, Read)
 						var reg8453 Obj
 						if reg8450 == True {
 							reg8451 := True
@@ -403,19 +403,19 @@ func init() {
 						reg8454 = reg8453
 					}
 					if reg8454 == True {
-						reg8455 := __e.Call(__defun__shen_4read_1char_1code, V1442)
-						__ctx.TailApply(__defun__shen_4read_1loop, V1442, reg8455, AllChars)
+						reg8455 := Call(__e, __defun__shen_4read_1char_1code, V1442)
+						__e.TailApply(__defun__shen_4read_1loop, V1442, reg8455, AllChars)
 						return
 					} else {
-						__ctx.Return(Read)
+						__e.Return(Read)
 						return
 					}
 				} else {
-					reg8457 := __e.Call(__defun__shen_4read_1char_1code, V1442)
+					reg8457 := Call(__e, __defun__shen_4read_1char_1code, V1442)
 					reg8458 := Nil
 					reg8459 := PrimCons(V1443, reg8458)
-					reg8460 := __e.Call(__defun__append, V1444, reg8459)
-					__ctx.TailApply(__defun__shen_4read_1loop, V1442, reg8457, reg8460)
+					reg8460 := Call(__e, __defun__append, V1444, reg8459)
+					__e.TailApply(__defun__shen_4read_1loop, V1442, reg8457, reg8460)
 					return
 				}
 			}
@@ -423,7 +423,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.read-loop", value: __defun__shen_4read_1loop})
 
-	__defun__shen_4terminator_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4terminator_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1446 := __args[0]
 		_ = V1446
 		reg8462 := MakeNumber(9)
@@ -441,22 +441,22 @@ func init() {
 		reg8474 := PrimCons(reg8464, reg8473)
 		reg8475 := PrimCons(reg8463, reg8474)
 		reg8476 := PrimCons(reg8462, reg8475)
-		__ctx.TailApply(__defun__element_2, V1446, reg8476)
+		__e.TailApply(__defun__element_2, V1446, reg8476)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.terminator?", value: __defun__shen_4terminator_2})
 
-	__defun__lineread = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__lineread = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1448 := __args[0]
 		_ = V1448
-		reg8478 := __e.Call(__defun__shen_4read_1char_1code, V1448)
+		reg8478 := Call(__e, __defun__shen_4read_1char_1code, V1448)
 		reg8479 := Nil
-		__ctx.TailApply(__defun__shen_4lineread_1loop, reg8478, reg8479, V1448)
+		__e.TailApply(__defun__shen_4lineread_1loop, reg8478, reg8479, V1448)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "lineread", value: __defun__lineread})
 
-	__defun__shen_4lineread_1loop = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lineread_1loop = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1453 := __args[0]
 		_ = V1453
 		V1454 := __args[1]
@@ -466,61 +466,61 @@ func init() {
 		reg8481 := MakeNumber(-1)
 		reg8482 := PrimEqual(reg8481, V1453)
 		if reg8482 == True {
-			reg8483 := __e.Call(__defun__empty_2, V1454)
+			reg8483 := Call(__e, __defun__empty_2, V1454)
 			if reg8483 == True {
 				reg8484 := MakeString("empty stream")
 				reg8485 := PrimSimpleError(reg8484)
-				__ctx.Return(reg8485)
+				__e.Return(reg8485)
 				return
 			} else {
-				reg8486 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg8486 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					X := __args[0]
 					_ = X
-					__ctx.TailApply(__defun__shen_4_5st__input_6, X)
+					__e.TailApply(__defun__shen_4_5st__input_6, X)
 					return
 				}, 1)
-				reg8488 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg8488 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					E := __args[0]
 					_ = E
-					__ctx.Return(E)
+					__e.Return(E)
 					return
 				}, 1)
-				__ctx.TailApply(__defun__compile, reg8486, V1454, reg8488)
+				__e.TailApply(__defun__compile, reg8486, V1454, reg8488)
 				return
 			}
 		} else {
-			reg8490 := __e.Call(__defun__shen_4hat)
+			reg8490 := Call(__e, __defun__shen_4hat)
 			reg8491 := PrimEqual(V1453, reg8490)
 			if reg8491 == True {
 				reg8492 := MakeString("line read aborted")
 				reg8493 := PrimSimpleError(reg8492)
-				__ctx.Return(reg8493)
+				__e.Return(reg8493)
 				return
 			} else {
-				reg8494 := __e.Call(__defun__shen_4newline)
-				reg8495 := __e.Call(__defun__shen_4carriage_1return)
+				reg8494 := Call(__e, __defun__shen_4newline)
+				reg8495 := Call(__e, __defun__shen_4carriage_1return)
 				reg8496 := Nil
 				reg8497 := PrimCons(reg8495, reg8496)
 				reg8498 := PrimCons(reg8494, reg8497)
-				reg8499 := __e.Call(__defun__element_2, V1453, reg8498)
+				reg8499 := Call(__e, __defun__element_2, V1453, reg8498)
 				if reg8499 == True {
-					reg8500 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg8500 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						X := __args[0]
 						_ = X
-						__ctx.TailApply(__defun__shen_4_5st__input_6, X)
+						__e.TailApply(__defun__shen_4_5st__input_6, X)
 						return
 					}, 1)
-					reg8502 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg8502 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						E := __args[0]
 						_ = E
 						reg8503 := MakeSymbol("shen.nextline")
-						__ctx.Return(reg8503)
+						__e.Return(reg8503)
 						return
 					}, 1)
-					reg8504 := __e.Call(__defun__compile, reg8500, V1454, reg8502)
+					reg8504 := Call(__e, __defun__compile, reg8500, V1454, reg8502)
 					Line := reg8504
 					_ = Line
-					reg8505 := __e.Call(__defun__shen_4record_1it, V1454)
+					reg8505 := Call(__e, __defun__shen_4record_1it, V1454)
 					It := reg8505
 					_ = It
 					reg8506 := MakeSymbol("shen.nextline")
@@ -530,7 +530,7 @@ func init() {
 						reg8508 := True
 						reg8513 = reg8508
 					} else {
-						reg8509 := __e.Call(__defun__empty_2, Line)
+						reg8509 := Call(__e, __defun__empty_2, Line)
 						var reg8512 Obj
 						if reg8509 == True {
 							reg8510 := True
@@ -542,22 +542,22 @@ func init() {
 						reg8513 = reg8512
 					}
 					if reg8513 == True {
-						reg8514 := __e.Call(__defun__shen_4read_1char_1code, V1455)
+						reg8514 := Call(__e, __defun__shen_4read_1char_1code, V1455)
 						reg8515 := Nil
 						reg8516 := PrimCons(V1453, reg8515)
-						reg8517 := __e.Call(__defun__append, V1454, reg8516)
-						__ctx.TailApply(__defun__shen_4lineread_1loop, reg8514, reg8517, V1455)
+						reg8517 := Call(__e, __defun__append, V1454, reg8516)
+						__e.TailApply(__defun__shen_4lineread_1loop, reg8514, reg8517, V1455)
 						return
 					} else {
-						__ctx.Return(Line)
+						__e.Return(Line)
 						return
 					}
 				} else {
-					reg8519 := __e.Call(__defun__shen_4read_1char_1code, V1455)
+					reg8519 := Call(__e, __defun__shen_4read_1char_1code, V1455)
 					reg8520 := Nil
 					reg8521 := PrimCons(V1453, reg8520)
-					reg8522 := __e.Call(__defun__append, V1454, reg8521)
-					__ctx.TailApply(__defun__shen_4lineread_1loop, reg8519, reg8522, V1455)
+					reg8522 := Call(__e, __defun__append, V1454, reg8521)
+					__e.TailApply(__defun__shen_4lineread_1loop, reg8519, reg8522, V1455)
 					return
 				}
 			}
@@ -565,25 +565,25 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.lineread-loop", value: __defun__shen_4lineread_1loop})
 
-	__defun__shen_4record_1it = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4record_1it = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1457 := __args[0]
 		_ = V1457
-		reg8524 := __e.Call(__defun__shen_4trim_1whitespace, V1457)
+		reg8524 := Call(__e, __defun__shen_4trim_1whitespace, V1457)
 		TrimLeft := reg8524
 		_ = TrimLeft
-		reg8525 := __e.Call(__defun__reverse, TrimLeft)
-		reg8526 := __e.Call(__defun__shen_4trim_1whitespace, reg8525)
+		reg8525 := Call(__e, __defun__reverse, TrimLeft)
+		reg8526 := Call(__e, __defun__shen_4trim_1whitespace, reg8525)
 		TrimRight := reg8526
 		_ = TrimRight
-		reg8527 := __e.Call(__defun__reverse, TrimRight)
+		reg8527 := Call(__e, __defun__reverse, TrimRight)
 		Trimmed := reg8527
 		_ = Trimmed
-		__ctx.TailApply(__defun__shen_4record_1it_1h, Trimmed)
+		__e.TailApply(__defun__shen_4record_1it_1h, Trimmed)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.record-it", value: __defun__shen_4record_1it})
 
-	__defun__shen_4trim_1whitespace = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4trim_1whitespace = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1459 := __args[0]
 		_ = V1459
 		reg8529 := PrimIsPair(V1459)
@@ -599,7 +599,7 @@ func init() {
 			reg8537 := PrimCons(reg8533, reg8536)
 			reg8538 := PrimCons(reg8532, reg8537)
 			reg8539 := PrimCons(reg8531, reg8538)
-			reg8540 := __e.Call(__defun__element_2, reg8530, reg8539)
+			reg8540 := Call(__e, __defun__element_2, reg8530, reg8539)
 			var reg8543 Obj
 			if reg8540 == True {
 				reg8541 := True
@@ -615,117 +615,117 @@ func init() {
 		}
 		if reg8545 == True {
 			reg8546 := PrimTail(V1459)
-			__ctx.TailApply(__defun__shen_4trim_1whitespace, reg8546)
+			__e.TailApply(__defun__shen_4trim_1whitespace, reg8546)
 			return
 		} else {
-			__ctx.Return(V1459)
+			__e.Return(V1459)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.trim-whitespace", value: __defun__shen_4trim_1whitespace})
 
-	__defun__shen_4record_1it_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4record_1it_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1461 := __args[0]
 		_ = V1461
 		reg8548 := MakeSymbol("shen.*it*")
-		reg8549 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg8549 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
 			reg8550 := PrimNumberToString(X)
-			__ctx.Return(reg8550)
+			__e.Return(reg8550)
 			return
 		}, 1)
-		reg8551 := __e.Call(__defun__map, reg8549, V1461)
-		reg8552 := __e.Call(__defun__shen_4cn_1all, reg8551)
+		reg8551 := Call(__e, __defun__map, reg8549, V1461)
+		reg8552 := Call(__e, __defun__shen_4cn_1all, reg8551)
 		reg8553 := PrimSet(reg8548, reg8552)
 		_ = reg8553
-		__ctx.Return(V1461)
+		__e.Return(V1461)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.record-it-h", value: __defun__shen_4record_1it_1h})
 
-	__defun__shen_4cn_1all = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4cn_1all = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1463 := __args[0]
 		_ = V1463
 		reg8554 := Nil
 		reg8555 := PrimEqual(reg8554, V1463)
 		if reg8555 == True {
 			reg8556 := MakeString("")
-			__ctx.Return(reg8556)
+			__e.Return(reg8556)
 			return
 		} else {
 			reg8557 := PrimIsPair(V1463)
 			if reg8557 == True {
 				reg8558 := PrimHead(V1463)
 				reg8559 := PrimTail(V1463)
-				reg8560 := __e.Call(__defun__shen_4cn_1all, reg8559)
+				reg8560 := Call(__e, __defun__shen_4cn_1all, reg8559)
 				reg8561 := PrimStringConcat(reg8558, reg8560)
-				__ctx.Return(reg8561)
+				__e.Return(reg8561)
 				return
 			} else {
 				reg8562 := MakeSymbol("shen.cn-all")
-				__ctx.TailApply(__defun__shen_4f__error, reg8562)
+				__e.TailApply(__defun__shen_4f__error, reg8562)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.cn-all", value: __defun__shen_4cn_1all})
 
-	__defun__read_1file = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__read_1file = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1465 := __args[0]
 		_ = V1465
-		reg8564 := __e.Call(__defun__shen_4read_1file_1as_1charlist, V1465)
+		reg8564 := Call(__e, __defun__shen_4read_1file_1as_1charlist, V1465)
 		Charlist := reg8564
 		_ = Charlist
-		reg8565 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg8565 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4_5st__input_6, X)
+			__e.TailApply(__defun__shen_4_5st__input_6, X)
 			return
 		}, 1)
-		reg8567 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg8567 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4read_1error, X)
+			__e.TailApply(__defun__shen_4read_1error, X)
 			return
 		}, 1)
-		__ctx.TailApply(__defun__compile, reg8565, Charlist, reg8567)
+		__e.TailApply(__defun__compile, reg8565, Charlist, reg8567)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "read-file", value: __defun__read_1file})
 
-	__defun__read_1from_1string = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__read_1from_1string = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1467 := __args[0]
 		_ = V1467
-		reg8570 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg8570 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
 			reg8571 := PrimStringToNumber(X)
-			__ctx.Return(reg8571)
+			__e.Return(reg8571)
 			return
 		}, 1)
-		reg8572 := __e.Call(__defun__explode, V1467)
-		reg8573 := __e.Call(__defun__map, reg8570, reg8572)
+		reg8572 := Call(__e, __defun__explode, V1467)
+		reg8573 := Call(__e, __defun__map, reg8570, reg8572)
 		Ns := reg8573
 		_ = Ns
-		reg8574 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg8574 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4_5st__input_6, X)
+			__e.TailApply(__defun__shen_4_5st__input_6, X)
 			return
 		}, 1)
-		reg8576 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg8576 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4read_1error, X)
+			__e.TailApply(__defun__shen_4read_1error, X)
 			return
 		}, 1)
-		__ctx.TailApply(__defun__compile, reg8574, Ns, reg8576)
+		__e.TailApply(__defun__compile, reg8574, Ns, reg8576)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "read-from-string", value: __defun__read_1from_1string})
 
-	__defun__shen_4read_1error = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4read_1error = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1475 := __args[0]
 		_ = V1475
 		reg8579 := PrimIsPair(V1475)
@@ -786,24 +786,24 @@ func init() {
 			reg8603 := MakeString("read error here:\n\n ")
 			reg8604 := MakeNumber(50)
 			reg8605 := PrimHead(V1475)
-			reg8606 := __e.Call(__defun__shen_4compress_150, reg8604, reg8605)
+			reg8606 := Call(__e, __defun__shen_4compress_150, reg8604, reg8605)
 			reg8607 := MakeString("\n")
 			reg8608 := MakeSymbol("shen.a")
-			reg8609 := __e.Call(__defun__shen_4app, reg8606, reg8607, reg8608)
+			reg8609 := Call(__e, __defun__shen_4app, reg8606, reg8607, reg8608)
 			reg8610 := PrimStringConcat(reg8603, reg8609)
 			reg8611 := PrimSimpleError(reg8610)
-			__ctx.Return(reg8611)
+			__e.Return(reg8611)
 			return
 		} else {
 			reg8612 := MakeString("read error\n")
 			reg8613 := PrimSimpleError(reg8612)
-			__ctx.Return(reg8613)
+			__e.Return(reg8613)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.read-error", value: __defun__shen_4read_1error})
 
-	__defun__shen_4compress_150 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4compress_150 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1482 := __args[0]
 		_ = V1482
 		V1483 := __args[1]
@@ -812,14 +812,14 @@ func init() {
 		reg8615 := PrimEqual(reg8614, V1483)
 		if reg8615 == True {
 			reg8616 := MakeString("")
-			__ctx.Return(reg8616)
+			__e.Return(reg8616)
 			return
 		} else {
 			reg8617 := MakeNumber(0)
 			reg8618 := PrimEqual(reg8617, V1482)
 			if reg8618 == True {
 				reg8619 := MakeString("")
-				__ctx.Return(reg8619)
+				__e.Return(reg8619)
 				return
 			} else {
 				reg8620 := PrimIsPair(V1483)
@@ -829,13 +829,13 @@ func init() {
 					reg8623 := MakeNumber(1)
 					reg8624 := PrimNumberSubtract(V1482, reg8623)
 					reg8625 := PrimTail(V1483)
-					reg8626 := __e.Call(__defun__shen_4compress_150, reg8624, reg8625)
+					reg8626 := Call(__e, __defun__shen_4compress_150, reg8624, reg8625)
 					reg8627 := PrimStringConcat(reg8622, reg8626)
-					__ctx.Return(reg8627)
+					__e.Return(reg8627)
 					return
 				} else {
 					reg8628 := MakeSymbol("shen.compress-50")
-					__ctx.TailApply(__defun__shen_4f__error, reg8628)
+					__e.TailApply(__defun__shen_4f__error, reg8628)
 					return
 				}
 			}
@@ -843,426 +843,426 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.compress-50", value: __defun__shen_4compress_150})
 
-	__defun__shen_4_5st__input_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5st__input_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1485 := __args[0]
 		_ = V1485
-		reg8630 := __e.Call(__defun__shen_4_5lsb_6, V1485)
+		reg8630 := Call(__e, __defun__shen_4_5lsb_6, V1485)
 		Parse__shen_4_5lsb_6 := reg8630
 		_ = Parse__shen_4_5lsb_6
-		reg8631 := __e.Call(__defun__fail)
+		reg8631 := Call(__e, __defun__fail)
 		reg8632 := PrimEqual(reg8631, Parse__shen_4_5lsb_6)
 		reg8633 := PrimNot(reg8632)
 		var reg8660 Obj
 		if reg8633 == True {
-			reg8634 := __e.Call(__defun__shen_4_5st__input1_6, Parse__shen_4_5lsb_6)
+			reg8634 := Call(__e, __defun__shen_4_5st__input1_6, Parse__shen_4_5lsb_6)
 			Parse__shen_4_5st__input1_6 := reg8634
 			_ = Parse__shen_4_5st__input1_6
-			reg8635 := __e.Call(__defun__fail)
+			reg8635 := Call(__e, __defun__fail)
 			reg8636 := PrimEqual(reg8635, Parse__shen_4_5st__input1_6)
 			reg8637 := PrimNot(reg8636)
 			var reg8658 Obj
 			if reg8637 == True {
-				reg8638 := __e.Call(__defun__shen_4_5rsb_6, Parse__shen_4_5st__input1_6)
+				reg8638 := Call(__e, __defun__shen_4_5rsb_6, Parse__shen_4_5st__input1_6)
 				Parse__shen_4_5rsb_6 := reg8638
 				_ = Parse__shen_4_5rsb_6
-				reg8639 := __e.Call(__defun__fail)
+				reg8639 := Call(__e, __defun__fail)
 				reg8640 := PrimEqual(reg8639, Parse__shen_4_5rsb_6)
 				reg8641 := PrimNot(reg8640)
 				var reg8656 Obj
 				if reg8641 == True {
-					reg8642 := __e.Call(__defun__shen_4_5st__input2_6, Parse__shen_4_5rsb_6)
+					reg8642 := Call(__e, __defun__shen_4_5st__input2_6, Parse__shen_4_5rsb_6)
 					Parse__shen_4_5st__input2_6 := reg8642
 					_ = Parse__shen_4_5st__input2_6
-					reg8643 := __e.Call(__defun__fail)
+					reg8643 := Call(__e, __defun__fail)
 					reg8644 := PrimEqual(reg8643, Parse__shen_4_5st__input2_6)
 					reg8645 := PrimNot(reg8644)
 					var reg8654 Obj
 					if reg8645 == True {
 						reg8646 := PrimHead(Parse__shen_4_5st__input2_6)
-						reg8647 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input1_6)
-						reg8648 := __e.Call(__defun__shen_4cons__form, reg8647)
-						reg8649 := __e.Call(__defun__macroexpand, reg8648)
-						reg8650 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input2_6)
+						reg8647 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input1_6)
+						reg8648 := Call(__e, __defun__shen_4cons__form, reg8647)
+						reg8649 := Call(__e, __defun__macroexpand, reg8648)
+						reg8650 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input2_6)
 						reg8651 := PrimCons(reg8649, reg8650)
-						reg8652 := __e.Call(__defun__shen_4pair, reg8646, reg8651)
+						reg8652 := Call(__e, __defun__shen_4pair, reg8646, reg8651)
 						reg8654 = reg8652
 					} else {
-						reg8653 := __e.Call(__defun__fail)
+						reg8653 := Call(__e, __defun__fail)
 						reg8654 = reg8653
 					}
 					reg8656 = reg8654
 				} else {
-					reg8655 := __e.Call(__defun__fail)
+					reg8655 := Call(__e, __defun__fail)
 					reg8656 = reg8655
 				}
 				reg8658 = reg8656
 			} else {
-				reg8657 := __e.Call(__defun__fail)
+				reg8657 := Call(__e, __defun__fail)
 				reg8658 = reg8657
 			}
 			reg8660 = reg8658
 		} else {
-			reg8659 := __e.Call(__defun__fail)
+			reg8659 := Call(__e, __defun__fail)
 			reg8660 = reg8659
 		}
 		YaccParse := reg8660
 		_ = YaccParse
-		reg8661 := __e.Call(__defun__fail)
+		reg8661 := Call(__e, __defun__fail)
 		reg8662 := PrimEqual(YaccParse, reg8661)
 		if reg8662 == True {
-			reg8663 := __e.Call(__defun__shen_4_5lrb_6, V1485)
+			reg8663 := Call(__e, __defun__shen_4_5lrb_6, V1485)
 			Parse__shen_4_5lrb_6 := reg8663
 			_ = Parse__shen_4_5lrb_6
-			reg8664 := __e.Call(__defun__fail)
+			reg8664 := Call(__e, __defun__fail)
 			reg8665 := PrimEqual(reg8664, Parse__shen_4_5lrb_6)
 			reg8666 := PrimNot(reg8665)
 			var reg8692 Obj
 			if reg8666 == True {
-				reg8667 := __e.Call(__defun__shen_4_5st__input1_6, Parse__shen_4_5lrb_6)
+				reg8667 := Call(__e, __defun__shen_4_5st__input1_6, Parse__shen_4_5lrb_6)
 				Parse__shen_4_5st__input1_6 := reg8667
 				_ = Parse__shen_4_5st__input1_6
-				reg8668 := __e.Call(__defun__fail)
+				reg8668 := Call(__e, __defun__fail)
 				reg8669 := PrimEqual(reg8668, Parse__shen_4_5st__input1_6)
 				reg8670 := PrimNot(reg8669)
 				var reg8690 Obj
 				if reg8670 == True {
-					reg8671 := __e.Call(__defun__shen_4_5rrb_6, Parse__shen_4_5st__input1_6)
+					reg8671 := Call(__e, __defun__shen_4_5rrb_6, Parse__shen_4_5st__input1_6)
 					Parse__shen_4_5rrb_6 := reg8671
 					_ = Parse__shen_4_5rrb_6
-					reg8672 := __e.Call(__defun__fail)
+					reg8672 := Call(__e, __defun__fail)
 					reg8673 := PrimEqual(reg8672, Parse__shen_4_5rrb_6)
 					reg8674 := PrimNot(reg8673)
 					var reg8688 Obj
 					if reg8674 == True {
-						reg8675 := __e.Call(__defun__shen_4_5st__input2_6, Parse__shen_4_5rrb_6)
+						reg8675 := Call(__e, __defun__shen_4_5st__input2_6, Parse__shen_4_5rrb_6)
 						Parse__shen_4_5st__input2_6 := reg8675
 						_ = Parse__shen_4_5st__input2_6
-						reg8676 := __e.Call(__defun__fail)
+						reg8676 := Call(__e, __defun__fail)
 						reg8677 := PrimEqual(reg8676, Parse__shen_4_5st__input2_6)
 						reg8678 := PrimNot(reg8677)
 						var reg8686 Obj
 						if reg8678 == True {
 							reg8679 := PrimHead(Parse__shen_4_5st__input2_6)
-							reg8680 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input1_6)
-							reg8681 := __e.Call(__defun__macroexpand, reg8680)
-							reg8682 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input2_6)
-							reg8683 := __e.Call(__defun__shen_4package_1macro, reg8681, reg8682)
-							reg8684 := __e.Call(__defun__shen_4pair, reg8679, reg8683)
+							reg8680 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input1_6)
+							reg8681 := Call(__e, __defun__macroexpand, reg8680)
+							reg8682 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input2_6)
+							reg8683 := Call(__e, __defun__shen_4package_1macro, reg8681, reg8682)
+							reg8684 := Call(__e, __defun__shen_4pair, reg8679, reg8683)
 							reg8686 = reg8684
 						} else {
-							reg8685 := __e.Call(__defun__fail)
+							reg8685 := Call(__e, __defun__fail)
 							reg8686 = reg8685
 						}
 						reg8688 = reg8686
 					} else {
-						reg8687 := __e.Call(__defun__fail)
+						reg8687 := Call(__e, __defun__fail)
 						reg8688 = reg8687
 					}
 					reg8690 = reg8688
 				} else {
-					reg8689 := __e.Call(__defun__fail)
+					reg8689 := Call(__e, __defun__fail)
 					reg8690 = reg8689
 				}
 				reg8692 = reg8690
 			} else {
-				reg8691 := __e.Call(__defun__fail)
+				reg8691 := Call(__e, __defun__fail)
 				reg8692 = reg8691
 			}
 			YaccParse := reg8692
 			_ = YaccParse
-			reg8693 := __e.Call(__defun__fail)
+			reg8693 := Call(__e, __defun__fail)
 			reg8694 := PrimEqual(YaccParse, reg8693)
 			if reg8694 == True {
-				reg8695 := __e.Call(__defun__shen_4_5lcurly_6, V1485)
+				reg8695 := Call(__e, __defun__shen_4_5lcurly_6, V1485)
 				Parse__shen_4_5lcurly_6 := reg8695
 				_ = Parse__shen_4_5lcurly_6
-				reg8696 := __e.Call(__defun__fail)
+				reg8696 := Call(__e, __defun__fail)
 				reg8697 := PrimEqual(reg8696, Parse__shen_4_5lcurly_6)
 				reg8698 := PrimNot(reg8697)
 				var reg8711 Obj
 				if reg8698 == True {
-					reg8699 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5lcurly_6)
+					reg8699 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5lcurly_6)
 					Parse__shen_4_5st__input_6 := reg8699
 					_ = Parse__shen_4_5st__input_6
-					reg8700 := __e.Call(__defun__fail)
+					reg8700 := Call(__e, __defun__fail)
 					reg8701 := PrimEqual(reg8700, Parse__shen_4_5st__input_6)
 					reg8702 := PrimNot(reg8701)
 					var reg8709 Obj
 					if reg8702 == True {
 						reg8703 := PrimHead(Parse__shen_4_5st__input_6)
 						reg8704 := MakeSymbol("{")
-						reg8705 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+						reg8705 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
 						reg8706 := PrimCons(reg8704, reg8705)
-						reg8707 := __e.Call(__defun__shen_4pair, reg8703, reg8706)
+						reg8707 := Call(__e, __defun__shen_4pair, reg8703, reg8706)
 						reg8709 = reg8707
 					} else {
-						reg8708 := __e.Call(__defun__fail)
+						reg8708 := Call(__e, __defun__fail)
 						reg8709 = reg8708
 					}
 					reg8711 = reg8709
 				} else {
-					reg8710 := __e.Call(__defun__fail)
+					reg8710 := Call(__e, __defun__fail)
 					reg8711 = reg8710
 				}
 				YaccParse := reg8711
 				_ = YaccParse
-				reg8712 := __e.Call(__defun__fail)
+				reg8712 := Call(__e, __defun__fail)
 				reg8713 := PrimEqual(YaccParse, reg8712)
 				if reg8713 == True {
-					reg8714 := __e.Call(__defun__shen_4_5rcurly_6, V1485)
+					reg8714 := Call(__e, __defun__shen_4_5rcurly_6, V1485)
 					Parse__shen_4_5rcurly_6 := reg8714
 					_ = Parse__shen_4_5rcurly_6
-					reg8715 := __e.Call(__defun__fail)
+					reg8715 := Call(__e, __defun__fail)
 					reg8716 := PrimEqual(reg8715, Parse__shen_4_5rcurly_6)
 					reg8717 := PrimNot(reg8716)
 					var reg8730 Obj
 					if reg8717 == True {
-						reg8718 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5rcurly_6)
+						reg8718 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5rcurly_6)
 						Parse__shen_4_5st__input_6 := reg8718
 						_ = Parse__shen_4_5st__input_6
-						reg8719 := __e.Call(__defun__fail)
+						reg8719 := Call(__e, __defun__fail)
 						reg8720 := PrimEqual(reg8719, Parse__shen_4_5st__input_6)
 						reg8721 := PrimNot(reg8720)
 						var reg8728 Obj
 						if reg8721 == True {
 							reg8722 := PrimHead(Parse__shen_4_5st__input_6)
 							reg8723 := MakeSymbol("}")
-							reg8724 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+							reg8724 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
 							reg8725 := PrimCons(reg8723, reg8724)
-							reg8726 := __e.Call(__defun__shen_4pair, reg8722, reg8725)
+							reg8726 := Call(__e, __defun__shen_4pair, reg8722, reg8725)
 							reg8728 = reg8726
 						} else {
-							reg8727 := __e.Call(__defun__fail)
+							reg8727 := Call(__e, __defun__fail)
 							reg8728 = reg8727
 						}
 						reg8730 = reg8728
 					} else {
-						reg8729 := __e.Call(__defun__fail)
+						reg8729 := Call(__e, __defun__fail)
 						reg8730 = reg8729
 					}
 					YaccParse := reg8730
 					_ = YaccParse
-					reg8731 := __e.Call(__defun__fail)
+					reg8731 := Call(__e, __defun__fail)
 					reg8732 := PrimEqual(YaccParse, reg8731)
 					if reg8732 == True {
-						reg8733 := __e.Call(__defun__shen_4_5bar_6, V1485)
+						reg8733 := Call(__e, __defun__shen_4_5bar_6, V1485)
 						Parse__shen_4_5bar_6 := reg8733
 						_ = Parse__shen_4_5bar_6
-						reg8734 := __e.Call(__defun__fail)
+						reg8734 := Call(__e, __defun__fail)
 						reg8735 := PrimEqual(reg8734, Parse__shen_4_5bar_6)
 						reg8736 := PrimNot(reg8735)
 						var reg8749 Obj
 						if reg8736 == True {
-							reg8737 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5bar_6)
+							reg8737 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5bar_6)
 							Parse__shen_4_5st__input_6 := reg8737
 							_ = Parse__shen_4_5st__input_6
-							reg8738 := __e.Call(__defun__fail)
+							reg8738 := Call(__e, __defun__fail)
 							reg8739 := PrimEqual(reg8738, Parse__shen_4_5st__input_6)
 							reg8740 := PrimNot(reg8739)
 							var reg8747 Obj
 							if reg8740 == True {
 								reg8741 := PrimHead(Parse__shen_4_5st__input_6)
 								reg8742 := MakeSymbol("bar!")
-								reg8743 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+								reg8743 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
 								reg8744 := PrimCons(reg8742, reg8743)
-								reg8745 := __e.Call(__defun__shen_4pair, reg8741, reg8744)
+								reg8745 := Call(__e, __defun__shen_4pair, reg8741, reg8744)
 								reg8747 = reg8745
 							} else {
-								reg8746 := __e.Call(__defun__fail)
+								reg8746 := Call(__e, __defun__fail)
 								reg8747 = reg8746
 							}
 							reg8749 = reg8747
 						} else {
-							reg8748 := __e.Call(__defun__fail)
+							reg8748 := Call(__e, __defun__fail)
 							reg8749 = reg8748
 						}
 						YaccParse := reg8749
 						_ = YaccParse
-						reg8750 := __e.Call(__defun__fail)
+						reg8750 := Call(__e, __defun__fail)
 						reg8751 := PrimEqual(YaccParse, reg8750)
 						if reg8751 == True {
-							reg8752 := __e.Call(__defun__shen_4_5semicolon_6, V1485)
+							reg8752 := Call(__e, __defun__shen_4_5semicolon_6, V1485)
 							Parse__shen_4_5semicolon_6 := reg8752
 							_ = Parse__shen_4_5semicolon_6
-							reg8753 := __e.Call(__defun__fail)
+							reg8753 := Call(__e, __defun__fail)
 							reg8754 := PrimEqual(reg8753, Parse__shen_4_5semicolon_6)
 							reg8755 := PrimNot(reg8754)
 							var reg8768 Obj
 							if reg8755 == True {
-								reg8756 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5semicolon_6)
+								reg8756 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5semicolon_6)
 								Parse__shen_4_5st__input_6 := reg8756
 								_ = Parse__shen_4_5st__input_6
-								reg8757 := __e.Call(__defun__fail)
+								reg8757 := Call(__e, __defun__fail)
 								reg8758 := PrimEqual(reg8757, Parse__shen_4_5st__input_6)
 								reg8759 := PrimNot(reg8758)
 								var reg8766 Obj
 								if reg8759 == True {
 									reg8760 := PrimHead(Parse__shen_4_5st__input_6)
 									reg8761 := MakeSymbol(";")
-									reg8762 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+									reg8762 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
 									reg8763 := PrimCons(reg8761, reg8762)
-									reg8764 := __e.Call(__defun__shen_4pair, reg8760, reg8763)
+									reg8764 := Call(__e, __defun__shen_4pair, reg8760, reg8763)
 									reg8766 = reg8764
 								} else {
-									reg8765 := __e.Call(__defun__fail)
+									reg8765 := Call(__e, __defun__fail)
 									reg8766 = reg8765
 								}
 								reg8768 = reg8766
 							} else {
-								reg8767 := __e.Call(__defun__fail)
+								reg8767 := Call(__e, __defun__fail)
 								reg8768 = reg8767
 							}
 							YaccParse := reg8768
 							_ = YaccParse
-							reg8769 := __e.Call(__defun__fail)
+							reg8769 := Call(__e, __defun__fail)
 							reg8770 := PrimEqual(YaccParse, reg8769)
 							if reg8770 == True {
-								reg8771 := __e.Call(__defun__shen_4_5colon_6, V1485)
+								reg8771 := Call(__e, __defun__shen_4_5colon_6, V1485)
 								Parse__shen_4_5colon_6 := reg8771
 								_ = Parse__shen_4_5colon_6
-								reg8772 := __e.Call(__defun__fail)
+								reg8772 := Call(__e, __defun__fail)
 								reg8773 := PrimEqual(reg8772, Parse__shen_4_5colon_6)
 								reg8774 := PrimNot(reg8773)
 								var reg8793 Obj
 								if reg8774 == True {
-									reg8775 := __e.Call(__defun__shen_4_5equal_6, Parse__shen_4_5colon_6)
+									reg8775 := Call(__e, __defun__shen_4_5equal_6, Parse__shen_4_5colon_6)
 									Parse__shen_4_5equal_6 := reg8775
 									_ = Parse__shen_4_5equal_6
-									reg8776 := __e.Call(__defun__fail)
+									reg8776 := Call(__e, __defun__fail)
 									reg8777 := PrimEqual(reg8776, Parse__shen_4_5equal_6)
 									reg8778 := PrimNot(reg8777)
 									var reg8791 Obj
 									if reg8778 == True {
-										reg8779 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5equal_6)
+										reg8779 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5equal_6)
 										Parse__shen_4_5st__input_6 := reg8779
 										_ = Parse__shen_4_5st__input_6
-										reg8780 := __e.Call(__defun__fail)
+										reg8780 := Call(__e, __defun__fail)
 										reg8781 := PrimEqual(reg8780, Parse__shen_4_5st__input_6)
 										reg8782 := PrimNot(reg8781)
 										var reg8789 Obj
 										if reg8782 == True {
 											reg8783 := PrimHead(Parse__shen_4_5st__input_6)
 											reg8784 := MakeSymbol(":=")
-											reg8785 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+											reg8785 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
 											reg8786 := PrimCons(reg8784, reg8785)
-											reg8787 := __e.Call(__defun__shen_4pair, reg8783, reg8786)
+											reg8787 := Call(__e, __defun__shen_4pair, reg8783, reg8786)
 											reg8789 = reg8787
 										} else {
-											reg8788 := __e.Call(__defun__fail)
+											reg8788 := Call(__e, __defun__fail)
 											reg8789 = reg8788
 										}
 										reg8791 = reg8789
 									} else {
-										reg8790 := __e.Call(__defun__fail)
+										reg8790 := Call(__e, __defun__fail)
 										reg8791 = reg8790
 									}
 									reg8793 = reg8791
 								} else {
-									reg8792 := __e.Call(__defun__fail)
+									reg8792 := Call(__e, __defun__fail)
 									reg8793 = reg8792
 								}
 								YaccParse := reg8793
 								_ = YaccParse
-								reg8794 := __e.Call(__defun__fail)
+								reg8794 := Call(__e, __defun__fail)
 								reg8795 := PrimEqual(YaccParse, reg8794)
 								if reg8795 == True {
-									reg8796 := __e.Call(__defun__shen_4_5colon_6, V1485)
+									reg8796 := Call(__e, __defun__shen_4_5colon_6, V1485)
 									Parse__shen_4_5colon_6 := reg8796
 									_ = Parse__shen_4_5colon_6
-									reg8797 := __e.Call(__defun__fail)
+									reg8797 := Call(__e, __defun__fail)
 									reg8798 := PrimEqual(reg8797, Parse__shen_4_5colon_6)
 									reg8799 := PrimNot(reg8798)
 									var reg8818 Obj
 									if reg8799 == True {
-										reg8800 := __e.Call(__defun__shen_4_5minus_6, Parse__shen_4_5colon_6)
+										reg8800 := Call(__e, __defun__shen_4_5minus_6, Parse__shen_4_5colon_6)
 										Parse__shen_4_5minus_6 := reg8800
 										_ = Parse__shen_4_5minus_6
-										reg8801 := __e.Call(__defun__fail)
+										reg8801 := Call(__e, __defun__fail)
 										reg8802 := PrimEqual(reg8801, Parse__shen_4_5minus_6)
 										reg8803 := PrimNot(reg8802)
 										var reg8816 Obj
 										if reg8803 == True {
-											reg8804 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5minus_6)
+											reg8804 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5minus_6)
 											Parse__shen_4_5st__input_6 := reg8804
 											_ = Parse__shen_4_5st__input_6
-											reg8805 := __e.Call(__defun__fail)
+											reg8805 := Call(__e, __defun__fail)
 											reg8806 := PrimEqual(reg8805, Parse__shen_4_5st__input_6)
 											reg8807 := PrimNot(reg8806)
 											var reg8814 Obj
 											if reg8807 == True {
 												reg8808 := PrimHead(Parse__shen_4_5st__input_6)
 												reg8809 := MakeSymbol(":-")
-												reg8810 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+												reg8810 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
 												reg8811 := PrimCons(reg8809, reg8810)
-												reg8812 := __e.Call(__defun__shen_4pair, reg8808, reg8811)
+												reg8812 := Call(__e, __defun__shen_4pair, reg8808, reg8811)
 												reg8814 = reg8812
 											} else {
-												reg8813 := __e.Call(__defun__fail)
+												reg8813 := Call(__e, __defun__fail)
 												reg8814 = reg8813
 											}
 											reg8816 = reg8814
 										} else {
-											reg8815 := __e.Call(__defun__fail)
+											reg8815 := Call(__e, __defun__fail)
 											reg8816 = reg8815
 										}
 										reg8818 = reg8816
 									} else {
-										reg8817 := __e.Call(__defun__fail)
+										reg8817 := Call(__e, __defun__fail)
 										reg8818 = reg8817
 									}
 									YaccParse := reg8818
 									_ = YaccParse
-									reg8819 := __e.Call(__defun__fail)
+									reg8819 := Call(__e, __defun__fail)
 									reg8820 := PrimEqual(YaccParse, reg8819)
 									if reg8820 == True {
-										reg8821 := __e.Call(__defun__shen_4_5colon_6, V1485)
+										reg8821 := Call(__e, __defun__shen_4_5colon_6, V1485)
 										Parse__shen_4_5colon_6 := reg8821
 										_ = Parse__shen_4_5colon_6
-										reg8822 := __e.Call(__defun__fail)
+										reg8822 := Call(__e, __defun__fail)
 										reg8823 := PrimEqual(reg8822, Parse__shen_4_5colon_6)
 										reg8824 := PrimNot(reg8823)
 										var reg8837 Obj
 										if reg8824 == True {
-											reg8825 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5colon_6)
+											reg8825 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5colon_6)
 											Parse__shen_4_5st__input_6 := reg8825
 											_ = Parse__shen_4_5st__input_6
-											reg8826 := __e.Call(__defun__fail)
+											reg8826 := Call(__e, __defun__fail)
 											reg8827 := PrimEqual(reg8826, Parse__shen_4_5st__input_6)
 											reg8828 := PrimNot(reg8827)
 											var reg8835 Obj
 											if reg8828 == True {
 												reg8829 := PrimHead(Parse__shen_4_5st__input_6)
 												reg8830 := MakeSymbol(":")
-												reg8831 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+												reg8831 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
 												reg8832 := PrimCons(reg8830, reg8831)
-												reg8833 := __e.Call(__defun__shen_4pair, reg8829, reg8832)
+												reg8833 := Call(__e, __defun__shen_4pair, reg8829, reg8832)
 												reg8835 = reg8833
 											} else {
-												reg8834 := __e.Call(__defun__fail)
+												reg8834 := Call(__e, __defun__fail)
 												reg8835 = reg8834
 											}
 											reg8837 = reg8835
 										} else {
-											reg8836 := __e.Call(__defun__fail)
+											reg8836 := Call(__e, __defun__fail)
 											reg8837 = reg8836
 										}
 										YaccParse := reg8837
 										_ = YaccParse
-										reg8838 := __e.Call(__defun__fail)
+										reg8838 := Call(__e, __defun__fail)
 										reg8839 := PrimEqual(YaccParse, reg8838)
 										if reg8839 == True {
-											reg8840 := __e.Call(__defun__shen_4_5comma_6, V1485)
+											reg8840 := Call(__e, __defun__shen_4_5comma_6, V1485)
 											Parse__shen_4_5comma_6 := reg8840
 											_ = Parse__shen_4_5comma_6
-											reg8841 := __e.Call(__defun__fail)
+											reg8841 := Call(__e, __defun__fail)
 											reg8842 := PrimEqual(reg8841, Parse__shen_4_5comma_6)
 											reg8843 := PrimNot(reg8842)
 											var reg8857 Obj
 											if reg8843 == True {
-												reg8844 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5comma_6)
+												reg8844 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5comma_6)
 												Parse__shen_4_5st__input_6 := reg8844
 												_ = Parse__shen_4_5st__input_6
-												reg8845 := __e.Call(__defun__fail)
+												reg8845 := Call(__e, __defun__fail)
 												reg8846 := PrimEqual(reg8845, Parse__shen_4_5st__input_6)
 												reg8847 := PrimNot(reg8846)
 												var reg8855 Obj
@@ -1270,200 +1270,200 @@ func init() {
 													reg8848 := PrimHead(Parse__shen_4_5st__input_6)
 													reg8849 := MakeString(",")
 													reg8850 := PrimIntern(reg8849)
-													reg8851 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+													reg8851 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
 													reg8852 := PrimCons(reg8850, reg8851)
-													reg8853 := __e.Call(__defun__shen_4pair, reg8848, reg8852)
+													reg8853 := Call(__e, __defun__shen_4pair, reg8848, reg8852)
 													reg8855 = reg8853
 												} else {
-													reg8854 := __e.Call(__defun__fail)
+													reg8854 := Call(__e, __defun__fail)
 													reg8855 = reg8854
 												}
 												reg8857 = reg8855
 											} else {
-												reg8856 := __e.Call(__defun__fail)
+												reg8856 := Call(__e, __defun__fail)
 												reg8857 = reg8856
 											}
 											YaccParse := reg8857
 											_ = YaccParse
-											reg8858 := __e.Call(__defun__fail)
+											reg8858 := Call(__e, __defun__fail)
 											reg8859 := PrimEqual(YaccParse, reg8858)
 											if reg8859 == True {
-												reg8860 := __e.Call(__defun__shen_4_5comment_6, V1485)
+												reg8860 := Call(__e, __defun__shen_4_5comment_6, V1485)
 												Parse__shen_4_5comment_6 := reg8860
 												_ = Parse__shen_4_5comment_6
-												reg8861 := __e.Call(__defun__fail)
+												reg8861 := Call(__e, __defun__fail)
 												reg8862 := PrimEqual(reg8861, Parse__shen_4_5comment_6)
 												reg8863 := PrimNot(reg8862)
 												var reg8874 Obj
 												if reg8863 == True {
-													reg8864 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5comment_6)
+													reg8864 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5comment_6)
 													Parse__shen_4_5st__input_6 := reg8864
 													_ = Parse__shen_4_5st__input_6
-													reg8865 := __e.Call(__defun__fail)
+													reg8865 := Call(__e, __defun__fail)
 													reg8866 := PrimEqual(reg8865, Parse__shen_4_5st__input_6)
 													reg8867 := PrimNot(reg8866)
 													var reg8872 Obj
 													if reg8867 == True {
 														reg8868 := PrimHead(Parse__shen_4_5st__input_6)
-														reg8869 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
-														reg8870 := __e.Call(__defun__shen_4pair, reg8868, reg8869)
+														reg8869 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+														reg8870 := Call(__e, __defun__shen_4pair, reg8868, reg8869)
 														reg8872 = reg8870
 													} else {
-														reg8871 := __e.Call(__defun__fail)
+														reg8871 := Call(__e, __defun__fail)
 														reg8872 = reg8871
 													}
 													reg8874 = reg8872
 												} else {
-													reg8873 := __e.Call(__defun__fail)
+													reg8873 := Call(__e, __defun__fail)
 													reg8874 = reg8873
 												}
 												YaccParse := reg8874
 												_ = YaccParse
-												reg8875 := __e.Call(__defun__fail)
+												reg8875 := Call(__e, __defun__fail)
 												reg8876 := PrimEqual(YaccParse, reg8875)
 												if reg8876 == True {
-													reg8877 := __e.Call(__defun__shen_4_5atom_6, V1485)
+													reg8877 := Call(__e, __defun__shen_4_5atom_6, V1485)
 													Parse__shen_4_5atom_6 := reg8877
 													_ = Parse__shen_4_5atom_6
-													reg8878 := __e.Call(__defun__fail)
+													reg8878 := Call(__e, __defun__fail)
 													reg8879 := PrimEqual(reg8878, Parse__shen_4_5atom_6)
 													reg8880 := PrimNot(reg8879)
 													var reg8894 Obj
 													if reg8880 == True {
-														reg8881 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5atom_6)
+														reg8881 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5atom_6)
 														Parse__shen_4_5st__input_6 := reg8881
 														_ = Parse__shen_4_5st__input_6
-														reg8882 := __e.Call(__defun__fail)
+														reg8882 := Call(__e, __defun__fail)
 														reg8883 := PrimEqual(reg8882, Parse__shen_4_5st__input_6)
 														reg8884 := PrimNot(reg8883)
 														var reg8892 Obj
 														if reg8884 == True {
 															reg8885 := PrimHead(Parse__shen_4_5st__input_6)
-															reg8886 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5atom_6)
-															reg8887 := __e.Call(__defun__macroexpand, reg8886)
-															reg8888 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+															reg8886 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5atom_6)
+															reg8887 := Call(__e, __defun__macroexpand, reg8886)
+															reg8888 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
 															reg8889 := PrimCons(reg8887, reg8888)
-															reg8890 := __e.Call(__defun__shen_4pair, reg8885, reg8889)
+															reg8890 := Call(__e, __defun__shen_4pair, reg8885, reg8889)
 															reg8892 = reg8890
 														} else {
-															reg8891 := __e.Call(__defun__fail)
+															reg8891 := Call(__e, __defun__fail)
 															reg8892 = reg8891
 														}
 														reg8894 = reg8892
 													} else {
-														reg8893 := __e.Call(__defun__fail)
+														reg8893 := Call(__e, __defun__fail)
 														reg8894 = reg8893
 													}
 													YaccParse := reg8894
 													_ = YaccParse
-													reg8895 := __e.Call(__defun__fail)
+													reg8895 := Call(__e, __defun__fail)
 													reg8896 := PrimEqual(YaccParse, reg8895)
 													if reg8896 == True {
-														reg8897 := __e.Call(__defun__shen_4_5whitespaces_6, V1485)
+														reg8897 := Call(__e, __defun__shen_4_5whitespaces_6, V1485)
 														Parse__shen_4_5whitespaces_6 := reg8897
 														_ = Parse__shen_4_5whitespaces_6
-														reg8898 := __e.Call(__defun__fail)
+														reg8898 := Call(__e, __defun__fail)
 														reg8899 := PrimEqual(reg8898, Parse__shen_4_5whitespaces_6)
 														reg8900 := PrimNot(reg8899)
 														var reg8911 Obj
 														if reg8900 == True {
-															reg8901 := __e.Call(__defun__shen_4_5st__input_6, Parse__shen_4_5whitespaces_6)
+															reg8901 := Call(__e, __defun__shen_4_5st__input_6, Parse__shen_4_5whitespaces_6)
 															Parse__shen_4_5st__input_6 := reg8901
 															_ = Parse__shen_4_5st__input_6
-															reg8902 := __e.Call(__defun__fail)
+															reg8902 := Call(__e, __defun__fail)
 															reg8903 := PrimEqual(reg8902, Parse__shen_4_5st__input_6)
 															reg8904 := PrimNot(reg8903)
 															var reg8909 Obj
 															if reg8904 == True {
 																reg8905 := PrimHead(Parse__shen_4_5st__input_6)
-																reg8906 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
-																reg8907 := __e.Call(__defun__shen_4pair, reg8905, reg8906)
+																reg8906 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+																reg8907 := Call(__e, __defun__shen_4pair, reg8905, reg8906)
 																reg8909 = reg8907
 															} else {
-																reg8908 := __e.Call(__defun__fail)
+																reg8908 := Call(__e, __defun__fail)
 																reg8909 = reg8908
 															}
 															reg8911 = reg8909
 														} else {
-															reg8910 := __e.Call(__defun__fail)
+															reg8910 := Call(__e, __defun__fail)
 															reg8911 = reg8910
 														}
 														YaccParse := reg8911
 														_ = YaccParse
-														reg8912 := __e.Call(__defun__fail)
+														reg8912 := Call(__e, __defun__fail)
 														reg8913 := PrimEqual(YaccParse, reg8912)
 														if reg8913 == True {
-															reg8914 := __e.Call(__defun___5e_6, V1485)
+															reg8914 := Call(__e, __defun___5e_6, V1485)
 															Parse___5e_6 := reg8914
 															_ = Parse___5e_6
-															reg8915 := __e.Call(__defun__fail)
+															reg8915 := Call(__e, __defun__fail)
 															reg8916 := PrimEqual(reg8915, Parse___5e_6)
 															reg8917 := PrimNot(reg8916)
 															if reg8917 == True {
 																reg8918 := PrimHead(Parse___5e_6)
 																reg8919 := Nil
-																__ctx.TailApply(__defun__shen_4pair, reg8918, reg8919)
+																__e.TailApply(__defun__shen_4pair, reg8918, reg8919)
 																return
 															} else {
-																__ctx.TailApply(__defun__fail)
+																__e.TailApply(__defun__fail)
 																return
 															}
 														} else {
-															__ctx.Return(YaccParse)
+															__e.Return(YaccParse)
 															return
 														}
 													} else {
-														__ctx.Return(YaccParse)
+														__e.Return(YaccParse)
 														return
 													}
 												} else {
-													__ctx.Return(YaccParse)
+													__e.Return(YaccParse)
 													return
 												}
 											} else {
-												__ctx.Return(YaccParse)
+												__e.Return(YaccParse)
 												return
 											}
 										} else {
-											__ctx.Return(YaccParse)
+											__e.Return(YaccParse)
 											return
 										}
 									} else {
-										__ctx.Return(YaccParse)
+										__e.Return(YaccParse)
 										return
 									}
 								} else {
-									__ctx.Return(YaccParse)
+									__e.Return(YaccParse)
 									return
 								}
 							} else {
-								__ctx.Return(YaccParse)
+								__e.Return(YaccParse)
 								return
 							}
 						} else {
-							__ctx.Return(YaccParse)
+							__e.Return(YaccParse)
 							return
 						}
 					} else {
-						__ctx.Return(YaccParse)
+						__e.Return(YaccParse)
 						return
 					}
 				} else {
-					__ctx.Return(YaccParse)
+					__e.Return(YaccParse)
 					return
 				}
 			} else {
-				__ctx.Return(YaccParse)
+				__e.Return(YaccParse)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<st_input>", value: __defun__shen_4_5st__input_6})
 
-	__defun__shen_4_5lsb_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5lsb_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1488 := __args[0]
 		_ = V1488
 		reg8922 := PrimHead(V1488)
@@ -1471,7 +1471,7 @@ func init() {
 		var reg8931 Obj
 		if reg8923 == True {
 			reg8924 := MakeNumber(91)
-			reg8925 := __e.Call(__defun__shen_4hdhd, V1488)
+			reg8925 := Call(__e, __defun__shen_4hdhd, V1488)
 			reg8926 := PrimEqual(reg8924, reg8925)
 			var reg8929 Obj
 			if reg8926 == True {
@@ -1487,23 +1487,23 @@ func init() {
 			reg8931 = reg8930
 		}
 		if reg8931 == True {
-			reg8932 := __e.Call(__defun__shen_4tlhd, V1488)
-			reg8933 := __e.Call(__defun__shen_4hdtl, V1488)
-			reg8934 := __e.Call(__defun__shen_4pair, reg8932, reg8933)
+			reg8932 := Call(__e, __defun__shen_4tlhd, V1488)
+			reg8933 := Call(__e, __defun__shen_4hdtl, V1488)
+			reg8934 := Call(__e, __defun__shen_4pair, reg8932, reg8933)
 			NewStream1486 := reg8934
 			_ = NewStream1486
 			reg8935 := PrimHead(NewStream1486)
 			reg8936 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg8935, reg8936)
+			__e.TailApply(__defun__shen_4pair, reg8935, reg8936)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<lsb>", value: __defun__shen_4_5lsb_6})
 
-	__defun__shen_4_5rsb_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5rsb_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1491 := __args[0]
 		_ = V1491
 		reg8939 := PrimHead(V1491)
@@ -1511,7 +1511,7 @@ func init() {
 		var reg8948 Obj
 		if reg8940 == True {
 			reg8941 := MakeNumber(93)
-			reg8942 := __e.Call(__defun__shen_4hdhd, V1491)
+			reg8942 := Call(__e, __defun__shen_4hdhd, V1491)
 			reg8943 := PrimEqual(reg8941, reg8942)
 			var reg8946 Obj
 			if reg8943 == True {
@@ -1527,23 +1527,23 @@ func init() {
 			reg8948 = reg8947
 		}
 		if reg8948 == True {
-			reg8949 := __e.Call(__defun__shen_4tlhd, V1491)
-			reg8950 := __e.Call(__defun__shen_4hdtl, V1491)
-			reg8951 := __e.Call(__defun__shen_4pair, reg8949, reg8950)
+			reg8949 := Call(__e, __defun__shen_4tlhd, V1491)
+			reg8950 := Call(__e, __defun__shen_4hdtl, V1491)
+			reg8951 := Call(__e, __defun__shen_4pair, reg8949, reg8950)
 			NewStream1489 := reg8951
 			_ = NewStream1489
 			reg8952 := PrimHead(NewStream1489)
 			reg8953 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg8952, reg8953)
+			__e.TailApply(__defun__shen_4pair, reg8952, reg8953)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<rsb>", value: __defun__shen_4_5rsb_6})
 
-	__defun__shen_4_5lcurly_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5lcurly_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1494 := __args[0]
 		_ = V1494
 		reg8956 := PrimHead(V1494)
@@ -1551,7 +1551,7 @@ func init() {
 		var reg8965 Obj
 		if reg8957 == True {
 			reg8958 := MakeNumber(123)
-			reg8959 := __e.Call(__defun__shen_4hdhd, V1494)
+			reg8959 := Call(__e, __defun__shen_4hdhd, V1494)
 			reg8960 := PrimEqual(reg8958, reg8959)
 			var reg8963 Obj
 			if reg8960 == True {
@@ -1567,23 +1567,23 @@ func init() {
 			reg8965 = reg8964
 		}
 		if reg8965 == True {
-			reg8966 := __e.Call(__defun__shen_4tlhd, V1494)
-			reg8967 := __e.Call(__defun__shen_4hdtl, V1494)
-			reg8968 := __e.Call(__defun__shen_4pair, reg8966, reg8967)
+			reg8966 := Call(__e, __defun__shen_4tlhd, V1494)
+			reg8967 := Call(__e, __defun__shen_4hdtl, V1494)
+			reg8968 := Call(__e, __defun__shen_4pair, reg8966, reg8967)
 			NewStream1492 := reg8968
 			_ = NewStream1492
 			reg8969 := PrimHead(NewStream1492)
 			reg8970 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg8969, reg8970)
+			__e.TailApply(__defun__shen_4pair, reg8969, reg8970)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<lcurly>", value: __defun__shen_4_5lcurly_6})
 
-	__defun__shen_4_5rcurly_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5rcurly_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1497 := __args[0]
 		_ = V1497
 		reg8973 := PrimHead(V1497)
@@ -1591,7 +1591,7 @@ func init() {
 		var reg8982 Obj
 		if reg8974 == True {
 			reg8975 := MakeNumber(125)
-			reg8976 := __e.Call(__defun__shen_4hdhd, V1497)
+			reg8976 := Call(__e, __defun__shen_4hdhd, V1497)
 			reg8977 := PrimEqual(reg8975, reg8976)
 			var reg8980 Obj
 			if reg8977 == True {
@@ -1607,23 +1607,23 @@ func init() {
 			reg8982 = reg8981
 		}
 		if reg8982 == True {
-			reg8983 := __e.Call(__defun__shen_4tlhd, V1497)
-			reg8984 := __e.Call(__defun__shen_4hdtl, V1497)
-			reg8985 := __e.Call(__defun__shen_4pair, reg8983, reg8984)
+			reg8983 := Call(__e, __defun__shen_4tlhd, V1497)
+			reg8984 := Call(__e, __defun__shen_4hdtl, V1497)
+			reg8985 := Call(__e, __defun__shen_4pair, reg8983, reg8984)
 			NewStream1495 := reg8985
 			_ = NewStream1495
 			reg8986 := PrimHead(NewStream1495)
 			reg8987 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg8986, reg8987)
+			__e.TailApply(__defun__shen_4pair, reg8986, reg8987)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<rcurly>", value: __defun__shen_4_5rcurly_6})
 
-	__defun__shen_4_5bar_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5bar_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1500 := __args[0]
 		_ = V1500
 		reg8990 := PrimHead(V1500)
@@ -1631,7 +1631,7 @@ func init() {
 		var reg8999 Obj
 		if reg8991 == True {
 			reg8992 := MakeNumber(124)
-			reg8993 := __e.Call(__defun__shen_4hdhd, V1500)
+			reg8993 := Call(__e, __defun__shen_4hdhd, V1500)
 			reg8994 := PrimEqual(reg8992, reg8993)
 			var reg8997 Obj
 			if reg8994 == True {
@@ -1647,23 +1647,23 @@ func init() {
 			reg8999 = reg8998
 		}
 		if reg8999 == True {
-			reg9000 := __e.Call(__defun__shen_4tlhd, V1500)
-			reg9001 := __e.Call(__defun__shen_4hdtl, V1500)
-			reg9002 := __e.Call(__defun__shen_4pair, reg9000, reg9001)
+			reg9000 := Call(__e, __defun__shen_4tlhd, V1500)
+			reg9001 := Call(__e, __defun__shen_4hdtl, V1500)
+			reg9002 := Call(__e, __defun__shen_4pair, reg9000, reg9001)
 			NewStream1498 := reg9002
 			_ = NewStream1498
 			reg9003 := PrimHead(NewStream1498)
 			reg9004 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg9003, reg9004)
+			__e.TailApply(__defun__shen_4pair, reg9003, reg9004)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<bar>", value: __defun__shen_4_5bar_6})
 
-	__defun__shen_4_5semicolon_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5semicolon_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1503 := __args[0]
 		_ = V1503
 		reg9007 := PrimHead(V1503)
@@ -1671,7 +1671,7 @@ func init() {
 		var reg9016 Obj
 		if reg9008 == True {
 			reg9009 := MakeNumber(59)
-			reg9010 := __e.Call(__defun__shen_4hdhd, V1503)
+			reg9010 := Call(__e, __defun__shen_4hdhd, V1503)
 			reg9011 := PrimEqual(reg9009, reg9010)
 			var reg9014 Obj
 			if reg9011 == True {
@@ -1687,23 +1687,23 @@ func init() {
 			reg9016 = reg9015
 		}
 		if reg9016 == True {
-			reg9017 := __e.Call(__defun__shen_4tlhd, V1503)
-			reg9018 := __e.Call(__defun__shen_4hdtl, V1503)
-			reg9019 := __e.Call(__defun__shen_4pair, reg9017, reg9018)
+			reg9017 := Call(__e, __defun__shen_4tlhd, V1503)
+			reg9018 := Call(__e, __defun__shen_4hdtl, V1503)
+			reg9019 := Call(__e, __defun__shen_4pair, reg9017, reg9018)
 			NewStream1501 := reg9019
 			_ = NewStream1501
 			reg9020 := PrimHead(NewStream1501)
 			reg9021 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg9020, reg9021)
+			__e.TailApply(__defun__shen_4pair, reg9020, reg9021)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<semicolon>", value: __defun__shen_4_5semicolon_6})
 
-	__defun__shen_4_5colon_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5colon_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1506 := __args[0]
 		_ = V1506
 		reg9024 := PrimHead(V1506)
@@ -1711,7 +1711,7 @@ func init() {
 		var reg9033 Obj
 		if reg9025 == True {
 			reg9026 := MakeNumber(58)
-			reg9027 := __e.Call(__defun__shen_4hdhd, V1506)
+			reg9027 := Call(__e, __defun__shen_4hdhd, V1506)
 			reg9028 := PrimEqual(reg9026, reg9027)
 			var reg9031 Obj
 			if reg9028 == True {
@@ -1727,23 +1727,23 @@ func init() {
 			reg9033 = reg9032
 		}
 		if reg9033 == True {
-			reg9034 := __e.Call(__defun__shen_4tlhd, V1506)
-			reg9035 := __e.Call(__defun__shen_4hdtl, V1506)
-			reg9036 := __e.Call(__defun__shen_4pair, reg9034, reg9035)
+			reg9034 := Call(__e, __defun__shen_4tlhd, V1506)
+			reg9035 := Call(__e, __defun__shen_4hdtl, V1506)
+			reg9036 := Call(__e, __defun__shen_4pair, reg9034, reg9035)
 			NewStream1504 := reg9036
 			_ = NewStream1504
 			reg9037 := PrimHead(NewStream1504)
 			reg9038 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg9037, reg9038)
+			__e.TailApply(__defun__shen_4pair, reg9037, reg9038)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<colon>", value: __defun__shen_4_5colon_6})
 
-	__defun__shen_4_5comma_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5comma_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1509 := __args[0]
 		_ = V1509
 		reg9041 := PrimHead(V1509)
@@ -1751,7 +1751,7 @@ func init() {
 		var reg9050 Obj
 		if reg9042 == True {
 			reg9043 := MakeNumber(44)
-			reg9044 := __e.Call(__defun__shen_4hdhd, V1509)
+			reg9044 := Call(__e, __defun__shen_4hdhd, V1509)
 			reg9045 := PrimEqual(reg9043, reg9044)
 			var reg9048 Obj
 			if reg9045 == True {
@@ -1767,23 +1767,23 @@ func init() {
 			reg9050 = reg9049
 		}
 		if reg9050 == True {
-			reg9051 := __e.Call(__defun__shen_4tlhd, V1509)
-			reg9052 := __e.Call(__defun__shen_4hdtl, V1509)
-			reg9053 := __e.Call(__defun__shen_4pair, reg9051, reg9052)
+			reg9051 := Call(__e, __defun__shen_4tlhd, V1509)
+			reg9052 := Call(__e, __defun__shen_4hdtl, V1509)
+			reg9053 := Call(__e, __defun__shen_4pair, reg9051, reg9052)
 			NewStream1507 := reg9053
 			_ = NewStream1507
 			reg9054 := PrimHead(NewStream1507)
 			reg9055 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg9054, reg9055)
+			__e.TailApply(__defun__shen_4pair, reg9054, reg9055)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<comma>", value: __defun__shen_4_5comma_6})
 
-	__defun__shen_4_5equal_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5equal_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1512 := __args[0]
 		_ = V1512
 		reg9058 := PrimHead(V1512)
@@ -1791,7 +1791,7 @@ func init() {
 		var reg9067 Obj
 		if reg9059 == True {
 			reg9060 := MakeNumber(61)
-			reg9061 := __e.Call(__defun__shen_4hdhd, V1512)
+			reg9061 := Call(__e, __defun__shen_4hdhd, V1512)
 			reg9062 := PrimEqual(reg9060, reg9061)
 			var reg9065 Obj
 			if reg9062 == True {
@@ -1807,23 +1807,23 @@ func init() {
 			reg9067 = reg9066
 		}
 		if reg9067 == True {
-			reg9068 := __e.Call(__defun__shen_4tlhd, V1512)
-			reg9069 := __e.Call(__defun__shen_4hdtl, V1512)
-			reg9070 := __e.Call(__defun__shen_4pair, reg9068, reg9069)
+			reg9068 := Call(__e, __defun__shen_4tlhd, V1512)
+			reg9069 := Call(__e, __defun__shen_4hdtl, V1512)
+			reg9070 := Call(__e, __defun__shen_4pair, reg9068, reg9069)
 			NewStream1510 := reg9070
 			_ = NewStream1510
 			reg9071 := PrimHead(NewStream1510)
 			reg9072 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg9071, reg9072)
+			__e.TailApply(__defun__shen_4pair, reg9071, reg9072)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<equal>", value: __defun__shen_4_5equal_6})
 
-	__defun__shen_4_5minus_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5minus_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1515 := __args[0]
 		_ = V1515
 		reg9075 := PrimHead(V1515)
@@ -1831,7 +1831,7 @@ func init() {
 		var reg9084 Obj
 		if reg9076 == True {
 			reg9077 := MakeNumber(45)
-			reg9078 := __e.Call(__defun__shen_4hdhd, V1515)
+			reg9078 := Call(__e, __defun__shen_4hdhd, V1515)
 			reg9079 := PrimEqual(reg9077, reg9078)
 			var reg9082 Obj
 			if reg9079 == True {
@@ -1847,23 +1847,23 @@ func init() {
 			reg9084 = reg9083
 		}
 		if reg9084 == True {
-			reg9085 := __e.Call(__defun__shen_4tlhd, V1515)
-			reg9086 := __e.Call(__defun__shen_4hdtl, V1515)
-			reg9087 := __e.Call(__defun__shen_4pair, reg9085, reg9086)
+			reg9085 := Call(__e, __defun__shen_4tlhd, V1515)
+			reg9086 := Call(__e, __defun__shen_4hdtl, V1515)
+			reg9087 := Call(__e, __defun__shen_4pair, reg9085, reg9086)
 			NewStream1513 := reg9087
 			_ = NewStream1513
 			reg9088 := PrimHead(NewStream1513)
 			reg9089 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg9088, reg9089)
+			__e.TailApply(__defun__shen_4pair, reg9088, reg9089)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<minus>", value: __defun__shen_4_5minus_6})
 
-	__defun__shen_4_5lrb_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5lrb_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1518 := __args[0]
 		_ = V1518
 		reg9092 := PrimHead(V1518)
@@ -1871,7 +1871,7 @@ func init() {
 		var reg9101 Obj
 		if reg9093 == True {
 			reg9094 := MakeNumber(40)
-			reg9095 := __e.Call(__defun__shen_4hdhd, V1518)
+			reg9095 := Call(__e, __defun__shen_4hdhd, V1518)
 			reg9096 := PrimEqual(reg9094, reg9095)
 			var reg9099 Obj
 			if reg9096 == True {
@@ -1887,23 +1887,23 @@ func init() {
 			reg9101 = reg9100
 		}
 		if reg9101 == True {
-			reg9102 := __e.Call(__defun__shen_4tlhd, V1518)
-			reg9103 := __e.Call(__defun__shen_4hdtl, V1518)
-			reg9104 := __e.Call(__defun__shen_4pair, reg9102, reg9103)
+			reg9102 := Call(__e, __defun__shen_4tlhd, V1518)
+			reg9103 := Call(__e, __defun__shen_4hdtl, V1518)
+			reg9104 := Call(__e, __defun__shen_4pair, reg9102, reg9103)
 			NewStream1516 := reg9104
 			_ = NewStream1516
 			reg9105 := PrimHead(NewStream1516)
 			reg9106 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg9105, reg9106)
+			__e.TailApply(__defun__shen_4pair, reg9105, reg9106)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<lrb>", value: __defun__shen_4_5lrb_6})
 
-	__defun__shen_4_5rrb_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5rrb_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1521 := __args[0]
 		_ = V1521
 		reg9109 := PrimHead(V1521)
@@ -1911,7 +1911,7 @@ func init() {
 		var reg9118 Obj
 		if reg9110 == True {
 			reg9111 := MakeNumber(41)
-			reg9112 := __e.Call(__defun__shen_4hdhd, V1521)
+			reg9112 := Call(__e, __defun__shen_4hdhd, V1521)
 			reg9113 := PrimEqual(reg9111, reg9112)
 			var reg9116 Obj
 			if reg9113 == True {
@@ -1927,77 +1927,77 @@ func init() {
 			reg9118 = reg9117
 		}
 		if reg9118 == True {
-			reg9119 := __e.Call(__defun__shen_4tlhd, V1521)
-			reg9120 := __e.Call(__defun__shen_4hdtl, V1521)
-			reg9121 := __e.Call(__defun__shen_4pair, reg9119, reg9120)
+			reg9119 := Call(__e, __defun__shen_4tlhd, V1521)
+			reg9120 := Call(__e, __defun__shen_4hdtl, V1521)
+			reg9121 := Call(__e, __defun__shen_4pair, reg9119, reg9120)
 			NewStream1519 := reg9121
 			_ = NewStream1519
 			reg9122 := PrimHead(NewStream1519)
 			reg9123 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg9122, reg9123)
+			__e.TailApply(__defun__shen_4pair, reg9122, reg9123)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<rrb>", value: __defun__shen_4_5rrb_6})
 
-	__defun__shen_4_5atom_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5atom_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1523 := __args[0]
 		_ = V1523
-		reg9126 := __e.Call(__defun__shen_4_5str_6, V1523)
+		reg9126 := Call(__e, __defun__shen_4_5str_6, V1523)
 		Parse__shen_4_5str_6 := reg9126
 		_ = Parse__shen_4_5str_6
-		reg9127 := __e.Call(__defun__fail)
+		reg9127 := Call(__e, __defun__fail)
 		reg9128 := PrimEqual(reg9127, Parse__shen_4_5str_6)
 		reg9129 := PrimNot(reg9128)
 		var reg9135 Obj
 		if reg9129 == True {
 			reg9130 := PrimHead(Parse__shen_4_5str_6)
-			reg9131 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5str_6)
-			reg9132 := __e.Call(__defun__shen_4control_1chars, reg9131)
-			reg9133 := __e.Call(__defun__shen_4pair, reg9130, reg9132)
+			reg9131 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5str_6)
+			reg9132 := Call(__e, __defun__shen_4control_1chars, reg9131)
+			reg9133 := Call(__e, __defun__shen_4pair, reg9130, reg9132)
 			reg9135 = reg9133
 		} else {
-			reg9134 := __e.Call(__defun__fail)
+			reg9134 := Call(__e, __defun__fail)
 			reg9135 = reg9134
 		}
 		YaccParse := reg9135
 		_ = YaccParse
-		reg9136 := __e.Call(__defun__fail)
+		reg9136 := Call(__e, __defun__fail)
 		reg9137 := PrimEqual(YaccParse, reg9136)
 		if reg9137 == True {
-			reg9138 := __e.Call(__defun__shen_4_5number_6, V1523)
+			reg9138 := Call(__e, __defun__shen_4_5number_6, V1523)
 			Parse__shen_4_5number_6 := reg9138
 			_ = Parse__shen_4_5number_6
-			reg9139 := __e.Call(__defun__fail)
+			reg9139 := Call(__e, __defun__fail)
 			reg9140 := PrimEqual(reg9139, Parse__shen_4_5number_6)
 			reg9141 := PrimNot(reg9140)
 			var reg9146 Obj
 			if reg9141 == True {
 				reg9142 := PrimHead(Parse__shen_4_5number_6)
-				reg9143 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5number_6)
-				reg9144 := __e.Call(__defun__shen_4pair, reg9142, reg9143)
+				reg9143 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5number_6)
+				reg9144 := Call(__e, __defun__shen_4pair, reg9142, reg9143)
 				reg9146 = reg9144
 			} else {
-				reg9145 := __e.Call(__defun__fail)
+				reg9145 := Call(__e, __defun__fail)
 				reg9146 = reg9145
 			}
 			YaccParse := reg9146
 			_ = YaccParse
-			reg9147 := __e.Call(__defun__fail)
+			reg9147 := Call(__e, __defun__fail)
 			reg9148 := PrimEqual(YaccParse, reg9147)
 			if reg9148 == True {
-				reg9149 := __e.Call(__defun__shen_4_5sym_6, V1523)
+				reg9149 := Call(__e, __defun__shen_4_5sym_6, V1523)
 				Parse__shen_4_5sym_6 := reg9149
 				_ = Parse__shen_4_5sym_6
-				reg9150 := __e.Call(__defun__fail)
+				reg9150 := Call(__e, __defun__fail)
 				reg9151 := PrimEqual(reg9150, Parse__shen_4_5sym_6)
 				reg9152 := PrimNot(reg9151)
 				if reg9152 == True {
 					reg9153 := PrimHead(Parse__shen_4_5sym_6)
-					reg9154 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5sym_6)
+					reg9154 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5sym_6)
 					reg9155 := MakeString("<>")
 					reg9156 := PrimEqual(reg9154, reg9155)
 					var reg9164 Obj
@@ -2009,35 +2009,35 @@ func init() {
 						reg9161 := PrimCons(reg9157, reg9160)
 						reg9164 = reg9161
 					} else {
-						reg9162 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5sym_6)
+						reg9162 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5sym_6)
 						reg9163 := PrimIntern(reg9162)
 						reg9164 = reg9163
 					}
-					__ctx.TailApply(__defun__shen_4pair, reg9153, reg9164)
+					__e.TailApply(__defun__shen_4pair, reg9153, reg9164)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.Return(YaccParse)
+				__e.Return(YaccParse)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<atom>", value: __defun__shen_4_5atom_6})
 
-	__defun__shen_4control_1chars = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4control_1chars = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1525 := __args[0]
 		_ = V1525
 		reg9167 := Nil
 		reg9168 := PrimEqual(reg9167, V1525)
 		if reg9168 == True {
 			reg9169 := MakeString("")
-			__ctx.Return(reg9169)
+			__e.Return(reg9169)
 			return
 		} else {
 			reg9170 := PrimIsPair(V1525)
@@ -2098,30 +2098,30 @@ func init() {
 			if reg9194 == True {
 				reg9195 := PrimTail(V1525)
 				reg9196 := PrimTail(reg9195)
-				reg9197 := __e.Call(__defun__shen_4code_1point, reg9196)
+				reg9197 := Call(__e, __defun__shen_4code_1point, reg9196)
 				CodePoint := reg9197
 				_ = CodePoint
 				reg9198 := PrimTail(V1525)
 				reg9199 := PrimTail(reg9198)
-				reg9200 := __e.Call(__defun__shen_4after_1codepoint, reg9199)
+				reg9200 := Call(__e, __defun__shen_4after_1codepoint, reg9199)
 				AfterCodePoint := reg9200
 				_ = AfterCodePoint
-				reg9201 := __e.Call(__defun__shen_4decimalise, CodePoint)
+				reg9201 := Call(__e, __defun__shen_4decimalise, CodePoint)
 				reg9202 := PrimNumberToString(reg9201)
-				reg9203 := __e.Call(__defun__shen_4control_1chars, AfterCodePoint)
-				__ctx.TailApply(__defun___8s, reg9202, reg9203)
+				reg9203 := Call(__e, __defun__shen_4control_1chars, AfterCodePoint)
+				__e.TailApply(__defun___8s, reg9202, reg9203)
 				return
 			} else {
 				reg9205 := PrimIsPair(V1525)
 				if reg9205 == True {
 					reg9206 := PrimHead(V1525)
 					reg9207 := PrimTail(V1525)
-					reg9208 := __e.Call(__defun__shen_4control_1chars, reg9207)
-					__ctx.TailApply(__defun___8s, reg9206, reg9208)
+					reg9208 := Call(__e, __defun__shen_4control_1chars, reg9207)
+					__e.TailApply(__defun___8s, reg9206, reg9208)
 					return
 				} else {
 					reg9210 := MakeSymbol("shen.control-chars")
-					__ctx.TailApply(__defun__shen_4f__error, reg9210)
+					__e.TailApply(__defun__shen_4f__error, reg9210)
 					return
 				}
 			}
@@ -2129,7 +2129,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.control-chars", value: __defun__shen_4control_1chars})
 
-	__defun__shen_4code_1point = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4code_1point = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1529 := __args[0]
 		_ = V1529
 		reg9212 := PrimIsPair(V1529)
@@ -2153,7 +2153,7 @@ func init() {
 		}
 		if reg9220 == True {
 			reg9221 := MakeString("")
-			__ctx.Return(reg9221)
+			__e.Return(reg9221)
 			return
 		} else {
 			reg9222 := PrimIsPair(V1529)
@@ -2183,7 +2183,7 @@ func init() {
 				reg9244 := PrimCons(reg9226, reg9243)
 				reg9245 := PrimCons(reg9225, reg9244)
 				reg9246 := PrimCons(reg9224, reg9245)
-				reg9247 := __e.Call(__defun__element_2, reg9223, reg9246)
+				reg9247 := Call(__e, __defun__element_2, reg9223, reg9246)
 				var reg9250 Obj
 				if reg9247 == True {
 					reg9248 := True
@@ -2200,32 +2200,32 @@ func init() {
 			if reg9252 == True {
 				reg9253 := PrimHead(V1529)
 				reg9254 := PrimTail(V1529)
-				reg9255 := __e.Call(__defun__shen_4code_1point, reg9254)
+				reg9255 := Call(__e, __defun__shen_4code_1point, reg9254)
 				reg9256 := PrimCons(reg9253, reg9255)
-				__ctx.Return(reg9256)
+				__e.Return(reg9256)
 				return
 			} else {
 				reg9257 := MakeString("code point parse error ")
 				reg9258 := MakeString("\n")
 				reg9259 := MakeSymbol("shen.a")
-				reg9260 := __e.Call(__defun__shen_4app, V1529, reg9258, reg9259)
+				reg9260 := Call(__e, __defun__shen_4app, V1529, reg9258, reg9259)
 				reg9261 := PrimStringConcat(reg9257, reg9260)
 				reg9262 := PrimSimpleError(reg9261)
-				__ctx.Return(reg9262)
+				__e.Return(reg9262)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.code-point", value: __defun__shen_4code_1point})
 
-	__defun__shen_4after_1codepoint = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4after_1codepoint = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1535 := __args[0]
 		_ = V1535
 		reg9263 := Nil
 		reg9264 := PrimEqual(reg9263, V1535)
 		if reg9264 == True {
 			reg9265 := Nil
-			__ctx.Return(reg9265)
+			__e.Return(reg9265)
 			return
 		} else {
 			reg9266 := PrimIsPair(V1535)
@@ -2249,17 +2249,17 @@ func init() {
 			}
 			if reg9274 == True {
 				reg9275 := PrimTail(V1535)
-				__ctx.Return(reg9275)
+				__e.Return(reg9275)
 				return
 			} else {
 				reg9276 := PrimIsPair(V1535)
 				if reg9276 == True {
 					reg9277 := PrimTail(V1535)
-					__ctx.TailApply(__defun__shen_4after_1codepoint, reg9277)
+					__e.TailApply(__defun__shen_4after_1codepoint, reg9277)
 					return
 				} else {
 					reg9279 := MakeSymbol("shen.after-codepoint")
-					__ctx.TailApply(__defun__shen_4f__error, reg9279)
+					__e.TailApply(__defun__shen_4f__error, reg9279)
 					return
 				}
 			}
@@ -2267,18 +2267,18 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.after-codepoint", value: __defun__shen_4after_1codepoint})
 
-	__defun__shen_4decimalise = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4decimalise = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1537 := __args[0]
 		_ = V1537
-		reg9281 := __e.Call(__defun__shen_4digits_1_6integers, V1537)
-		reg9282 := __e.Call(__defun__reverse, reg9281)
+		reg9281 := Call(__e, __defun__shen_4digits_1_6integers, V1537)
+		reg9282 := Call(__e, __defun__reverse, reg9281)
 		reg9283 := MakeNumber(0)
-		__ctx.TailApply(__defun__shen_4pre, reg9282, reg9283)
+		__e.TailApply(__defun__shen_4pre, reg9282, reg9283)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.decimalise", value: __defun__shen_4decimalise})
 
-	__defun__shen_4digits_1_6integers = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4digits_1_6integers = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1543 := __args[0]
 		_ = V1543
 		reg9285 := PrimIsPair(V1543)
@@ -2303,9 +2303,9 @@ func init() {
 		if reg9293 == True {
 			reg9294 := MakeNumber(0)
 			reg9295 := PrimTail(V1543)
-			reg9296 := __e.Call(__defun__shen_4digits_1_6integers, reg9295)
+			reg9296 := Call(__e, __defun__shen_4digits_1_6integers, reg9295)
 			reg9297 := PrimCons(reg9294, reg9296)
-			__ctx.Return(reg9297)
+			__e.Return(reg9297)
 			return
 		} else {
 			reg9298 := PrimIsPair(V1543)
@@ -2330,9 +2330,9 @@ func init() {
 			if reg9306 == True {
 				reg9307 := MakeNumber(1)
 				reg9308 := PrimTail(V1543)
-				reg9309 := __e.Call(__defun__shen_4digits_1_6integers, reg9308)
+				reg9309 := Call(__e, __defun__shen_4digits_1_6integers, reg9308)
 				reg9310 := PrimCons(reg9307, reg9309)
-				__ctx.Return(reg9310)
+				__e.Return(reg9310)
 				return
 			} else {
 				reg9311 := PrimIsPair(V1543)
@@ -2357,9 +2357,9 @@ func init() {
 				if reg9319 == True {
 					reg9320 := MakeNumber(2)
 					reg9321 := PrimTail(V1543)
-					reg9322 := __e.Call(__defun__shen_4digits_1_6integers, reg9321)
+					reg9322 := Call(__e, __defun__shen_4digits_1_6integers, reg9321)
 					reg9323 := PrimCons(reg9320, reg9322)
-					__ctx.Return(reg9323)
+					__e.Return(reg9323)
 					return
 				} else {
 					reg9324 := PrimIsPair(V1543)
@@ -2384,9 +2384,9 @@ func init() {
 					if reg9332 == True {
 						reg9333 := MakeNumber(3)
 						reg9334 := PrimTail(V1543)
-						reg9335 := __e.Call(__defun__shen_4digits_1_6integers, reg9334)
+						reg9335 := Call(__e, __defun__shen_4digits_1_6integers, reg9334)
 						reg9336 := PrimCons(reg9333, reg9335)
-						__ctx.Return(reg9336)
+						__e.Return(reg9336)
 						return
 					} else {
 						reg9337 := PrimIsPair(V1543)
@@ -2411,9 +2411,9 @@ func init() {
 						if reg9345 == True {
 							reg9346 := MakeNumber(4)
 							reg9347 := PrimTail(V1543)
-							reg9348 := __e.Call(__defun__shen_4digits_1_6integers, reg9347)
+							reg9348 := Call(__e, __defun__shen_4digits_1_6integers, reg9347)
 							reg9349 := PrimCons(reg9346, reg9348)
-							__ctx.Return(reg9349)
+							__e.Return(reg9349)
 							return
 						} else {
 							reg9350 := PrimIsPair(V1543)
@@ -2438,9 +2438,9 @@ func init() {
 							if reg9358 == True {
 								reg9359 := MakeNumber(5)
 								reg9360 := PrimTail(V1543)
-								reg9361 := __e.Call(__defun__shen_4digits_1_6integers, reg9360)
+								reg9361 := Call(__e, __defun__shen_4digits_1_6integers, reg9360)
 								reg9362 := PrimCons(reg9359, reg9361)
-								__ctx.Return(reg9362)
+								__e.Return(reg9362)
 								return
 							} else {
 								reg9363 := PrimIsPair(V1543)
@@ -2465,9 +2465,9 @@ func init() {
 								if reg9371 == True {
 									reg9372 := MakeNumber(6)
 									reg9373 := PrimTail(V1543)
-									reg9374 := __e.Call(__defun__shen_4digits_1_6integers, reg9373)
+									reg9374 := Call(__e, __defun__shen_4digits_1_6integers, reg9373)
 									reg9375 := PrimCons(reg9372, reg9374)
-									__ctx.Return(reg9375)
+									__e.Return(reg9375)
 									return
 								} else {
 									reg9376 := PrimIsPair(V1543)
@@ -2492,9 +2492,9 @@ func init() {
 									if reg9384 == True {
 										reg9385 := MakeNumber(7)
 										reg9386 := PrimTail(V1543)
-										reg9387 := __e.Call(__defun__shen_4digits_1_6integers, reg9386)
+										reg9387 := Call(__e, __defun__shen_4digits_1_6integers, reg9386)
 										reg9388 := PrimCons(reg9385, reg9387)
-										__ctx.Return(reg9388)
+										__e.Return(reg9388)
 										return
 									} else {
 										reg9389 := PrimIsPair(V1543)
@@ -2519,9 +2519,9 @@ func init() {
 										if reg9397 == True {
 											reg9398 := MakeNumber(8)
 											reg9399 := PrimTail(V1543)
-											reg9400 := __e.Call(__defun__shen_4digits_1_6integers, reg9399)
+											reg9400 := Call(__e, __defun__shen_4digits_1_6integers, reg9399)
 											reg9401 := PrimCons(reg9398, reg9400)
-											__ctx.Return(reg9401)
+											__e.Return(reg9401)
 											return
 										} else {
 											reg9402 := PrimIsPair(V1543)
@@ -2546,13 +2546,13 @@ func init() {
 											if reg9410 == True {
 												reg9411 := MakeNumber(9)
 												reg9412 := PrimTail(V1543)
-												reg9413 := __e.Call(__defun__shen_4digits_1_6integers, reg9412)
+												reg9413 := Call(__e, __defun__shen_4digits_1_6integers, reg9412)
 												reg9414 := PrimCons(reg9411, reg9413)
-												__ctx.Return(reg9414)
+												__e.Return(reg9414)
 												return
 											} else {
 												reg9415 := Nil
-												__ctx.Return(reg9415)
+												__e.Return(reg9415)
 												return
 											}
 										}
@@ -2567,251 +2567,251 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.digits->integers", value: __defun__shen_4digits_1_6integers})
 
-	__defun__shen_4_5sym_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5sym_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1545 := __args[0]
 		_ = V1545
-		reg9416 := __e.Call(__defun__shen_4_5alpha_6, V1545)
+		reg9416 := Call(__e, __defun__shen_4_5alpha_6, V1545)
 		Parse__shen_4_5alpha_6 := reg9416
 		_ = Parse__shen_4_5alpha_6
-		reg9417 := __e.Call(__defun__fail)
+		reg9417 := Call(__e, __defun__fail)
 		reg9418 := PrimEqual(reg9417, Parse__shen_4_5alpha_6)
 		reg9419 := PrimNot(reg9418)
 		if reg9419 == True {
-			reg9420 := __e.Call(__defun__shen_4_5alphanums_6, Parse__shen_4_5alpha_6)
+			reg9420 := Call(__e, __defun__shen_4_5alphanums_6, Parse__shen_4_5alpha_6)
 			Parse__shen_4_5alphanums_6 := reg9420
 			_ = Parse__shen_4_5alphanums_6
-			reg9421 := __e.Call(__defun__fail)
+			reg9421 := Call(__e, __defun__fail)
 			reg9422 := PrimEqual(reg9421, Parse__shen_4_5alphanums_6)
 			reg9423 := PrimNot(reg9422)
 			if reg9423 == True {
 				reg9424 := PrimHead(Parse__shen_4_5alphanums_6)
-				reg9425 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5alpha_6)
-				reg9426 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5alphanums_6)
-				reg9427 := __e.Call(__defun___8s, reg9425, reg9426)
-				__ctx.TailApply(__defun__shen_4pair, reg9424, reg9427)
+				reg9425 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5alpha_6)
+				reg9426 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5alphanums_6)
+				reg9427 := Call(__e, __defun___8s, reg9425, reg9426)
+				__e.TailApply(__defun__shen_4pair, reg9424, reg9427)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<sym>", value: __defun__shen_4_5sym_6})
 
-	__defun__shen_4_5alphanums_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5alphanums_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1547 := __args[0]
 		_ = V1547
-		reg9431 := __e.Call(__defun__shen_4_5alphanum_6, V1547)
+		reg9431 := Call(__e, __defun__shen_4_5alphanum_6, V1547)
 		Parse__shen_4_5alphanum_6 := reg9431
 		_ = Parse__shen_4_5alphanum_6
-		reg9432 := __e.Call(__defun__fail)
+		reg9432 := Call(__e, __defun__fail)
 		reg9433 := PrimEqual(reg9432, Parse__shen_4_5alphanum_6)
 		reg9434 := PrimNot(reg9433)
 		var reg9447 Obj
 		if reg9434 == True {
-			reg9435 := __e.Call(__defun__shen_4_5alphanums_6, Parse__shen_4_5alphanum_6)
+			reg9435 := Call(__e, __defun__shen_4_5alphanums_6, Parse__shen_4_5alphanum_6)
 			Parse__shen_4_5alphanums_6 := reg9435
 			_ = Parse__shen_4_5alphanums_6
-			reg9436 := __e.Call(__defun__fail)
+			reg9436 := Call(__e, __defun__fail)
 			reg9437 := PrimEqual(reg9436, Parse__shen_4_5alphanums_6)
 			reg9438 := PrimNot(reg9437)
 			var reg9445 Obj
 			if reg9438 == True {
 				reg9439 := PrimHead(Parse__shen_4_5alphanums_6)
-				reg9440 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5alphanum_6)
-				reg9441 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5alphanums_6)
-				reg9442 := __e.Call(__defun___8s, reg9440, reg9441)
-				reg9443 := __e.Call(__defun__shen_4pair, reg9439, reg9442)
+				reg9440 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5alphanum_6)
+				reg9441 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5alphanums_6)
+				reg9442 := Call(__e, __defun___8s, reg9440, reg9441)
+				reg9443 := Call(__e, __defun__shen_4pair, reg9439, reg9442)
 				reg9445 = reg9443
 			} else {
-				reg9444 := __e.Call(__defun__fail)
+				reg9444 := Call(__e, __defun__fail)
 				reg9445 = reg9444
 			}
 			reg9447 = reg9445
 		} else {
-			reg9446 := __e.Call(__defun__fail)
+			reg9446 := Call(__e, __defun__fail)
 			reg9447 = reg9446
 		}
 		YaccParse := reg9447
 		_ = YaccParse
-		reg9448 := __e.Call(__defun__fail)
+		reg9448 := Call(__e, __defun__fail)
 		reg9449 := PrimEqual(YaccParse, reg9448)
 		if reg9449 == True {
-			reg9450 := __e.Call(__defun___5e_6, V1547)
+			reg9450 := Call(__e, __defun___5e_6, V1547)
 			Parse___5e_6 := reg9450
 			_ = Parse___5e_6
-			reg9451 := __e.Call(__defun__fail)
+			reg9451 := Call(__e, __defun__fail)
 			reg9452 := PrimEqual(reg9451, Parse___5e_6)
 			reg9453 := PrimNot(reg9452)
 			if reg9453 == True {
 				reg9454 := PrimHead(Parse___5e_6)
 				reg9455 := MakeString("")
-				__ctx.TailApply(__defun__shen_4pair, reg9454, reg9455)
+				__e.TailApply(__defun__shen_4pair, reg9454, reg9455)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<alphanums>", value: __defun__shen_4_5alphanums_6})
 
-	__defun__shen_4_5alphanum_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5alphanum_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1549 := __args[0]
 		_ = V1549
-		reg9458 := __e.Call(__defun__shen_4_5alpha_6, V1549)
+		reg9458 := Call(__e, __defun__shen_4_5alpha_6, V1549)
 		Parse__shen_4_5alpha_6 := reg9458
 		_ = Parse__shen_4_5alpha_6
-		reg9459 := __e.Call(__defun__fail)
+		reg9459 := Call(__e, __defun__fail)
 		reg9460 := PrimEqual(reg9459, Parse__shen_4_5alpha_6)
 		reg9461 := PrimNot(reg9460)
 		var reg9466 Obj
 		if reg9461 == True {
 			reg9462 := PrimHead(Parse__shen_4_5alpha_6)
-			reg9463 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5alpha_6)
-			reg9464 := __e.Call(__defun__shen_4pair, reg9462, reg9463)
+			reg9463 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5alpha_6)
+			reg9464 := Call(__e, __defun__shen_4pair, reg9462, reg9463)
 			reg9466 = reg9464
 		} else {
-			reg9465 := __e.Call(__defun__fail)
+			reg9465 := Call(__e, __defun__fail)
 			reg9466 = reg9465
 		}
 		YaccParse := reg9466
 		_ = YaccParse
-		reg9467 := __e.Call(__defun__fail)
+		reg9467 := Call(__e, __defun__fail)
 		reg9468 := PrimEqual(YaccParse, reg9467)
 		if reg9468 == True {
-			reg9469 := __e.Call(__defun__shen_4_5num_6, V1549)
+			reg9469 := Call(__e, __defun__shen_4_5num_6, V1549)
 			Parse__shen_4_5num_6 := reg9469
 			_ = Parse__shen_4_5num_6
-			reg9470 := __e.Call(__defun__fail)
+			reg9470 := Call(__e, __defun__fail)
 			reg9471 := PrimEqual(reg9470, Parse__shen_4_5num_6)
 			reg9472 := PrimNot(reg9471)
 			if reg9472 == True {
 				reg9473 := PrimHead(Parse__shen_4_5num_6)
-				reg9474 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5num_6)
-				__ctx.TailApply(__defun__shen_4pair, reg9473, reg9474)
+				reg9474 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5num_6)
+				__e.TailApply(__defun__shen_4pair, reg9473, reg9474)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<alphanum>", value: __defun__shen_4_5alphanum_6})
 
-	__defun__shen_4_5num_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5num_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1551 := __args[0]
 		_ = V1551
 		reg9477 := PrimHead(V1551)
 		reg9478 := PrimIsPair(reg9477)
 		if reg9478 == True {
-			reg9479 := __e.Call(__defun__shen_4hdhd, V1551)
+			reg9479 := Call(__e, __defun__shen_4hdhd, V1551)
 			Parse__Char := reg9479
 			_ = Parse__Char
-			reg9480 := __e.Call(__defun__shen_4numbyte_2, Parse__Char)
+			reg9480 := Call(__e, __defun__shen_4numbyte_2, Parse__Char)
 			if reg9480 == True {
-				reg9481 := __e.Call(__defun__shen_4tlhd, V1551)
-				reg9482 := __e.Call(__defun__shen_4hdtl, V1551)
-				reg9483 := __e.Call(__defun__shen_4pair, reg9481, reg9482)
+				reg9481 := Call(__e, __defun__shen_4tlhd, V1551)
+				reg9482 := Call(__e, __defun__shen_4hdtl, V1551)
+				reg9483 := Call(__e, __defun__shen_4pair, reg9481, reg9482)
 				reg9484 := PrimHead(reg9483)
 				reg9485 := PrimNumberToString(Parse__Char)
-				__ctx.TailApply(__defun__shen_4pair, reg9484, reg9485)
+				__e.TailApply(__defun__shen_4pair, reg9484, reg9485)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<num>", value: __defun__shen_4_5num_6})
 
-	__defun__shen_4numbyte_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4numbyte_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1557 := __args[0]
 		_ = V1557
 		reg9489 := MakeNumber(48)
 		reg9490 := PrimEqual(reg9489, V1557)
 		if reg9490 == True {
 			reg9491 := True
-			__ctx.Return(reg9491)
+			__e.Return(reg9491)
 			return
 		} else {
 			reg9492 := MakeNumber(49)
 			reg9493 := PrimEqual(reg9492, V1557)
 			if reg9493 == True {
 				reg9494 := True
-				__ctx.Return(reg9494)
+				__e.Return(reg9494)
 				return
 			} else {
 				reg9495 := MakeNumber(50)
 				reg9496 := PrimEqual(reg9495, V1557)
 				if reg9496 == True {
 					reg9497 := True
-					__ctx.Return(reg9497)
+					__e.Return(reg9497)
 					return
 				} else {
 					reg9498 := MakeNumber(51)
 					reg9499 := PrimEqual(reg9498, V1557)
 					if reg9499 == True {
 						reg9500 := True
-						__ctx.Return(reg9500)
+						__e.Return(reg9500)
 						return
 					} else {
 						reg9501 := MakeNumber(52)
 						reg9502 := PrimEqual(reg9501, V1557)
 						if reg9502 == True {
 							reg9503 := True
-							__ctx.Return(reg9503)
+							__e.Return(reg9503)
 							return
 						} else {
 							reg9504 := MakeNumber(53)
 							reg9505 := PrimEqual(reg9504, V1557)
 							if reg9505 == True {
 								reg9506 := True
-								__ctx.Return(reg9506)
+								__e.Return(reg9506)
 								return
 							} else {
 								reg9507 := MakeNumber(54)
 								reg9508 := PrimEqual(reg9507, V1557)
 								if reg9508 == True {
 									reg9509 := True
-									__ctx.Return(reg9509)
+									__e.Return(reg9509)
 									return
 								} else {
 									reg9510 := MakeNumber(55)
 									reg9511 := PrimEqual(reg9510, V1557)
 									if reg9511 == True {
 										reg9512 := True
-										__ctx.Return(reg9512)
+										__e.Return(reg9512)
 										return
 									} else {
 										reg9513 := MakeNumber(56)
 										reg9514 := PrimEqual(reg9513, V1557)
 										if reg9514 == True {
 											reg9515 := True
-											__ctx.Return(reg9515)
+											__e.Return(reg9515)
 											return
 										} else {
 											reg9516 := MakeNumber(57)
 											reg9517 := PrimEqual(reg9516, V1557)
 											if reg9517 == True {
 												reg9518 := True
-												__ctx.Return(reg9518)
+												__e.Return(reg9518)
 												return
 											} else {
 												reg9519 := False
-												__ctx.Return(reg9519)
+												__e.Return(reg9519)
 												return
 											}
 										}
@@ -2826,43 +2826,43 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.numbyte?", value: __defun__shen_4numbyte_2})
 
-	__defun__shen_4_5alpha_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5alpha_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1559 := __args[0]
 		_ = V1559
 		reg9520 := PrimHead(V1559)
 		reg9521 := PrimIsPair(reg9520)
 		if reg9521 == True {
-			reg9522 := __e.Call(__defun__shen_4hdhd, V1559)
+			reg9522 := Call(__e, __defun__shen_4hdhd, V1559)
 			Parse__Char := reg9522
 			_ = Parse__Char
-			reg9523 := __e.Call(__defun__shen_4symbol_1code_2, Parse__Char)
+			reg9523 := Call(__e, __defun__shen_4symbol_1code_2, Parse__Char)
 			if reg9523 == True {
-				reg9524 := __e.Call(__defun__shen_4tlhd, V1559)
-				reg9525 := __e.Call(__defun__shen_4hdtl, V1559)
-				reg9526 := __e.Call(__defun__shen_4pair, reg9524, reg9525)
+				reg9524 := Call(__e, __defun__shen_4tlhd, V1559)
+				reg9525 := Call(__e, __defun__shen_4hdtl, V1559)
+				reg9526 := Call(__e, __defun__shen_4pair, reg9524, reg9525)
 				reg9527 := PrimHead(reg9526)
 				reg9528 := PrimNumberToString(Parse__Char)
-				__ctx.TailApply(__defun__shen_4pair, reg9527, reg9528)
+				__e.TailApply(__defun__shen_4pair, reg9527, reg9528)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<alpha>", value: __defun__shen_4_5alpha_6})
 
-	__defun__shen_4symbol_1code_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4symbol_1code_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1561 := __args[0]
 		_ = V1561
 		reg9532 := MakeNumber(126)
 		reg9533 := PrimEqual(V1561, reg9532)
 		if reg9533 == True {
 			reg9534 := True
-			__ctx.Return(reg9534)
+			__e.Return(reg9534)
 			return
 		} else {
 			reg9535 := MakeNumber(94)
@@ -3023,511 +3023,511 @@ func init() {
 			}
 			if reg9600 == True {
 				reg9601 := True
-				__ctx.Return(reg9601)
+				__e.Return(reg9601)
 				return
 			} else {
 				reg9602 := False
-				__ctx.Return(reg9602)
+				__e.Return(reg9602)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.symbol-code?", value: __defun__shen_4symbol_1code_2})
 
-	__defun__shen_4_5str_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5str_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1563 := __args[0]
 		_ = V1563
-		reg9603 := __e.Call(__defun__shen_4_5dbq_6, V1563)
+		reg9603 := Call(__e, __defun__shen_4_5dbq_6, V1563)
 		Parse__shen_4_5dbq_6 := reg9603
 		_ = Parse__shen_4_5dbq_6
-		reg9604 := __e.Call(__defun__fail)
+		reg9604 := Call(__e, __defun__fail)
 		reg9605 := PrimEqual(reg9604, Parse__shen_4_5dbq_6)
 		reg9606 := PrimNot(reg9605)
 		if reg9606 == True {
-			reg9607 := __e.Call(__defun__shen_4_5strcontents_6, Parse__shen_4_5dbq_6)
+			reg9607 := Call(__e, __defun__shen_4_5strcontents_6, Parse__shen_4_5dbq_6)
 			Parse__shen_4_5strcontents_6 := reg9607
 			_ = Parse__shen_4_5strcontents_6
-			reg9608 := __e.Call(__defun__fail)
+			reg9608 := Call(__e, __defun__fail)
 			reg9609 := PrimEqual(reg9608, Parse__shen_4_5strcontents_6)
 			reg9610 := PrimNot(reg9609)
 			if reg9610 == True {
-				reg9611 := __e.Call(__defun__shen_4_5dbq_6, Parse__shen_4_5strcontents_6)
+				reg9611 := Call(__e, __defun__shen_4_5dbq_6, Parse__shen_4_5strcontents_6)
 				Parse__shen_4_5dbq_6 := reg9611
 				_ = Parse__shen_4_5dbq_6
-				reg9612 := __e.Call(__defun__fail)
+				reg9612 := Call(__e, __defun__fail)
 				reg9613 := PrimEqual(reg9612, Parse__shen_4_5dbq_6)
 				reg9614 := PrimNot(reg9613)
 				if reg9614 == True {
 					reg9615 := PrimHead(Parse__shen_4_5dbq_6)
-					reg9616 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5strcontents_6)
-					__ctx.TailApply(__defun__shen_4pair, reg9615, reg9616)
+					reg9616 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5strcontents_6)
+					__e.TailApply(__defun__shen_4pair, reg9615, reg9616)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<str>", value: __defun__shen_4_5str_6})
 
-	__defun__shen_4_5dbq_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5dbq_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1565 := __args[0]
 		_ = V1565
 		reg9621 := PrimHead(V1565)
 		reg9622 := PrimIsPair(reg9621)
 		if reg9622 == True {
-			reg9623 := __e.Call(__defun__shen_4hdhd, V1565)
+			reg9623 := Call(__e, __defun__shen_4hdhd, V1565)
 			Parse__Char := reg9623
 			_ = Parse__Char
 			reg9624 := MakeNumber(34)
 			reg9625 := PrimEqual(Parse__Char, reg9624)
 			if reg9625 == True {
-				reg9626 := __e.Call(__defun__shen_4tlhd, V1565)
-				reg9627 := __e.Call(__defun__shen_4hdtl, V1565)
-				reg9628 := __e.Call(__defun__shen_4pair, reg9626, reg9627)
+				reg9626 := Call(__e, __defun__shen_4tlhd, V1565)
+				reg9627 := Call(__e, __defun__shen_4hdtl, V1565)
+				reg9628 := Call(__e, __defun__shen_4pair, reg9626, reg9627)
 				reg9629 := PrimHead(reg9628)
-				__ctx.TailApply(__defun__shen_4pair, reg9629, Parse__Char)
+				__e.TailApply(__defun__shen_4pair, reg9629, Parse__Char)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<dbq>", value: __defun__shen_4_5dbq_6})
 
-	__defun__shen_4_5strcontents_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5strcontents_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1567 := __args[0]
 		_ = V1567
-		reg9633 := __e.Call(__defun__shen_4_5strc_6, V1567)
+		reg9633 := Call(__e, __defun__shen_4_5strc_6, V1567)
 		Parse__shen_4_5strc_6 := reg9633
 		_ = Parse__shen_4_5strc_6
-		reg9634 := __e.Call(__defun__fail)
+		reg9634 := Call(__e, __defun__fail)
 		reg9635 := PrimEqual(reg9634, Parse__shen_4_5strc_6)
 		reg9636 := PrimNot(reg9635)
 		var reg9649 Obj
 		if reg9636 == True {
-			reg9637 := __e.Call(__defun__shen_4_5strcontents_6, Parse__shen_4_5strc_6)
+			reg9637 := Call(__e, __defun__shen_4_5strcontents_6, Parse__shen_4_5strc_6)
 			Parse__shen_4_5strcontents_6 := reg9637
 			_ = Parse__shen_4_5strcontents_6
-			reg9638 := __e.Call(__defun__fail)
+			reg9638 := Call(__e, __defun__fail)
 			reg9639 := PrimEqual(reg9638, Parse__shen_4_5strcontents_6)
 			reg9640 := PrimNot(reg9639)
 			var reg9647 Obj
 			if reg9640 == True {
 				reg9641 := PrimHead(Parse__shen_4_5strcontents_6)
-				reg9642 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5strc_6)
-				reg9643 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5strcontents_6)
+				reg9642 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5strc_6)
+				reg9643 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5strcontents_6)
 				reg9644 := PrimCons(reg9642, reg9643)
-				reg9645 := __e.Call(__defun__shen_4pair, reg9641, reg9644)
+				reg9645 := Call(__e, __defun__shen_4pair, reg9641, reg9644)
 				reg9647 = reg9645
 			} else {
-				reg9646 := __e.Call(__defun__fail)
+				reg9646 := Call(__e, __defun__fail)
 				reg9647 = reg9646
 			}
 			reg9649 = reg9647
 		} else {
-			reg9648 := __e.Call(__defun__fail)
+			reg9648 := Call(__e, __defun__fail)
 			reg9649 = reg9648
 		}
 		YaccParse := reg9649
 		_ = YaccParse
-		reg9650 := __e.Call(__defun__fail)
+		reg9650 := Call(__e, __defun__fail)
 		reg9651 := PrimEqual(YaccParse, reg9650)
 		if reg9651 == True {
-			reg9652 := __e.Call(__defun___5e_6, V1567)
+			reg9652 := Call(__e, __defun___5e_6, V1567)
 			Parse___5e_6 := reg9652
 			_ = Parse___5e_6
-			reg9653 := __e.Call(__defun__fail)
+			reg9653 := Call(__e, __defun__fail)
 			reg9654 := PrimEqual(reg9653, Parse___5e_6)
 			reg9655 := PrimNot(reg9654)
 			if reg9655 == True {
 				reg9656 := PrimHead(Parse___5e_6)
 				reg9657 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg9656, reg9657)
+				__e.TailApply(__defun__shen_4pair, reg9656, reg9657)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<strcontents>", value: __defun__shen_4_5strcontents_6})
 
-	__defun__shen_4_5byte_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5byte_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1569 := __args[0]
 		_ = V1569
 		reg9660 := PrimHead(V1569)
 		reg9661 := PrimIsPair(reg9660)
 		if reg9661 == True {
-			reg9662 := __e.Call(__defun__shen_4hdhd, V1569)
+			reg9662 := Call(__e, __defun__shen_4hdhd, V1569)
 			Parse__Char := reg9662
 			_ = Parse__Char
-			reg9663 := __e.Call(__defun__shen_4tlhd, V1569)
-			reg9664 := __e.Call(__defun__shen_4hdtl, V1569)
-			reg9665 := __e.Call(__defun__shen_4pair, reg9663, reg9664)
+			reg9663 := Call(__e, __defun__shen_4tlhd, V1569)
+			reg9664 := Call(__e, __defun__shen_4hdtl, V1569)
+			reg9665 := Call(__e, __defun__shen_4pair, reg9663, reg9664)
 			reg9666 := PrimHead(reg9665)
 			reg9667 := PrimNumberToString(Parse__Char)
-			__ctx.TailApply(__defun__shen_4pair, reg9666, reg9667)
+			__e.TailApply(__defun__shen_4pair, reg9666, reg9667)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<byte>", value: __defun__shen_4_5byte_6})
 
-	__defun__shen_4_5strc_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5strc_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1571 := __args[0]
 		_ = V1571
 		reg9670 := PrimHead(V1571)
 		reg9671 := PrimIsPair(reg9670)
 		if reg9671 == True {
-			reg9672 := __e.Call(__defun__shen_4hdhd, V1571)
+			reg9672 := Call(__e, __defun__shen_4hdhd, V1571)
 			Parse__Char := reg9672
 			_ = Parse__Char
 			reg9673 := MakeNumber(34)
 			reg9674 := PrimEqual(Parse__Char, reg9673)
 			reg9675 := PrimNot(reg9674)
 			if reg9675 == True {
-				reg9676 := __e.Call(__defun__shen_4tlhd, V1571)
-				reg9677 := __e.Call(__defun__shen_4hdtl, V1571)
-				reg9678 := __e.Call(__defun__shen_4pair, reg9676, reg9677)
+				reg9676 := Call(__e, __defun__shen_4tlhd, V1571)
+				reg9677 := Call(__e, __defun__shen_4hdtl, V1571)
+				reg9678 := Call(__e, __defun__shen_4pair, reg9676, reg9677)
 				reg9679 := PrimHead(reg9678)
 				reg9680 := PrimNumberToString(Parse__Char)
-				__ctx.TailApply(__defun__shen_4pair, reg9679, reg9680)
+				__e.TailApply(__defun__shen_4pair, reg9679, reg9680)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<strc>", value: __defun__shen_4_5strc_6})
 
-	__defun__shen_4_5number_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5number_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1573 := __args[0]
 		_ = V1573
-		reg9684 := __e.Call(__defun__shen_4_5minus_6, V1573)
+		reg9684 := Call(__e, __defun__shen_4_5minus_6, V1573)
 		Parse__shen_4_5minus_6 := reg9684
 		_ = Parse__shen_4_5minus_6
-		reg9685 := __e.Call(__defun__fail)
+		reg9685 := Call(__e, __defun__fail)
 		reg9686 := PrimEqual(reg9685, Parse__shen_4_5minus_6)
 		reg9687 := PrimNot(reg9686)
 		var reg9700 Obj
 		if reg9687 == True {
-			reg9688 := __e.Call(__defun__shen_4_5number_6, Parse__shen_4_5minus_6)
+			reg9688 := Call(__e, __defun__shen_4_5number_6, Parse__shen_4_5minus_6)
 			Parse__shen_4_5number_6 := reg9688
 			_ = Parse__shen_4_5number_6
-			reg9689 := __e.Call(__defun__fail)
+			reg9689 := Call(__e, __defun__fail)
 			reg9690 := PrimEqual(reg9689, Parse__shen_4_5number_6)
 			reg9691 := PrimNot(reg9690)
 			var reg9698 Obj
 			if reg9691 == True {
 				reg9692 := PrimHead(Parse__shen_4_5number_6)
 				reg9693 := MakeNumber(0)
-				reg9694 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5number_6)
+				reg9694 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5number_6)
 				reg9695 := PrimNumberSubtract(reg9693, reg9694)
-				reg9696 := __e.Call(__defun__shen_4pair, reg9692, reg9695)
+				reg9696 := Call(__e, __defun__shen_4pair, reg9692, reg9695)
 				reg9698 = reg9696
 			} else {
-				reg9697 := __e.Call(__defun__fail)
+				reg9697 := Call(__e, __defun__fail)
 				reg9698 = reg9697
 			}
 			reg9700 = reg9698
 		} else {
-			reg9699 := __e.Call(__defun__fail)
+			reg9699 := Call(__e, __defun__fail)
 			reg9700 = reg9699
 		}
 		YaccParse := reg9700
 		_ = YaccParse
-		reg9701 := __e.Call(__defun__fail)
+		reg9701 := Call(__e, __defun__fail)
 		reg9702 := PrimEqual(YaccParse, reg9701)
 		if reg9702 == True {
-			reg9703 := __e.Call(__defun__shen_4_5plus_6, V1573)
+			reg9703 := Call(__e, __defun__shen_4_5plus_6, V1573)
 			Parse__shen_4_5plus_6 := reg9703
 			_ = Parse__shen_4_5plus_6
-			reg9704 := __e.Call(__defun__fail)
+			reg9704 := Call(__e, __defun__fail)
 			reg9705 := PrimEqual(reg9704, Parse__shen_4_5plus_6)
 			reg9706 := PrimNot(reg9705)
 			var reg9717 Obj
 			if reg9706 == True {
-				reg9707 := __e.Call(__defun__shen_4_5number_6, Parse__shen_4_5plus_6)
+				reg9707 := Call(__e, __defun__shen_4_5number_6, Parse__shen_4_5plus_6)
 				Parse__shen_4_5number_6 := reg9707
 				_ = Parse__shen_4_5number_6
-				reg9708 := __e.Call(__defun__fail)
+				reg9708 := Call(__e, __defun__fail)
 				reg9709 := PrimEqual(reg9708, Parse__shen_4_5number_6)
 				reg9710 := PrimNot(reg9709)
 				var reg9715 Obj
 				if reg9710 == True {
 					reg9711 := PrimHead(Parse__shen_4_5number_6)
-					reg9712 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5number_6)
-					reg9713 := __e.Call(__defun__shen_4pair, reg9711, reg9712)
+					reg9712 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5number_6)
+					reg9713 := Call(__e, __defun__shen_4pair, reg9711, reg9712)
 					reg9715 = reg9713
 				} else {
-					reg9714 := __e.Call(__defun__fail)
+					reg9714 := Call(__e, __defun__fail)
 					reg9715 = reg9714
 				}
 				reg9717 = reg9715
 			} else {
-				reg9716 := __e.Call(__defun__fail)
+				reg9716 := Call(__e, __defun__fail)
 				reg9717 = reg9716
 			}
 			YaccParse := reg9717
 			_ = YaccParse
-			reg9718 := __e.Call(__defun__fail)
+			reg9718 := Call(__e, __defun__fail)
 			reg9719 := PrimEqual(YaccParse, reg9718)
 			if reg9719 == True {
-				reg9720 := __e.Call(__defun__shen_4_5predigits_6, V1573)
+				reg9720 := Call(__e, __defun__shen_4_5predigits_6, V1573)
 				Parse__shen_4_5predigits_6 := reg9720
 				_ = Parse__shen_4_5predigits_6
-				reg9721 := __e.Call(__defun__fail)
+				reg9721 := Call(__e, __defun__fail)
 				reg9722 := PrimEqual(reg9721, Parse__shen_4_5predigits_6)
 				reg9723 := PrimNot(reg9722)
 				var reg9763 Obj
 				if reg9723 == True {
-					reg9724 := __e.Call(__defun__shen_4_5stop_6, Parse__shen_4_5predigits_6)
+					reg9724 := Call(__e, __defun__shen_4_5stop_6, Parse__shen_4_5predigits_6)
 					Parse__shen_4_5stop_6 := reg9724
 					_ = Parse__shen_4_5stop_6
-					reg9725 := __e.Call(__defun__fail)
+					reg9725 := Call(__e, __defun__fail)
 					reg9726 := PrimEqual(reg9725, Parse__shen_4_5stop_6)
 					reg9727 := PrimNot(reg9726)
 					var reg9761 Obj
 					if reg9727 == True {
-						reg9728 := __e.Call(__defun__shen_4_5postdigits_6, Parse__shen_4_5stop_6)
+						reg9728 := Call(__e, __defun__shen_4_5postdigits_6, Parse__shen_4_5stop_6)
 						Parse__shen_4_5postdigits_6 := reg9728
 						_ = Parse__shen_4_5postdigits_6
-						reg9729 := __e.Call(__defun__fail)
+						reg9729 := Call(__e, __defun__fail)
 						reg9730 := PrimEqual(reg9729, Parse__shen_4_5postdigits_6)
 						reg9731 := PrimNot(reg9730)
 						var reg9759 Obj
 						if reg9731 == True {
-							reg9732 := __e.Call(__defun__shen_4_5E_6, Parse__shen_4_5postdigits_6)
+							reg9732 := Call(__e, __defun__shen_4_5E_6, Parse__shen_4_5postdigits_6)
 							Parse__shen_4_5E_6 := reg9732
 							_ = Parse__shen_4_5E_6
-							reg9733 := __e.Call(__defun__fail)
+							reg9733 := Call(__e, __defun__fail)
 							reg9734 := PrimEqual(reg9733, Parse__shen_4_5E_6)
 							reg9735 := PrimNot(reg9734)
 							var reg9757 Obj
 							if reg9735 == True {
-								reg9736 := __e.Call(__defun__shen_4_5log10_6, Parse__shen_4_5E_6)
+								reg9736 := Call(__e, __defun__shen_4_5log10_6, Parse__shen_4_5E_6)
 								Parse__shen_4_5log10_6 := reg9736
 								_ = Parse__shen_4_5log10_6
-								reg9737 := __e.Call(__defun__fail)
+								reg9737 := Call(__e, __defun__fail)
 								reg9738 := PrimEqual(reg9737, Parse__shen_4_5log10_6)
 								reg9739 := PrimNot(reg9738)
 								var reg9755 Obj
 								if reg9739 == True {
 									reg9740 := PrimHead(Parse__shen_4_5log10_6)
 									reg9741 := MakeNumber(10)
-									reg9742 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5log10_6)
-									reg9743 := __e.Call(__defun__shen_4expt, reg9741, reg9742)
-									reg9744 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5predigits_6)
-									reg9745 := __e.Call(__defun__reverse, reg9744)
+									reg9742 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5log10_6)
+									reg9743 := Call(__e, __defun__shen_4expt, reg9741, reg9742)
+									reg9744 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5predigits_6)
+									reg9745 := Call(__e, __defun__reverse, reg9744)
 									reg9746 := MakeNumber(0)
-									reg9747 := __e.Call(__defun__shen_4pre, reg9745, reg9746)
-									reg9748 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5postdigits_6)
+									reg9747 := Call(__e, __defun__shen_4pre, reg9745, reg9746)
+									reg9748 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5postdigits_6)
 									reg9749 := MakeNumber(1)
-									reg9750 := __e.Call(__defun__shen_4post, reg9748, reg9749)
+									reg9750 := Call(__e, __defun__shen_4post, reg9748, reg9749)
 									reg9751 := PrimNumberAdd(reg9747, reg9750)
 									reg9752 := PrimNumberMultiply(reg9743, reg9751)
-									reg9753 := __e.Call(__defun__shen_4pair, reg9740, reg9752)
+									reg9753 := Call(__e, __defun__shen_4pair, reg9740, reg9752)
 									reg9755 = reg9753
 								} else {
-									reg9754 := __e.Call(__defun__fail)
+									reg9754 := Call(__e, __defun__fail)
 									reg9755 = reg9754
 								}
 								reg9757 = reg9755
 							} else {
-								reg9756 := __e.Call(__defun__fail)
+								reg9756 := Call(__e, __defun__fail)
 								reg9757 = reg9756
 							}
 							reg9759 = reg9757
 						} else {
-							reg9758 := __e.Call(__defun__fail)
+							reg9758 := Call(__e, __defun__fail)
 							reg9759 = reg9758
 						}
 						reg9761 = reg9759
 					} else {
-						reg9760 := __e.Call(__defun__fail)
+						reg9760 := Call(__e, __defun__fail)
 						reg9761 = reg9760
 					}
 					reg9763 = reg9761
 				} else {
-					reg9762 := __e.Call(__defun__fail)
+					reg9762 := Call(__e, __defun__fail)
 					reg9763 = reg9762
 				}
 				YaccParse := reg9763
 				_ = YaccParse
-				reg9764 := __e.Call(__defun__fail)
+				reg9764 := Call(__e, __defun__fail)
 				reg9765 := PrimEqual(YaccParse, reg9764)
 				if reg9765 == True {
-					reg9766 := __e.Call(__defun__shen_4_5digits_6, V1573)
+					reg9766 := Call(__e, __defun__shen_4_5digits_6, V1573)
 					Parse__shen_4_5digits_6 := reg9766
 					_ = Parse__shen_4_5digits_6
-					reg9767 := __e.Call(__defun__fail)
+					reg9767 := Call(__e, __defun__fail)
 					reg9768 := PrimEqual(reg9767, Parse__shen_4_5digits_6)
 					reg9769 := PrimNot(reg9768)
 					var reg9793 Obj
 					if reg9769 == True {
-						reg9770 := __e.Call(__defun__shen_4_5E_6, Parse__shen_4_5digits_6)
+						reg9770 := Call(__e, __defun__shen_4_5E_6, Parse__shen_4_5digits_6)
 						Parse__shen_4_5E_6 := reg9770
 						_ = Parse__shen_4_5E_6
-						reg9771 := __e.Call(__defun__fail)
+						reg9771 := Call(__e, __defun__fail)
 						reg9772 := PrimEqual(reg9771, Parse__shen_4_5E_6)
 						reg9773 := PrimNot(reg9772)
 						var reg9791 Obj
 						if reg9773 == True {
-							reg9774 := __e.Call(__defun__shen_4_5log10_6, Parse__shen_4_5E_6)
+							reg9774 := Call(__e, __defun__shen_4_5log10_6, Parse__shen_4_5E_6)
 							Parse__shen_4_5log10_6 := reg9774
 							_ = Parse__shen_4_5log10_6
-							reg9775 := __e.Call(__defun__fail)
+							reg9775 := Call(__e, __defun__fail)
 							reg9776 := PrimEqual(reg9775, Parse__shen_4_5log10_6)
 							reg9777 := PrimNot(reg9776)
 							var reg9789 Obj
 							if reg9777 == True {
 								reg9778 := PrimHead(Parse__shen_4_5log10_6)
 								reg9779 := MakeNumber(10)
-								reg9780 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5log10_6)
-								reg9781 := __e.Call(__defun__shen_4expt, reg9779, reg9780)
-								reg9782 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5digits_6)
-								reg9783 := __e.Call(__defun__reverse, reg9782)
+								reg9780 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5log10_6)
+								reg9781 := Call(__e, __defun__shen_4expt, reg9779, reg9780)
+								reg9782 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5digits_6)
+								reg9783 := Call(__e, __defun__reverse, reg9782)
 								reg9784 := MakeNumber(0)
-								reg9785 := __e.Call(__defun__shen_4pre, reg9783, reg9784)
+								reg9785 := Call(__e, __defun__shen_4pre, reg9783, reg9784)
 								reg9786 := PrimNumberMultiply(reg9781, reg9785)
-								reg9787 := __e.Call(__defun__shen_4pair, reg9778, reg9786)
+								reg9787 := Call(__e, __defun__shen_4pair, reg9778, reg9786)
 								reg9789 = reg9787
 							} else {
-								reg9788 := __e.Call(__defun__fail)
+								reg9788 := Call(__e, __defun__fail)
 								reg9789 = reg9788
 							}
 							reg9791 = reg9789
 						} else {
-							reg9790 := __e.Call(__defun__fail)
+							reg9790 := Call(__e, __defun__fail)
 							reg9791 = reg9790
 						}
 						reg9793 = reg9791
 					} else {
-						reg9792 := __e.Call(__defun__fail)
+						reg9792 := Call(__e, __defun__fail)
 						reg9793 = reg9792
 					}
 					YaccParse := reg9793
 					_ = YaccParse
-					reg9794 := __e.Call(__defun__fail)
+					reg9794 := Call(__e, __defun__fail)
 					reg9795 := PrimEqual(YaccParse, reg9794)
 					if reg9795 == True {
-						reg9796 := __e.Call(__defun__shen_4_5predigits_6, V1573)
+						reg9796 := Call(__e, __defun__shen_4_5predigits_6, V1573)
 						Parse__shen_4_5predigits_6 := reg9796
 						_ = Parse__shen_4_5predigits_6
-						reg9797 := __e.Call(__defun__fail)
+						reg9797 := Call(__e, __defun__fail)
 						reg9798 := PrimEqual(reg9797, Parse__shen_4_5predigits_6)
 						reg9799 := PrimNot(reg9798)
 						var reg9823 Obj
 						if reg9799 == True {
-							reg9800 := __e.Call(__defun__shen_4_5stop_6, Parse__shen_4_5predigits_6)
+							reg9800 := Call(__e, __defun__shen_4_5stop_6, Parse__shen_4_5predigits_6)
 							Parse__shen_4_5stop_6 := reg9800
 							_ = Parse__shen_4_5stop_6
-							reg9801 := __e.Call(__defun__fail)
+							reg9801 := Call(__e, __defun__fail)
 							reg9802 := PrimEqual(reg9801, Parse__shen_4_5stop_6)
 							reg9803 := PrimNot(reg9802)
 							var reg9821 Obj
 							if reg9803 == True {
-								reg9804 := __e.Call(__defun__shen_4_5postdigits_6, Parse__shen_4_5stop_6)
+								reg9804 := Call(__e, __defun__shen_4_5postdigits_6, Parse__shen_4_5stop_6)
 								Parse__shen_4_5postdigits_6 := reg9804
 								_ = Parse__shen_4_5postdigits_6
-								reg9805 := __e.Call(__defun__fail)
+								reg9805 := Call(__e, __defun__fail)
 								reg9806 := PrimEqual(reg9805, Parse__shen_4_5postdigits_6)
 								reg9807 := PrimNot(reg9806)
 								var reg9819 Obj
 								if reg9807 == True {
 									reg9808 := PrimHead(Parse__shen_4_5postdigits_6)
-									reg9809 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5predigits_6)
-									reg9810 := __e.Call(__defun__reverse, reg9809)
+									reg9809 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5predigits_6)
+									reg9810 := Call(__e, __defun__reverse, reg9809)
 									reg9811 := MakeNumber(0)
-									reg9812 := __e.Call(__defun__shen_4pre, reg9810, reg9811)
-									reg9813 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5postdigits_6)
+									reg9812 := Call(__e, __defun__shen_4pre, reg9810, reg9811)
+									reg9813 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5postdigits_6)
 									reg9814 := MakeNumber(1)
-									reg9815 := __e.Call(__defun__shen_4post, reg9813, reg9814)
+									reg9815 := Call(__e, __defun__shen_4post, reg9813, reg9814)
 									reg9816 := PrimNumberAdd(reg9812, reg9815)
-									reg9817 := __e.Call(__defun__shen_4pair, reg9808, reg9816)
+									reg9817 := Call(__e, __defun__shen_4pair, reg9808, reg9816)
 									reg9819 = reg9817
 								} else {
-									reg9818 := __e.Call(__defun__fail)
+									reg9818 := Call(__e, __defun__fail)
 									reg9819 = reg9818
 								}
 								reg9821 = reg9819
 							} else {
-								reg9820 := __e.Call(__defun__fail)
+								reg9820 := Call(__e, __defun__fail)
 								reg9821 = reg9820
 							}
 							reg9823 = reg9821
 						} else {
-							reg9822 := __e.Call(__defun__fail)
+							reg9822 := Call(__e, __defun__fail)
 							reg9823 = reg9822
 						}
 						YaccParse := reg9823
 						_ = YaccParse
-						reg9824 := __e.Call(__defun__fail)
+						reg9824 := Call(__e, __defun__fail)
 						reg9825 := PrimEqual(YaccParse, reg9824)
 						if reg9825 == True {
-							reg9826 := __e.Call(__defun__shen_4_5digits_6, V1573)
+							reg9826 := Call(__e, __defun__shen_4_5digits_6, V1573)
 							Parse__shen_4_5digits_6 := reg9826
 							_ = Parse__shen_4_5digits_6
-							reg9827 := __e.Call(__defun__fail)
+							reg9827 := Call(__e, __defun__fail)
 							reg9828 := PrimEqual(reg9827, Parse__shen_4_5digits_6)
 							reg9829 := PrimNot(reg9828)
 							if reg9829 == True {
 								reg9830 := PrimHead(Parse__shen_4_5digits_6)
-								reg9831 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5digits_6)
-								reg9832 := __e.Call(__defun__reverse, reg9831)
+								reg9831 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5digits_6)
+								reg9832 := Call(__e, __defun__reverse, reg9831)
 								reg9833 := MakeNumber(0)
-								reg9834 := __e.Call(__defun__shen_4pre, reg9832, reg9833)
-								__ctx.TailApply(__defun__shen_4pair, reg9830, reg9834)
+								reg9834 := Call(__e, __defun__shen_4pre, reg9832, reg9833)
+								__e.TailApply(__defun__shen_4pair, reg9830, reg9834)
 								return
 							} else {
-								__ctx.TailApply(__defun__fail)
+								__e.TailApply(__defun__fail)
 								return
 							}
 						} else {
-							__ctx.Return(YaccParse)
+							__e.Return(YaccParse)
 							return
 						}
 					} else {
-						__ctx.Return(YaccParse)
+						__e.Return(YaccParse)
 						return
 					}
 				} else {
-					__ctx.Return(YaccParse)
+					__e.Return(YaccParse)
 					return
 				}
 			} else {
-				__ctx.Return(YaccParse)
+				__e.Return(YaccParse)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<number>", value: __defun__shen_4_5number_6})
 
-	__defun__shen_4_5E_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5E_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1576 := __args[0]
 		_ = V1576
 		reg9837 := PrimHead(V1576)
@@ -3535,7 +3535,7 @@ func init() {
 		var reg9846 Obj
 		if reg9838 == True {
 			reg9839 := MakeNumber(101)
-			reg9840 := __e.Call(__defun__shen_4hdhd, V1576)
+			reg9840 := Call(__e, __defun__shen_4hdhd, V1576)
 			reg9841 := PrimEqual(reg9839, reg9840)
 			var reg9844 Obj
 			if reg9841 == True {
@@ -3551,381 +3551,381 @@ func init() {
 			reg9846 = reg9845
 		}
 		if reg9846 == True {
-			reg9847 := __e.Call(__defun__shen_4tlhd, V1576)
-			reg9848 := __e.Call(__defun__shen_4hdtl, V1576)
-			reg9849 := __e.Call(__defun__shen_4pair, reg9847, reg9848)
+			reg9847 := Call(__e, __defun__shen_4tlhd, V1576)
+			reg9848 := Call(__e, __defun__shen_4hdtl, V1576)
+			reg9849 := Call(__e, __defun__shen_4pair, reg9847, reg9848)
 			NewStream1574 := reg9849
 			_ = NewStream1574
 			reg9850 := PrimHead(NewStream1574)
 			reg9851 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg9850, reg9851)
+			__e.TailApply(__defun__shen_4pair, reg9850, reg9851)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<E>", value: __defun__shen_4_5E_6})
 
-	__defun__shen_4_5log10_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5log10_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1578 := __args[0]
 		_ = V1578
-		reg9854 := __e.Call(__defun__shen_4_5minus_6, V1578)
+		reg9854 := Call(__e, __defun__shen_4_5minus_6, V1578)
 		Parse__shen_4_5minus_6 := reg9854
 		_ = Parse__shen_4_5minus_6
-		reg9855 := __e.Call(__defun__fail)
+		reg9855 := Call(__e, __defun__fail)
 		reg9856 := PrimEqual(reg9855, Parse__shen_4_5minus_6)
 		reg9857 := PrimNot(reg9856)
 		var reg9873 Obj
 		if reg9857 == True {
-			reg9858 := __e.Call(__defun__shen_4_5digits_6, Parse__shen_4_5minus_6)
+			reg9858 := Call(__e, __defun__shen_4_5digits_6, Parse__shen_4_5minus_6)
 			Parse__shen_4_5digits_6 := reg9858
 			_ = Parse__shen_4_5digits_6
-			reg9859 := __e.Call(__defun__fail)
+			reg9859 := Call(__e, __defun__fail)
 			reg9860 := PrimEqual(reg9859, Parse__shen_4_5digits_6)
 			reg9861 := PrimNot(reg9860)
 			var reg9871 Obj
 			if reg9861 == True {
 				reg9862 := PrimHead(Parse__shen_4_5digits_6)
 				reg9863 := MakeNumber(0)
-				reg9864 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5digits_6)
-				reg9865 := __e.Call(__defun__reverse, reg9864)
+				reg9864 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5digits_6)
+				reg9865 := Call(__e, __defun__reverse, reg9864)
 				reg9866 := MakeNumber(0)
-				reg9867 := __e.Call(__defun__shen_4pre, reg9865, reg9866)
+				reg9867 := Call(__e, __defun__shen_4pre, reg9865, reg9866)
 				reg9868 := PrimNumberSubtract(reg9863, reg9867)
-				reg9869 := __e.Call(__defun__shen_4pair, reg9862, reg9868)
+				reg9869 := Call(__e, __defun__shen_4pair, reg9862, reg9868)
 				reg9871 = reg9869
 			} else {
-				reg9870 := __e.Call(__defun__fail)
+				reg9870 := Call(__e, __defun__fail)
 				reg9871 = reg9870
 			}
 			reg9873 = reg9871
 		} else {
-			reg9872 := __e.Call(__defun__fail)
+			reg9872 := Call(__e, __defun__fail)
 			reg9873 = reg9872
 		}
 		YaccParse := reg9873
 		_ = YaccParse
-		reg9874 := __e.Call(__defun__fail)
+		reg9874 := Call(__e, __defun__fail)
 		reg9875 := PrimEqual(YaccParse, reg9874)
 		if reg9875 == True {
-			reg9876 := __e.Call(__defun__shen_4_5digits_6, V1578)
+			reg9876 := Call(__e, __defun__shen_4_5digits_6, V1578)
 			Parse__shen_4_5digits_6 := reg9876
 			_ = Parse__shen_4_5digits_6
-			reg9877 := __e.Call(__defun__fail)
+			reg9877 := Call(__e, __defun__fail)
 			reg9878 := PrimEqual(reg9877, Parse__shen_4_5digits_6)
 			reg9879 := PrimNot(reg9878)
 			if reg9879 == True {
 				reg9880 := PrimHead(Parse__shen_4_5digits_6)
-				reg9881 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5digits_6)
-				reg9882 := __e.Call(__defun__reverse, reg9881)
+				reg9881 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5digits_6)
+				reg9882 := Call(__e, __defun__reverse, reg9881)
 				reg9883 := MakeNumber(0)
-				reg9884 := __e.Call(__defun__shen_4pre, reg9882, reg9883)
-				__ctx.TailApply(__defun__shen_4pair, reg9880, reg9884)
+				reg9884 := Call(__e, __defun__shen_4pre, reg9882, reg9883)
+				__e.TailApply(__defun__shen_4pair, reg9880, reg9884)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<log10>", value: __defun__shen_4_5log10_6})
 
-	__defun__shen_4_5plus_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5plus_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1580 := __args[0]
 		_ = V1580
 		reg9887 := PrimHead(V1580)
 		reg9888 := PrimIsPair(reg9887)
 		if reg9888 == True {
-			reg9889 := __e.Call(__defun__shen_4hdhd, V1580)
+			reg9889 := Call(__e, __defun__shen_4hdhd, V1580)
 			Parse__Char := reg9889
 			_ = Parse__Char
 			reg9890 := MakeNumber(43)
 			reg9891 := PrimEqual(Parse__Char, reg9890)
 			if reg9891 == True {
-				reg9892 := __e.Call(__defun__shen_4tlhd, V1580)
-				reg9893 := __e.Call(__defun__shen_4hdtl, V1580)
-				reg9894 := __e.Call(__defun__shen_4pair, reg9892, reg9893)
+				reg9892 := Call(__e, __defun__shen_4tlhd, V1580)
+				reg9893 := Call(__e, __defun__shen_4hdtl, V1580)
+				reg9894 := Call(__e, __defun__shen_4pair, reg9892, reg9893)
 				reg9895 := PrimHead(reg9894)
-				__ctx.TailApply(__defun__shen_4pair, reg9895, Parse__Char)
+				__e.TailApply(__defun__shen_4pair, reg9895, Parse__Char)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<plus>", value: __defun__shen_4_5plus_6})
 
-	__defun__shen_4_5stop_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5stop_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1582 := __args[0]
 		_ = V1582
 		reg9899 := PrimHead(V1582)
 		reg9900 := PrimIsPair(reg9899)
 		if reg9900 == True {
-			reg9901 := __e.Call(__defun__shen_4hdhd, V1582)
+			reg9901 := Call(__e, __defun__shen_4hdhd, V1582)
 			Parse__Char := reg9901
 			_ = Parse__Char
 			reg9902 := MakeNumber(46)
 			reg9903 := PrimEqual(Parse__Char, reg9902)
 			if reg9903 == True {
-				reg9904 := __e.Call(__defun__shen_4tlhd, V1582)
-				reg9905 := __e.Call(__defun__shen_4hdtl, V1582)
-				reg9906 := __e.Call(__defun__shen_4pair, reg9904, reg9905)
+				reg9904 := Call(__e, __defun__shen_4tlhd, V1582)
+				reg9905 := Call(__e, __defun__shen_4hdtl, V1582)
+				reg9906 := Call(__e, __defun__shen_4pair, reg9904, reg9905)
 				reg9907 := PrimHead(reg9906)
-				__ctx.TailApply(__defun__shen_4pair, reg9907, Parse__Char)
+				__e.TailApply(__defun__shen_4pair, reg9907, Parse__Char)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<stop>", value: __defun__shen_4_5stop_6})
 
-	__defun__shen_4_5predigits_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5predigits_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1584 := __args[0]
 		_ = V1584
-		reg9911 := __e.Call(__defun__shen_4_5digits_6, V1584)
+		reg9911 := Call(__e, __defun__shen_4_5digits_6, V1584)
 		Parse__shen_4_5digits_6 := reg9911
 		_ = Parse__shen_4_5digits_6
-		reg9912 := __e.Call(__defun__fail)
+		reg9912 := Call(__e, __defun__fail)
 		reg9913 := PrimEqual(reg9912, Parse__shen_4_5digits_6)
 		reg9914 := PrimNot(reg9913)
 		var reg9919 Obj
 		if reg9914 == True {
 			reg9915 := PrimHead(Parse__shen_4_5digits_6)
-			reg9916 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5digits_6)
-			reg9917 := __e.Call(__defun__shen_4pair, reg9915, reg9916)
+			reg9916 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5digits_6)
+			reg9917 := Call(__e, __defun__shen_4pair, reg9915, reg9916)
 			reg9919 = reg9917
 		} else {
-			reg9918 := __e.Call(__defun__fail)
+			reg9918 := Call(__e, __defun__fail)
 			reg9919 = reg9918
 		}
 		YaccParse := reg9919
 		_ = YaccParse
-		reg9920 := __e.Call(__defun__fail)
+		reg9920 := Call(__e, __defun__fail)
 		reg9921 := PrimEqual(YaccParse, reg9920)
 		if reg9921 == True {
-			reg9922 := __e.Call(__defun___5e_6, V1584)
+			reg9922 := Call(__e, __defun___5e_6, V1584)
 			Parse___5e_6 := reg9922
 			_ = Parse___5e_6
-			reg9923 := __e.Call(__defun__fail)
+			reg9923 := Call(__e, __defun__fail)
 			reg9924 := PrimEqual(reg9923, Parse___5e_6)
 			reg9925 := PrimNot(reg9924)
 			if reg9925 == True {
 				reg9926 := PrimHead(Parse___5e_6)
 				reg9927 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg9926, reg9927)
+				__e.TailApply(__defun__shen_4pair, reg9926, reg9927)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<predigits>", value: __defun__shen_4_5predigits_6})
 
-	__defun__shen_4_5postdigits_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5postdigits_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1586 := __args[0]
 		_ = V1586
-		reg9930 := __e.Call(__defun__shen_4_5digits_6, V1586)
+		reg9930 := Call(__e, __defun__shen_4_5digits_6, V1586)
 		Parse__shen_4_5digits_6 := reg9930
 		_ = Parse__shen_4_5digits_6
-		reg9931 := __e.Call(__defun__fail)
+		reg9931 := Call(__e, __defun__fail)
 		reg9932 := PrimEqual(reg9931, Parse__shen_4_5digits_6)
 		reg9933 := PrimNot(reg9932)
 		if reg9933 == True {
 			reg9934 := PrimHead(Parse__shen_4_5digits_6)
-			reg9935 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5digits_6)
-			__ctx.TailApply(__defun__shen_4pair, reg9934, reg9935)
+			reg9935 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5digits_6)
+			__e.TailApply(__defun__shen_4pair, reg9934, reg9935)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<postdigits>", value: __defun__shen_4_5postdigits_6})
 
-	__defun__shen_4_5digits_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5digits_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1588 := __args[0]
 		_ = V1588
-		reg9938 := __e.Call(__defun__shen_4_5digit_6, V1588)
+		reg9938 := Call(__e, __defun__shen_4_5digit_6, V1588)
 		Parse__shen_4_5digit_6 := reg9938
 		_ = Parse__shen_4_5digit_6
-		reg9939 := __e.Call(__defun__fail)
+		reg9939 := Call(__e, __defun__fail)
 		reg9940 := PrimEqual(reg9939, Parse__shen_4_5digit_6)
 		reg9941 := PrimNot(reg9940)
 		var reg9954 Obj
 		if reg9941 == True {
-			reg9942 := __e.Call(__defun__shen_4_5digits_6, Parse__shen_4_5digit_6)
+			reg9942 := Call(__e, __defun__shen_4_5digits_6, Parse__shen_4_5digit_6)
 			Parse__shen_4_5digits_6 := reg9942
 			_ = Parse__shen_4_5digits_6
-			reg9943 := __e.Call(__defun__fail)
+			reg9943 := Call(__e, __defun__fail)
 			reg9944 := PrimEqual(reg9943, Parse__shen_4_5digits_6)
 			reg9945 := PrimNot(reg9944)
 			var reg9952 Obj
 			if reg9945 == True {
 				reg9946 := PrimHead(Parse__shen_4_5digits_6)
-				reg9947 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5digit_6)
-				reg9948 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5digits_6)
+				reg9947 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5digit_6)
+				reg9948 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5digits_6)
 				reg9949 := PrimCons(reg9947, reg9948)
-				reg9950 := __e.Call(__defun__shen_4pair, reg9946, reg9949)
+				reg9950 := Call(__e, __defun__shen_4pair, reg9946, reg9949)
 				reg9952 = reg9950
 			} else {
-				reg9951 := __e.Call(__defun__fail)
+				reg9951 := Call(__e, __defun__fail)
 				reg9952 = reg9951
 			}
 			reg9954 = reg9952
 		} else {
-			reg9953 := __e.Call(__defun__fail)
+			reg9953 := Call(__e, __defun__fail)
 			reg9954 = reg9953
 		}
 		YaccParse := reg9954
 		_ = YaccParse
-		reg9955 := __e.Call(__defun__fail)
+		reg9955 := Call(__e, __defun__fail)
 		reg9956 := PrimEqual(YaccParse, reg9955)
 		if reg9956 == True {
-			reg9957 := __e.Call(__defun__shen_4_5digit_6, V1588)
+			reg9957 := Call(__e, __defun__shen_4_5digit_6, V1588)
 			Parse__shen_4_5digit_6 := reg9957
 			_ = Parse__shen_4_5digit_6
-			reg9958 := __e.Call(__defun__fail)
+			reg9958 := Call(__e, __defun__fail)
 			reg9959 := PrimEqual(reg9958, Parse__shen_4_5digit_6)
 			reg9960 := PrimNot(reg9959)
 			if reg9960 == True {
 				reg9961 := PrimHead(Parse__shen_4_5digit_6)
-				reg9962 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5digit_6)
+				reg9962 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5digit_6)
 				reg9963 := Nil
 				reg9964 := PrimCons(reg9962, reg9963)
-				__ctx.TailApply(__defun__shen_4pair, reg9961, reg9964)
+				__e.TailApply(__defun__shen_4pair, reg9961, reg9964)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<digits>", value: __defun__shen_4_5digits_6})
 
-	__defun__shen_4_5digit_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5digit_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1590 := __args[0]
 		_ = V1590
 		reg9967 := PrimHead(V1590)
 		reg9968 := PrimIsPair(reg9967)
 		if reg9968 == True {
-			reg9969 := __e.Call(__defun__shen_4hdhd, V1590)
+			reg9969 := Call(__e, __defun__shen_4hdhd, V1590)
 			Parse__X := reg9969
 			_ = Parse__X
-			reg9970 := __e.Call(__defun__shen_4numbyte_2, Parse__X)
+			reg9970 := Call(__e, __defun__shen_4numbyte_2, Parse__X)
 			if reg9970 == True {
-				reg9971 := __e.Call(__defun__shen_4tlhd, V1590)
-				reg9972 := __e.Call(__defun__shen_4hdtl, V1590)
-				reg9973 := __e.Call(__defun__shen_4pair, reg9971, reg9972)
+				reg9971 := Call(__e, __defun__shen_4tlhd, V1590)
+				reg9972 := Call(__e, __defun__shen_4hdtl, V1590)
+				reg9973 := Call(__e, __defun__shen_4pair, reg9971, reg9972)
 				reg9974 := PrimHead(reg9973)
-				reg9975 := __e.Call(__defun__shen_4byte_1_6digit, Parse__X)
-				__ctx.TailApply(__defun__shen_4pair, reg9974, reg9975)
+				reg9975 := Call(__e, __defun__shen_4byte_1_6digit, Parse__X)
+				__e.TailApply(__defun__shen_4pair, reg9974, reg9975)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<digit>", value: __defun__shen_4_5digit_6})
 
-	__defun__shen_4byte_1_6digit = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4byte_1_6digit = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1592 := __args[0]
 		_ = V1592
 		reg9979 := MakeNumber(48)
 		reg9980 := PrimEqual(reg9979, V1592)
 		if reg9980 == True {
 			reg9981 := MakeNumber(0)
-			__ctx.Return(reg9981)
+			__e.Return(reg9981)
 			return
 		} else {
 			reg9982 := MakeNumber(49)
 			reg9983 := PrimEqual(reg9982, V1592)
 			if reg9983 == True {
 				reg9984 := MakeNumber(1)
-				__ctx.Return(reg9984)
+				__e.Return(reg9984)
 				return
 			} else {
 				reg9985 := MakeNumber(50)
 				reg9986 := PrimEqual(reg9985, V1592)
 				if reg9986 == True {
 					reg9987 := MakeNumber(2)
-					__ctx.Return(reg9987)
+					__e.Return(reg9987)
 					return
 				} else {
 					reg9988 := MakeNumber(51)
 					reg9989 := PrimEqual(reg9988, V1592)
 					if reg9989 == True {
 						reg9990 := MakeNumber(3)
-						__ctx.Return(reg9990)
+						__e.Return(reg9990)
 						return
 					} else {
 						reg9991 := MakeNumber(52)
 						reg9992 := PrimEqual(reg9991, V1592)
 						if reg9992 == True {
 							reg9993 := MakeNumber(4)
-							__ctx.Return(reg9993)
+							__e.Return(reg9993)
 							return
 						} else {
 							reg9994 := MakeNumber(53)
 							reg9995 := PrimEqual(reg9994, V1592)
 							if reg9995 == True {
 								reg9996 := MakeNumber(5)
-								__ctx.Return(reg9996)
+								__e.Return(reg9996)
 								return
 							} else {
 								reg9997 := MakeNumber(54)
 								reg9998 := PrimEqual(reg9997, V1592)
 								if reg9998 == True {
 									reg9999 := MakeNumber(6)
-									__ctx.Return(reg9999)
+									__e.Return(reg9999)
 									return
 								} else {
 									reg10000 := MakeNumber(55)
 									reg10001 := PrimEqual(reg10000, V1592)
 									if reg10001 == True {
 										reg10002 := MakeNumber(7)
-										__ctx.Return(reg10002)
+										__e.Return(reg10002)
 										return
 									} else {
 										reg10003 := MakeNumber(56)
 										reg10004 := PrimEqual(reg10003, V1592)
 										if reg10004 == True {
 											reg10005 := MakeNumber(8)
-											__ctx.Return(reg10005)
+											__e.Return(reg10005)
 											return
 										} else {
 											reg10006 := MakeNumber(57)
 											reg10007 := PrimEqual(reg10006, V1592)
 											if reg10007 == True {
 												reg10008 := MakeNumber(9)
-												__ctx.Return(reg10008)
+												__e.Return(reg10008)
 												return
 											} else {
 												reg10009 := MakeSymbol("shen.byte->digit")
-												__ctx.TailApply(__defun__shen_4f__error, reg10009)
+												__e.TailApply(__defun__shen_4f__error, reg10009)
 												return
 											}
 										}
@@ -3940,7 +3940,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.byte->digit", value: __defun__shen_4byte_1_6digit})
 
-	__defun__shen_4pre = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4pre = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1597 := __args[0]
 		_ = V1597
 		V1598 := __args[1]
@@ -3949,32 +3949,32 @@ func init() {
 		reg10012 := PrimEqual(reg10011, V1597)
 		if reg10012 == True {
 			reg10013 := MakeNumber(0)
-			__ctx.Return(reg10013)
+			__e.Return(reg10013)
 			return
 		} else {
 			reg10014 := PrimIsPair(V1597)
 			if reg10014 == True {
 				reg10015 := MakeNumber(10)
-				reg10016 := __e.Call(__defun__shen_4expt, reg10015, V1598)
+				reg10016 := Call(__e, __defun__shen_4expt, reg10015, V1598)
 				reg10017 := PrimHead(V1597)
 				reg10018 := PrimNumberMultiply(reg10016, reg10017)
 				reg10019 := PrimTail(V1597)
 				reg10020 := MakeNumber(1)
 				reg10021 := PrimNumberAdd(V1598, reg10020)
-				reg10022 := __e.Call(__defun__shen_4pre, reg10019, reg10021)
+				reg10022 := Call(__e, __defun__shen_4pre, reg10019, reg10021)
 				reg10023 := PrimNumberAdd(reg10018, reg10022)
-				__ctx.Return(reg10023)
+				__e.Return(reg10023)
 				return
 			} else {
 				reg10024 := MakeSymbol("shen.pre")
-				__ctx.TailApply(__defun__shen_4f__error, reg10024)
+				__e.TailApply(__defun__shen_4f__error, reg10024)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.pre", value: __defun__shen_4pre})
 
-	__defun__shen_4post = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4post = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1603 := __args[0]
 		_ = V1603
 		V1604 := __args[1]
@@ -3983,7 +3983,7 @@ func init() {
 		reg10027 := PrimEqual(reg10026, V1603)
 		if reg10027 == True {
 			reg10028 := MakeNumber(0)
-			__ctx.Return(reg10028)
+			__e.Return(reg10028)
 			return
 		} else {
 			reg10029 := PrimIsPair(V1603)
@@ -3991,26 +3991,26 @@ func init() {
 				reg10030 := MakeNumber(10)
 				reg10031 := MakeNumber(0)
 				reg10032 := PrimNumberSubtract(reg10031, V1604)
-				reg10033 := __e.Call(__defun__shen_4expt, reg10030, reg10032)
+				reg10033 := Call(__e, __defun__shen_4expt, reg10030, reg10032)
 				reg10034 := PrimHead(V1603)
 				reg10035 := PrimNumberMultiply(reg10033, reg10034)
 				reg10036 := PrimTail(V1603)
 				reg10037 := MakeNumber(1)
 				reg10038 := PrimNumberAdd(V1604, reg10037)
-				reg10039 := __e.Call(__defun__shen_4post, reg10036, reg10038)
+				reg10039 := Call(__e, __defun__shen_4post, reg10036, reg10038)
 				reg10040 := PrimNumberAdd(reg10035, reg10039)
-				__ctx.Return(reg10040)
+				__e.Return(reg10040)
 				return
 			} else {
 				reg10041 := MakeSymbol("shen.post")
-				__ctx.TailApply(__defun__shen_4f__error, reg10041)
+				__e.TailApply(__defun__shen_4f__error, reg10041)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.post", value: __defun__shen_4post})
 
-	__defun__shen_4expt = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4expt = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1609 := __args[0]
 		_ = V1609
 		V1610 := __args[1]
@@ -4019,7 +4019,7 @@ func init() {
 		reg10044 := PrimEqual(reg10043, V1610)
 		if reg10044 == True {
 			reg10045 := MakeNumber(1)
-			__ctx.Return(reg10045)
+			__e.Return(reg10045)
 			return
 		} else {
 			reg10046 := MakeNumber(0)
@@ -4027,167 +4027,167 @@ func init() {
 			if reg10047 == True {
 				reg10048 := MakeNumber(1)
 				reg10049 := PrimNumberSubtract(V1610, reg10048)
-				reg10050 := __e.Call(__defun__shen_4expt, V1609, reg10049)
+				reg10050 := Call(__e, __defun__shen_4expt, V1609, reg10049)
 				reg10051 := PrimNumberMultiply(V1609, reg10050)
-				__ctx.Return(reg10051)
+				__e.Return(reg10051)
 				return
 			} else {
 				reg10052 := MakeNumber(1)
 				reg10053 := MakeNumber(1)
 				reg10054 := PrimNumberAdd(V1610, reg10053)
-				reg10055 := __e.Call(__defun__shen_4expt, V1609, reg10054)
+				reg10055 := Call(__e, __defun__shen_4expt, V1609, reg10054)
 				reg10056 := PrimNumberDivide(reg10055, V1609)
 				reg10057 := PrimNumberMultiply(reg10052, reg10056)
-				__ctx.Return(reg10057)
+				__e.Return(reg10057)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.expt", value: __defun__shen_4expt})
 
-	__defun__shen_4_5st__input1_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5st__input1_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1612 := __args[0]
 		_ = V1612
-		reg10058 := __e.Call(__defun__shen_4_5st__input_6, V1612)
+		reg10058 := Call(__e, __defun__shen_4_5st__input_6, V1612)
 		Parse__shen_4_5st__input_6 := reg10058
 		_ = Parse__shen_4_5st__input_6
-		reg10059 := __e.Call(__defun__fail)
+		reg10059 := Call(__e, __defun__fail)
 		reg10060 := PrimEqual(reg10059, Parse__shen_4_5st__input_6)
 		reg10061 := PrimNot(reg10060)
 		if reg10061 == True {
 			reg10062 := PrimHead(Parse__shen_4_5st__input_6)
-			reg10063 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
-			__ctx.TailApply(__defun__shen_4pair, reg10062, reg10063)
+			reg10063 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+			__e.TailApply(__defun__shen_4pair, reg10062, reg10063)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<st_input1>", value: __defun__shen_4_5st__input1_6})
 
-	__defun__shen_4_5st__input2_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5st__input2_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1614 := __args[0]
 		_ = V1614
-		reg10066 := __e.Call(__defun__shen_4_5st__input_6, V1614)
+		reg10066 := Call(__e, __defun__shen_4_5st__input_6, V1614)
 		Parse__shen_4_5st__input_6 := reg10066
 		_ = Parse__shen_4_5st__input_6
-		reg10067 := __e.Call(__defun__fail)
+		reg10067 := Call(__e, __defun__fail)
 		reg10068 := PrimEqual(reg10067, Parse__shen_4_5st__input_6)
 		reg10069 := PrimNot(reg10068)
 		if reg10069 == True {
 			reg10070 := PrimHead(Parse__shen_4_5st__input_6)
-			reg10071 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5st__input_6)
-			__ctx.TailApply(__defun__shen_4pair, reg10070, reg10071)
+			reg10071 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5st__input_6)
+			__e.TailApply(__defun__shen_4pair, reg10070, reg10071)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<st_input2>", value: __defun__shen_4_5st__input2_6})
 
-	__defun__shen_4_5comment_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5comment_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1616 := __args[0]
 		_ = V1616
-		reg10074 := __e.Call(__defun__shen_4_5singleline_6, V1616)
+		reg10074 := Call(__e, __defun__shen_4_5singleline_6, V1616)
 		Parse__shen_4_5singleline_6 := reg10074
 		_ = Parse__shen_4_5singleline_6
-		reg10075 := __e.Call(__defun__fail)
+		reg10075 := Call(__e, __defun__fail)
 		reg10076 := PrimEqual(reg10075, Parse__shen_4_5singleline_6)
 		reg10077 := PrimNot(reg10076)
 		var reg10082 Obj
 		if reg10077 == True {
 			reg10078 := PrimHead(Parse__shen_4_5singleline_6)
 			reg10079 := MakeSymbol("shen.skip")
-			reg10080 := __e.Call(__defun__shen_4pair, reg10078, reg10079)
+			reg10080 := Call(__e, __defun__shen_4pair, reg10078, reg10079)
 			reg10082 = reg10080
 		} else {
-			reg10081 := __e.Call(__defun__fail)
+			reg10081 := Call(__e, __defun__fail)
 			reg10082 = reg10081
 		}
 		YaccParse := reg10082
 		_ = YaccParse
-		reg10083 := __e.Call(__defun__fail)
+		reg10083 := Call(__e, __defun__fail)
 		reg10084 := PrimEqual(YaccParse, reg10083)
 		if reg10084 == True {
-			reg10085 := __e.Call(__defun__shen_4_5multiline_6, V1616)
+			reg10085 := Call(__e, __defun__shen_4_5multiline_6, V1616)
 			Parse__shen_4_5multiline_6 := reg10085
 			_ = Parse__shen_4_5multiline_6
-			reg10086 := __e.Call(__defun__fail)
+			reg10086 := Call(__e, __defun__fail)
 			reg10087 := PrimEqual(reg10086, Parse__shen_4_5multiline_6)
 			reg10088 := PrimNot(reg10087)
 			if reg10088 == True {
 				reg10089 := PrimHead(Parse__shen_4_5multiline_6)
 				reg10090 := MakeSymbol("shen.skip")
-				__ctx.TailApply(__defun__shen_4pair, reg10089, reg10090)
+				__e.TailApply(__defun__shen_4pair, reg10089, reg10090)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<comment>", value: __defun__shen_4_5comment_6})
 
-	__defun__shen_4_5singleline_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5singleline_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1618 := __args[0]
 		_ = V1618
-		reg10093 := __e.Call(__defun__shen_4_5backslash_6, V1618)
+		reg10093 := Call(__e, __defun__shen_4_5backslash_6, V1618)
 		Parse__shen_4_5backslash_6 := reg10093
 		_ = Parse__shen_4_5backslash_6
-		reg10094 := __e.Call(__defun__fail)
+		reg10094 := Call(__e, __defun__fail)
 		reg10095 := PrimEqual(reg10094, Parse__shen_4_5backslash_6)
 		reg10096 := PrimNot(reg10095)
 		if reg10096 == True {
-			reg10097 := __e.Call(__defun__shen_4_5backslash_6, Parse__shen_4_5backslash_6)
+			reg10097 := Call(__e, __defun__shen_4_5backslash_6, Parse__shen_4_5backslash_6)
 			Parse__shen_4_5backslash_6 := reg10097
 			_ = Parse__shen_4_5backslash_6
-			reg10098 := __e.Call(__defun__fail)
+			reg10098 := Call(__e, __defun__fail)
 			reg10099 := PrimEqual(reg10098, Parse__shen_4_5backslash_6)
 			reg10100 := PrimNot(reg10099)
 			if reg10100 == True {
-				reg10101 := __e.Call(__defun__shen_4_5anysingle_6, Parse__shen_4_5backslash_6)
+				reg10101 := Call(__e, __defun__shen_4_5anysingle_6, Parse__shen_4_5backslash_6)
 				Parse__shen_4_5anysingle_6 := reg10101
 				_ = Parse__shen_4_5anysingle_6
-				reg10102 := __e.Call(__defun__fail)
+				reg10102 := Call(__e, __defun__fail)
 				reg10103 := PrimEqual(reg10102, Parse__shen_4_5anysingle_6)
 				reg10104 := PrimNot(reg10103)
 				if reg10104 == True {
-					reg10105 := __e.Call(__defun__shen_4_5return_6, Parse__shen_4_5anysingle_6)
+					reg10105 := Call(__e, __defun__shen_4_5return_6, Parse__shen_4_5anysingle_6)
 					Parse__shen_4_5return_6 := reg10105
 					_ = Parse__shen_4_5return_6
-					reg10106 := __e.Call(__defun__fail)
+					reg10106 := Call(__e, __defun__fail)
 					reg10107 := PrimEqual(reg10106, Parse__shen_4_5return_6)
 					reg10108 := PrimNot(reg10107)
 					if reg10108 == True {
 						reg10109 := PrimHead(Parse__shen_4_5return_6)
 						reg10110 := MakeSymbol("shen.skip")
-						__ctx.TailApply(__defun__shen_4pair, reg10109, reg10110)
+						__e.TailApply(__defun__shen_4pair, reg10109, reg10110)
 						return
 					} else {
-						__ctx.TailApply(__defun__fail)
+						__e.TailApply(__defun__fail)
 						return
 					}
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<singleline>", value: __defun__shen_4_5singleline_6})
 
-	__defun__shen_4_5backslash_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5backslash_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1621 := __args[0]
 		_ = V1621
 		reg10116 := PrimHead(V1621)
@@ -4195,7 +4195,7 @@ func init() {
 		var reg10125 Obj
 		if reg10117 == True {
 			reg10118 := MakeNumber(92)
-			reg10119 := __e.Call(__defun__shen_4hdhd, V1621)
+			reg10119 := Call(__e, __defun__shen_4hdhd, V1621)
 			reg10120 := PrimEqual(reg10118, reg10119)
 			var reg10123 Obj
 			if reg10120 == True {
@@ -4211,88 +4211,88 @@ func init() {
 			reg10125 = reg10124
 		}
 		if reg10125 == True {
-			reg10126 := __e.Call(__defun__shen_4tlhd, V1621)
-			reg10127 := __e.Call(__defun__shen_4hdtl, V1621)
-			reg10128 := __e.Call(__defun__shen_4pair, reg10126, reg10127)
+			reg10126 := Call(__e, __defun__shen_4tlhd, V1621)
+			reg10127 := Call(__e, __defun__shen_4hdtl, V1621)
+			reg10128 := Call(__e, __defun__shen_4pair, reg10126, reg10127)
 			NewStream1619 := reg10128
 			_ = NewStream1619
 			reg10129 := PrimHead(NewStream1619)
 			reg10130 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg10129, reg10130)
+			__e.TailApply(__defun__shen_4pair, reg10129, reg10130)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<backslash>", value: __defun__shen_4_5backslash_6})
 
-	__defun__shen_4_5anysingle_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5anysingle_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1623 := __args[0]
 		_ = V1623
-		reg10133 := __e.Call(__defun__shen_4_5non_1return_6, V1623)
+		reg10133 := Call(__e, __defun__shen_4_5non_1return_6, V1623)
 		Parse__shen_4_5non_1return_6 := reg10133
 		_ = Parse__shen_4_5non_1return_6
-		reg10134 := __e.Call(__defun__fail)
+		reg10134 := Call(__e, __defun__fail)
 		reg10135 := PrimEqual(reg10134, Parse__shen_4_5non_1return_6)
 		reg10136 := PrimNot(reg10135)
 		var reg10147 Obj
 		if reg10136 == True {
-			reg10137 := __e.Call(__defun__shen_4_5anysingle_6, Parse__shen_4_5non_1return_6)
+			reg10137 := Call(__e, __defun__shen_4_5anysingle_6, Parse__shen_4_5non_1return_6)
 			Parse__shen_4_5anysingle_6 := reg10137
 			_ = Parse__shen_4_5anysingle_6
-			reg10138 := __e.Call(__defun__fail)
+			reg10138 := Call(__e, __defun__fail)
 			reg10139 := PrimEqual(reg10138, Parse__shen_4_5anysingle_6)
 			reg10140 := PrimNot(reg10139)
 			var reg10145 Obj
 			if reg10140 == True {
 				reg10141 := PrimHead(Parse__shen_4_5anysingle_6)
 				reg10142 := MakeSymbol("shen.skip")
-				reg10143 := __e.Call(__defun__shen_4pair, reg10141, reg10142)
+				reg10143 := Call(__e, __defun__shen_4pair, reg10141, reg10142)
 				reg10145 = reg10143
 			} else {
-				reg10144 := __e.Call(__defun__fail)
+				reg10144 := Call(__e, __defun__fail)
 				reg10145 = reg10144
 			}
 			reg10147 = reg10145
 		} else {
-			reg10146 := __e.Call(__defun__fail)
+			reg10146 := Call(__e, __defun__fail)
 			reg10147 = reg10146
 		}
 		YaccParse := reg10147
 		_ = YaccParse
-		reg10148 := __e.Call(__defun__fail)
+		reg10148 := Call(__e, __defun__fail)
 		reg10149 := PrimEqual(YaccParse, reg10148)
 		if reg10149 == True {
-			reg10150 := __e.Call(__defun___5e_6, V1623)
+			reg10150 := Call(__e, __defun___5e_6, V1623)
 			Parse___5e_6 := reg10150
 			_ = Parse___5e_6
-			reg10151 := __e.Call(__defun__fail)
+			reg10151 := Call(__e, __defun__fail)
 			reg10152 := PrimEqual(reg10151, Parse___5e_6)
 			reg10153 := PrimNot(reg10152)
 			if reg10153 == True {
 				reg10154 := PrimHead(Parse___5e_6)
 				reg10155 := MakeSymbol("shen.skip")
-				__ctx.TailApply(__defun__shen_4pair, reg10154, reg10155)
+				__e.TailApply(__defun__shen_4pair, reg10154, reg10155)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<anysingle>", value: __defun__shen_4_5anysingle_6})
 
-	__defun__shen_4_5non_1return_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5non_1return_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1625 := __args[0]
 		_ = V1625
 		reg10158 := PrimHead(V1625)
 		reg10159 := PrimIsPair(reg10158)
 		if reg10159 == True {
-			reg10160 := __e.Call(__defun__shen_4hdhd, V1625)
+			reg10160 := Call(__e, __defun__shen_4hdhd, V1625)
 			Parse__X := reg10160
 			_ = Parse__X
 			reg10161 := MakeNumber(10)
@@ -4300,34 +4300,34 @@ func init() {
 			reg10163 := Nil
 			reg10164 := PrimCons(reg10162, reg10163)
 			reg10165 := PrimCons(reg10161, reg10164)
-			reg10166 := __e.Call(__defun__element_2, Parse__X, reg10165)
+			reg10166 := Call(__e, __defun__element_2, Parse__X, reg10165)
 			reg10167 := PrimNot(reg10166)
 			if reg10167 == True {
-				reg10168 := __e.Call(__defun__shen_4tlhd, V1625)
-				reg10169 := __e.Call(__defun__shen_4hdtl, V1625)
-				reg10170 := __e.Call(__defun__shen_4pair, reg10168, reg10169)
+				reg10168 := Call(__e, __defun__shen_4tlhd, V1625)
+				reg10169 := Call(__e, __defun__shen_4hdtl, V1625)
+				reg10170 := Call(__e, __defun__shen_4pair, reg10168, reg10169)
 				reg10171 := PrimHead(reg10170)
 				reg10172 := MakeSymbol("shen.skip")
-				__ctx.TailApply(__defun__shen_4pair, reg10171, reg10172)
+				__e.TailApply(__defun__shen_4pair, reg10171, reg10172)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<non-return>", value: __defun__shen_4_5non_1return_6})
 
-	__defun__shen_4_5return_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5return_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1627 := __args[0]
 		_ = V1627
 		reg10176 := PrimHead(V1627)
 		reg10177 := PrimIsPair(reg10176)
 		if reg10177 == True {
-			reg10178 := __e.Call(__defun__shen_4hdhd, V1627)
+			reg10178 := Call(__e, __defun__shen_4hdhd, V1627)
 			Parse__X := reg10178
 			_ = Parse__X
 			reg10179 := MakeNumber(10)
@@ -4335,70 +4335,70 @@ func init() {
 			reg10181 := Nil
 			reg10182 := PrimCons(reg10180, reg10181)
 			reg10183 := PrimCons(reg10179, reg10182)
-			reg10184 := __e.Call(__defun__element_2, Parse__X, reg10183)
+			reg10184 := Call(__e, __defun__element_2, Parse__X, reg10183)
 			if reg10184 == True {
-				reg10185 := __e.Call(__defun__shen_4tlhd, V1627)
-				reg10186 := __e.Call(__defun__shen_4hdtl, V1627)
-				reg10187 := __e.Call(__defun__shen_4pair, reg10185, reg10186)
+				reg10185 := Call(__e, __defun__shen_4tlhd, V1627)
+				reg10186 := Call(__e, __defun__shen_4hdtl, V1627)
+				reg10187 := Call(__e, __defun__shen_4pair, reg10185, reg10186)
 				reg10188 := PrimHead(reg10187)
 				reg10189 := MakeSymbol("shen.skip")
-				__ctx.TailApply(__defun__shen_4pair, reg10188, reg10189)
+				__e.TailApply(__defun__shen_4pair, reg10188, reg10189)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<return>", value: __defun__shen_4_5return_6})
 
-	__defun__shen_4_5multiline_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5multiline_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1629 := __args[0]
 		_ = V1629
-		reg10193 := __e.Call(__defun__shen_4_5backslash_6, V1629)
+		reg10193 := Call(__e, __defun__shen_4_5backslash_6, V1629)
 		Parse__shen_4_5backslash_6 := reg10193
 		_ = Parse__shen_4_5backslash_6
-		reg10194 := __e.Call(__defun__fail)
+		reg10194 := Call(__e, __defun__fail)
 		reg10195 := PrimEqual(reg10194, Parse__shen_4_5backslash_6)
 		reg10196 := PrimNot(reg10195)
 		if reg10196 == True {
-			reg10197 := __e.Call(__defun__shen_4_5times_6, Parse__shen_4_5backslash_6)
+			reg10197 := Call(__e, __defun__shen_4_5times_6, Parse__shen_4_5backslash_6)
 			Parse__shen_4_5times_6 := reg10197
 			_ = Parse__shen_4_5times_6
-			reg10198 := __e.Call(__defun__fail)
+			reg10198 := Call(__e, __defun__fail)
 			reg10199 := PrimEqual(reg10198, Parse__shen_4_5times_6)
 			reg10200 := PrimNot(reg10199)
 			if reg10200 == True {
-				reg10201 := __e.Call(__defun__shen_4_5anymulti_6, Parse__shen_4_5times_6)
+				reg10201 := Call(__e, __defun__shen_4_5anymulti_6, Parse__shen_4_5times_6)
 				Parse__shen_4_5anymulti_6 := reg10201
 				_ = Parse__shen_4_5anymulti_6
-				reg10202 := __e.Call(__defun__fail)
+				reg10202 := Call(__e, __defun__fail)
 				reg10203 := PrimEqual(reg10202, Parse__shen_4_5anymulti_6)
 				reg10204 := PrimNot(reg10203)
 				if reg10204 == True {
 					reg10205 := PrimHead(Parse__shen_4_5anymulti_6)
 					reg10206 := MakeSymbol("shen.skip")
-					__ctx.TailApply(__defun__shen_4pair, reg10205, reg10206)
+					__e.TailApply(__defun__shen_4pair, reg10205, reg10206)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<multiline>", value: __defun__shen_4_5multiline_6})
 
-	__defun__shen_4_5times_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5times_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1632 := __args[0]
 		_ = V1632
 		reg10211 := PrimHead(V1632)
@@ -4406,7 +4406,7 @@ func init() {
 		var reg10220 Obj
 		if reg10212 == True {
 			reg10213 := MakeNumber(42)
-			reg10214 := __e.Call(__defun__shen_4hdhd, V1632)
+			reg10214 := Call(__e, __defun__shen_4hdhd, V1632)
 			reg10215 := PrimEqual(reg10213, reg10214)
 			var reg10218 Obj
 			if reg10215 == True {
@@ -4422,198 +4422,198 @@ func init() {
 			reg10220 = reg10219
 		}
 		if reg10220 == True {
-			reg10221 := __e.Call(__defun__shen_4tlhd, V1632)
-			reg10222 := __e.Call(__defun__shen_4hdtl, V1632)
-			reg10223 := __e.Call(__defun__shen_4pair, reg10221, reg10222)
+			reg10221 := Call(__e, __defun__shen_4tlhd, V1632)
+			reg10222 := Call(__e, __defun__shen_4hdtl, V1632)
+			reg10223 := Call(__e, __defun__shen_4pair, reg10221, reg10222)
 			NewStream1630 := reg10223
 			_ = NewStream1630
 			reg10224 := PrimHead(NewStream1630)
 			reg10225 := MakeSymbol("shen.skip")
-			__ctx.TailApply(__defun__shen_4pair, reg10224, reg10225)
+			__e.TailApply(__defun__shen_4pair, reg10224, reg10225)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<times>", value: __defun__shen_4_5times_6})
 
-	__defun__shen_4_5anymulti_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5anymulti_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1634 := __args[0]
 		_ = V1634
-		reg10228 := __e.Call(__defun__shen_4_5comment_6, V1634)
+		reg10228 := Call(__e, __defun__shen_4_5comment_6, V1634)
 		Parse__shen_4_5comment_6 := reg10228
 		_ = Parse__shen_4_5comment_6
-		reg10229 := __e.Call(__defun__fail)
+		reg10229 := Call(__e, __defun__fail)
 		reg10230 := PrimEqual(reg10229, Parse__shen_4_5comment_6)
 		reg10231 := PrimNot(reg10230)
 		var reg10242 Obj
 		if reg10231 == True {
-			reg10232 := __e.Call(__defun__shen_4_5anymulti_6, Parse__shen_4_5comment_6)
+			reg10232 := Call(__e, __defun__shen_4_5anymulti_6, Parse__shen_4_5comment_6)
 			Parse__shen_4_5anymulti_6 := reg10232
 			_ = Parse__shen_4_5anymulti_6
-			reg10233 := __e.Call(__defun__fail)
+			reg10233 := Call(__e, __defun__fail)
 			reg10234 := PrimEqual(reg10233, Parse__shen_4_5anymulti_6)
 			reg10235 := PrimNot(reg10234)
 			var reg10240 Obj
 			if reg10235 == True {
 				reg10236 := PrimHead(Parse__shen_4_5anymulti_6)
 				reg10237 := MakeSymbol("shen.skip")
-				reg10238 := __e.Call(__defun__shen_4pair, reg10236, reg10237)
+				reg10238 := Call(__e, __defun__shen_4pair, reg10236, reg10237)
 				reg10240 = reg10238
 			} else {
-				reg10239 := __e.Call(__defun__fail)
+				reg10239 := Call(__e, __defun__fail)
 				reg10240 = reg10239
 			}
 			reg10242 = reg10240
 		} else {
-			reg10241 := __e.Call(__defun__fail)
+			reg10241 := Call(__e, __defun__fail)
 			reg10242 = reg10241
 		}
 		YaccParse := reg10242
 		_ = YaccParse
-		reg10243 := __e.Call(__defun__fail)
+		reg10243 := Call(__e, __defun__fail)
 		reg10244 := PrimEqual(YaccParse, reg10243)
 		if reg10244 == True {
-			reg10245 := __e.Call(__defun__shen_4_5times_6, V1634)
+			reg10245 := Call(__e, __defun__shen_4_5times_6, V1634)
 			Parse__shen_4_5times_6 := reg10245
 			_ = Parse__shen_4_5times_6
-			reg10246 := __e.Call(__defun__fail)
+			reg10246 := Call(__e, __defun__fail)
 			reg10247 := PrimEqual(reg10246, Parse__shen_4_5times_6)
 			reg10248 := PrimNot(reg10247)
 			var reg10259 Obj
 			if reg10248 == True {
-				reg10249 := __e.Call(__defun__shen_4_5backslash_6, Parse__shen_4_5times_6)
+				reg10249 := Call(__e, __defun__shen_4_5backslash_6, Parse__shen_4_5times_6)
 				Parse__shen_4_5backslash_6 := reg10249
 				_ = Parse__shen_4_5backslash_6
-				reg10250 := __e.Call(__defun__fail)
+				reg10250 := Call(__e, __defun__fail)
 				reg10251 := PrimEqual(reg10250, Parse__shen_4_5backslash_6)
 				reg10252 := PrimNot(reg10251)
 				var reg10257 Obj
 				if reg10252 == True {
 					reg10253 := PrimHead(Parse__shen_4_5backslash_6)
 					reg10254 := MakeSymbol("shen.skip")
-					reg10255 := __e.Call(__defun__shen_4pair, reg10253, reg10254)
+					reg10255 := Call(__e, __defun__shen_4pair, reg10253, reg10254)
 					reg10257 = reg10255
 				} else {
-					reg10256 := __e.Call(__defun__fail)
+					reg10256 := Call(__e, __defun__fail)
 					reg10257 = reg10256
 				}
 				reg10259 = reg10257
 			} else {
-				reg10258 := __e.Call(__defun__fail)
+				reg10258 := Call(__e, __defun__fail)
 				reg10259 = reg10258
 			}
 			YaccParse := reg10259
 			_ = YaccParse
-			reg10260 := __e.Call(__defun__fail)
+			reg10260 := Call(__e, __defun__fail)
 			reg10261 := PrimEqual(YaccParse, reg10260)
 			if reg10261 == True {
 				reg10262 := PrimHead(V1634)
 				reg10263 := PrimIsPair(reg10262)
 				if reg10263 == True {
-					reg10264 := __e.Call(__defun__shen_4hdhd, V1634)
+					reg10264 := Call(__e, __defun__shen_4hdhd, V1634)
 					Parse__X := reg10264
 					_ = Parse__X
-					reg10265 := __e.Call(__defun__shen_4tlhd, V1634)
-					reg10266 := __e.Call(__defun__shen_4hdtl, V1634)
-					reg10267 := __e.Call(__defun__shen_4pair, reg10265, reg10266)
-					reg10268 := __e.Call(__defun__shen_4_5anymulti_6, reg10267)
+					reg10265 := Call(__e, __defun__shen_4tlhd, V1634)
+					reg10266 := Call(__e, __defun__shen_4hdtl, V1634)
+					reg10267 := Call(__e, __defun__shen_4pair, reg10265, reg10266)
+					reg10268 := Call(__e, __defun__shen_4_5anymulti_6, reg10267)
 					Parse__shen_4_5anymulti_6 := reg10268
 					_ = Parse__shen_4_5anymulti_6
-					reg10269 := __e.Call(__defun__fail)
+					reg10269 := Call(__e, __defun__fail)
 					reg10270 := PrimEqual(reg10269, Parse__shen_4_5anymulti_6)
 					reg10271 := PrimNot(reg10270)
 					if reg10271 == True {
 						reg10272 := PrimHead(Parse__shen_4_5anymulti_6)
 						reg10273 := MakeSymbol("shen.skip")
-						__ctx.TailApply(__defun__shen_4pair, reg10272, reg10273)
+						__e.TailApply(__defun__shen_4pair, reg10272, reg10273)
 						return
 					} else {
-						__ctx.TailApply(__defun__fail)
+						__e.TailApply(__defun__fail)
 						return
 					}
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.Return(YaccParse)
+				__e.Return(YaccParse)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<anymulti>", value: __defun__shen_4_5anymulti_6})
 
-	__defun__shen_4_5whitespaces_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5whitespaces_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1636 := __args[0]
 		_ = V1636
-		reg10277 := __e.Call(__defun__shen_4_5whitespace_6, V1636)
+		reg10277 := Call(__e, __defun__shen_4_5whitespace_6, V1636)
 		Parse__shen_4_5whitespace_6 := reg10277
 		_ = Parse__shen_4_5whitespace_6
-		reg10278 := __e.Call(__defun__fail)
+		reg10278 := Call(__e, __defun__fail)
 		reg10279 := PrimEqual(reg10278, Parse__shen_4_5whitespace_6)
 		reg10280 := PrimNot(reg10279)
 		var reg10291 Obj
 		if reg10280 == True {
-			reg10281 := __e.Call(__defun__shen_4_5whitespaces_6, Parse__shen_4_5whitespace_6)
+			reg10281 := Call(__e, __defun__shen_4_5whitespaces_6, Parse__shen_4_5whitespace_6)
 			Parse__shen_4_5whitespaces_6 := reg10281
 			_ = Parse__shen_4_5whitespaces_6
-			reg10282 := __e.Call(__defun__fail)
+			reg10282 := Call(__e, __defun__fail)
 			reg10283 := PrimEqual(reg10282, Parse__shen_4_5whitespaces_6)
 			reg10284 := PrimNot(reg10283)
 			var reg10289 Obj
 			if reg10284 == True {
 				reg10285 := PrimHead(Parse__shen_4_5whitespaces_6)
 				reg10286 := MakeSymbol("shen.skip")
-				reg10287 := __e.Call(__defun__shen_4pair, reg10285, reg10286)
+				reg10287 := Call(__e, __defun__shen_4pair, reg10285, reg10286)
 				reg10289 = reg10287
 			} else {
-				reg10288 := __e.Call(__defun__fail)
+				reg10288 := Call(__e, __defun__fail)
 				reg10289 = reg10288
 			}
 			reg10291 = reg10289
 		} else {
-			reg10290 := __e.Call(__defun__fail)
+			reg10290 := Call(__e, __defun__fail)
 			reg10291 = reg10290
 		}
 		YaccParse := reg10291
 		_ = YaccParse
-		reg10292 := __e.Call(__defun__fail)
+		reg10292 := Call(__e, __defun__fail)
 		reg10293 := PrimEqual(YaccParse, reg10292)
 		if reg10293 == True {
-			reg10294 := __e.Call(__defun__shen_4_5whitespace_6, V1636)
+			reg10294 := Call(__e, __defun__shen_4_5whitespace_6, V1636)
 			Parse__shen_4_5whitespace_6 := reg10294
 			_ = Parse__shen_4_5whitespace_6
-			reg10295 := __e.Call(__defun__fail)
+			reg10295 := Call(__e, __defun__fail)
 			reg10296 := PrimEqual(reg10295, Parse__shen_4_5whitespace_6)
 			reg10297 := PrimNot(reg10296)
 			if reg10297 == True {
 				reg10298 := PrimHead(Parse__shen_4_5whitespace_6)
 				reg10299 := MakeSymbol("shen.skip")
-				__ctx.TailApply(__defun__shen_4pair, reg10298, reg10299)
+				__e.TailApply(__defun__shen_4pair, reg10298, reg10299)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<whitespaces>", value: __defun__shen_4_5whitespaces_6})
 
-	__defun__shen_4_5whitespace_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5whitespace_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1638 := __args[0]
 		_ = V1638
 		reg10302 := PrimHead(V1638)
 		reg10303 := PrimIsPair(reg10302)
 		if reg10303 == True {
-			reg10304 := __e.Call(__defun__shen_4hdhd, V1638)
+			reg10304 := Call(__e, __defun__shen_4hdhd, V1638)
 			Parse__X := reg10304
 			_ = Parse__X
 			Parse__Case := Parse__X
@@ -4672,32 +4672,32 @@ func init() {
 				reg10327 = reg10326
 			}
 			if reg10327 == True {
-				reg10328 := __e.Call(__defun__shen_4tlhd, V1638)
-				reg10329 := __e.Call(__defun__shen_4hdtl, V1638)
-				reg10330 := __e.Call(__defun__shen_4pair, reg10328, reg10329)
+				reg10328 := Call(__e, __defun__shen_4tlhd, V1638)
+				reg10329 := Call(__e, __defun__shen_4hdtl, V1638)
+				reg10330 := Call(__e, __defun__shen_4pair, reg10328, reg10329)
 				reg10331 := PrimHead(reg10330)
 				reg10332 := MakeSymbol("shen.skip")
-				__ctx.TailApply(__defun__shen_4pair, reg10331, reg10332)
+				__e.TailApply(__defun__shen_4pair, reg10331, reg10332)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<whitespace>", value: __defun__shen_4_5whitespace_6})
 
-	__defun__shen_4cons__form = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4cons__form = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1640 := __args[0]
 		_ = V1640
 		reg10336 := Nil
 		reg10337 := PrimEqual(reg10336, V1640)
 		if reg10337 == True {
 			reg10338 := Nil
-			__ctx.Return(reg10338)
+			__e.Return(reg10338)
 			return
 		} else {
 			reg10339 := PrimIsPair(V1640)
@@ -4782,7 +4782,7 @@ func init() {
 				reg10377 := PrimTail(reg10376)
 				reg10378 := PrimCons(reg10375, reg10377)
 				reg10379 := PrimCons(reg10374, reg10378)
-				__ctx.Return(reg10379)
+				__e.Return(reg10379)
 				return
 			} else {
 				reg10380 := PrimIsPair(V1640)
@@ -4790,16 +4790,16 @@ func init() {
 					reg10381 := MakeSymbol("cons")
 					reg10382 := PrimHead(V1640)
 					reg10383 := PrimTail(V1640)
-					reg10384 := __e.Call(__defun__shen_4cons__form, reg10383)
+					reg10384 := Call(__e, __defun__shen_4cons__form, reg10383)
 					reg10385 := Nil
 					reg10386 := PrimCons(reg10384, reg10385)
 					reg10387 := PrimCons(reg10382, reg10386)
 					reg10388 := PrimCons(reg10381, reg10387)
-					__ctx.Return(reg10388)
+					__e.Return(reg10388)
 					return
 				} else {
 					reg10389 := MakeSymbol("shen.cons_form")
-					__ctx.TailApply(__defun__shen_4f__error, reg10389)
+					__e.TailApply(__defun__shen_4f__error, reg10389)
 					return
 				}
 			}
@@ -4807,7 +4807,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.cons_form", value: __defun__shen_4cons__form})
 
-	__defun__shen_4package_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4package_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1645 := __args[0]
 		_ = V1645
 		V1646 := __args[1]
@@ -4870,8 +4870,8 @@ func init() {
 		if reg10415 == True {
 			reg10416 := PrimTail(V1645)
 			reg10417 := PrimHead(reg10416)
-			reg10418 := __e.Call(__defun__explode, reg10417)
-			__ctx.TailApply(__defun__append, reg10418, V1646)
+			reg10418 := Call(__e, __defun__explode, reg10417)
+			__e.TailApply(__defun__append, reg10418, V1646)
 			return
 		} else {
 			reg10420 := PrimIsPair(V1645)
@@ -4951,7 +4951,7 @@ func init() {
 				reg10453 := PrimTail(V1645)
 				reg10454 := PrimTail(reg10453)
 				reg10455 := PrimTail(reg10454)
-				__ctx.TailApply(__defun__append, reg10455, V1646)
+				__e.TailApply(__defun__append, reg10455, V1646)
 				return
 			} else {
 				reg10457 := PrimIsPair(V1645)
@@ -5012,12 +5012,12 @@ func init() {
 					reg10481 := PrimTail(V1645)
 					reg10482 := PrimTail(reg10481)
 					reg10483 := PrimHead(reg10482)
-					reg10484 := __e.Call(__defun__shen_4eval_1without_1macros, reg10483)
+					reg10484 := Call(__e, __defun__shen_4eval_1without_1macros, reg10483)
 					ListofExceptions := reg10484
 					_ = ListofExceptions
 					reg10485 := PrimTail(V1645)
 					reg10486 := PrimHead(reg10485)
-					reg10487 := __e.Call(__defun__shen_4record_1exceptions, ListofExceptions, reg10486)
+					reg10487 := Call(__e, __defun__shen_4record_1exceptions, ListofExceptions, reg10486)
 					External := reg10487
 					_ = External
 					reg10488 := PrimTail(V1645)
@@ -5028,26 +5028,26 @@ func init() {
 					reg10493 := PrimIntern(reg10492)
 					PackageNameDot := reg10493
 					_ = PackageNameDot
-					reg10494 := __e.Call(__defun__explode, PackageNameDot)
+					reg10494 := Call(__e, __defun__explode, PackageNameDot)
 					ExpPackageNameDot := reg10494
 					_ = ExpPackageNameDot
 					reg10495 := PrimTail(V1645)
 					reg10496 := PrimTail(reg10495)
 					reg10497 := PrimTail(reg10496)
-					reg10498 := __e.Call(__defun__shen_4packageh, PackageNameDot, ListofExceptions, reg10497, ExpPackageNameDot)
+					reg10498 := Call(__e, __defun__shen_4packageh, PackageNameDot, ListofExceptions, reg10497, ExpPackageNameDot)
 					Packaged := reg10498
 					_ = Packaged
 					reg10499 := PrimTail(V1645)
 					reg10500 := PrimHead(reg10499)
-					reg10501 := __e.Call(__defun__shen_4internal_1symbols, ExpPackageNameDot, Packaged)
-					reg10502 := __e.Call(__defun__shen_4record_1internal, reg10500, reg10501)
+					reg10501 := Call(__e, __defun__shen_4internal_1symbols, ExpPackageNameDot, Packaged)
+					reg10502 := Call(__e, __defun__shen_4record_1internal, reg10500, reg10501)
 					Internal := reg10502
 					_ = Internal
-					__ctx.TailApply(__defun__append, Packaged, V1646)
+					__e.TailApply(__defun__append, Packaged, V1646)
 					return
 				} else {
 					reg10504 := PrimCons(V1645, V1646)
-					__ctx.Return(reg10504)
+					__e.Return(reg10504)
 					return
 				}
 			}
@@ -5055,69 +5055,69 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.package-macro", value: __defun__shen_4package_1macro})
 
-	__defun__shen_4record_1exceptions = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4record_1exceptions = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1649 := __args[0]
 		_ = V1649
 		V1650 := __args[1]
 		_ = V1650
-		reg10505 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg10505 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg10506 := MakeSymbol("shen.external-symbols")
 			reg10507 := MakeSymbol("*property-vector*")
 			reg10508 := PrimValue(reg10507)
-			__ctx.TailApply(__defun__get, V1650, reg10506, reg10508)
+			__e.TailApply(__defun__get, V1650, reg10506, reg10508)
 			return
 		}, 0)
-		reg10510 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg10510 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg10511 := Nil
-			__ctx.Return(reg10511)
+			__e.Return(reg10511)
 			return
 		}, 1)
-		reg10512 := __e.Try(reg10505).Catch(reg10510)
+		reg10512 := Try(__e, reg10505).Catch(reg10510)
 		CurrExceptions := reg10512
 		_ = CurrExceptions
-		reg10513 := __e.Call(__defun__union, V1649, CurrExceptions)
+		reg10513 := Call(__e, __defun__union, V1649, CurrExceptions)
 		AllExceptions := reg10513
 		_ = AllExceptions
 		reg10514 := MakeSymbol("shen.external-symbols")
 		reg10515 := MakeSymbol("*property-vector*")
 		reg10516 := PrimValue(reg10515)
-		__ctx.TailApply(__defun__put, V1650, reg10514, AllExceptions, reg10516)
+		__e.TailApply(__defun__put, V1650, reg10514, AllExceptions, reg10516)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.record-exceptions", value: __defun__shen_4record_1exceptions})
 
-	__defun__shen_4record_1internal = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4record_1internal = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1653 := __args[0]
 		_ = V1653
 		V1654 := __args[1]
 		_ = V1654
 		reg10518 := MakeSymbol("shen.internal-symbols")
-		reg10519 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg10519 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg10520 := MakeSymbol("shen.internal-symbols")
 			reg10521 := MakeSymbol("*property-vector*")
 			reg10522 := PrimValue(reg10521)
-			__ctx.TailApply(__defun__get, V1653, reg10520, reg10522)
+			__e.TailApply(__defun__get, V1653, reg10520, reg10522)
 			return
 		}, 0)
-		reg10524 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg10524 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg10525 := Nil
-			__ctx.Return(reg10525)
+			__e.Return(reg10525)
 			return
 		}, 1)
-		reg10526 := __e.Try(reg10519).Catch(reg10524)
-		reg10527 := __e.Call(__defun__union, V1654, reg10526)
+		reg10526 := Try(__e, reg10519).Catch(reg10524)
+		reg10527 := Call(__e, __defun__union, V1654, reg10526)
 		reg10528 := MakeSymbol("*property-vector*")
 		reg10529 := PrimValue(reg10528)
-		__ctx.TailApply(__defun__put, V1653, reg10518, reg10527, reg10529)
+		__e.TailApply(__defun__put, V1653, reg10518, reg10527, reg10529)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.record-internal", value: __defun__shen_4record_1internal})
 
-	__defun__shen_4internal_1symbols = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4internal_1symbols = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1665 := __args[0]
 		_ = V1665
 		V1666 := __args[1]
@@ -5125,8 +5125,8 @@ func init() {
 		reg10531 := PrimIsSymbol(V1666)
 		var reg10538 Obj
 		if reg10531 == True {
-			reg10532 := __e.Call(__defun__explode, V1666)
-			reg10533 := __e.Call(__defun__shen_4prefix_2, V1665, reg10532)
+			reg10532 := Call(__e, __defun__explode, V1666)
+			reg10533 := Call(__e, __defun__shen_4prefix_2, V1665, reg10532)
 			var reg10536 Obj
 			if reg10533 == True {
 				reg10534 := True
@@ -5143,27 +5143,27 @@ func init() {
 		if reg10538 == True {
 			reg10539 := Nil
 			reg10540 := PrimCons(V1666, reg10539)
-			__ctx.Return(reg10540)
+			__e.Return(reg10540)
 			return
 		} else {
 			reg10541 := PrimIsPair(V1666)
 			if reg10541 == True {
 				reg10542 := PrimHead(V1666)
-				reg10543 := __e.Call(__defun__shen_4internal_1symbols, V1665, reg10542)
+				reg10543 := Call(__e, __defun__shen_4internal_1symbols, V1665, reg10542)
 				reg10544 := PrimTail(V1666)
-				reg10545 := __e.Call(__defun__shen_4internal_1symbols, V1665, reg10544)
-				__ctx.TailApply(__defun__union, reg10543, reg10545)
+				reg10545 := Call(__e, __defun__shen_4internal_1symbols, V1665, reg10544)
+				__e.TailApply(__defun__union, reg10543, reg10545)
 				return
 			} else {
 				reg10547 := Nil
-				__ctx.Return(reg10547)
+				__e.Return(reg10547)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.internal-symbols", value: __defun__shen_4internal_1symbols})
 
-	__defun__shen_4packageh = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4packageh = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1683 := __args[0]
 		_ = V1683
 		V1684 := __args[1]
@@ -5175,14 +5175,14 @@ func init() {
 		reg10548 := PrimIsPair(V1685)
 		if reg10548 == True {
 			reg10549 := PrimHead(V1685)
-			reg10550 := __e.Call(__defun__shen_4packageh, V1683, V1684, reg10549, V1686)
+			reg10550 := Call(__e, __defun__shen_4packageh, V1683, V1684, reg10549, V1686)
 			reg10551 := PrimTail(V1685)
-			reg10552 := __e.Call(__defun__shen_4packageh, V1683, V1684, reg10551, V1686)
+			reg10552 := Call(__e, __defun__shen_4packageh, V1683, V1684, reg10551, V1686)
 			reg10553 := PrimCons(reg10550, reg10552)
-			__ctx.Return(reg10553)
+			__e.Return(reg10553)
 			return
 		} else {
-			reg10554 := __e.Call(__defun__shen_4sysfunc_2, V1685)
+			reg10554 := Call(__e, __defun__shen_4sysfunc_2, V1685)
 			var reg10578 Obj
 			if reg10554 == True {
 				reg10555 := True
@@ -5194,19 +5194,19 @@ func init() {
 					reg10557 := True
 					reg10574 = reg10557
 				} else {
-					reg10558 := __e.Call(__defun__element_2, V1685, V1684)
+					reg10558 := Call(__e, __defun__element_2, V1685, V1684)
 					var reg10570 Obj
 					if reg10558 == True {
 						reg10559 := True
 						reg10570 = reg10559
 					} else {
-						reg10560 := __e.Call(__defun__shen_4doubleunderline_2, V1685)
+						reg10560 := Call(__e, __defun__shen_4doubleunderline_2, V1685)
 						var reg10566 Obj
 						if reg10560 == True {
 							reg10561 := True
 							reg10566 = reg10561
 						} else {
-							reg10562 := __e.Call(__defun__shen_4singleunderline_2, V1685)
+							reg10562 := Call(__e, __defun__shen_4singleunderline_2, V1685)
 							var reg10565 Obj
 							if reg10562 == True {
 								reg10563 := True
@@ -5248,13 +5248,13 @@ func init() {
 				reg10578 = reg10577
 			}
 			if reg10578 == True {
-				__ctx.Return(V1685)
+				__e.Return(V1685)
 				return
 			} else {
 				reg10579 := PrimIsSymbol(V1685)
 				var reg10605 Obj
 				if reg10579 == True {
-					reg10580 := __e.Call(__defun__explode, V1685)
+					reg10580 := Call(__e, __defun__explode, V1685)
 					ExplodeX := reg10580
 					_ = ExplodeX
 					reg10581 := MakeString("s")
@@ -5268,11 +5268,11 @@ func init() {
 					reg10589 := PrimCons(reg10583, reg10588)
 					reg10590 := PrimCons(reg10582, reg10589)
 					reg10591 := PrimCons(reg10581, reg10590)
-					reg10592 := __e.Call(__defun__shen_4prefix_2, reg10591, ExplodeX)
+					reg10592 := Call(__e, __defun__shen_4prefix_2, reg10591, ExplodeX)
 					reg10593 := PrimNot(reg10592)
 					var reg10600 Obj
 					if reg10593 == True {
-						reg10594 := __e.Call(__defun__shen_4prefix_2, V1686, ExplodeX)
+						reg10594 := Call(__e, __defun__shen_4prefix_2, V1686, ExplodeX)
 						reg10595 := PrimNot(reg10594)
 						var reg10598 Obj
 						if reg10595 == True {
@@ -5301,10 +5301,10 @@ func init() {
 					reg10605 = reg10604
 				}
 				if reg10605 == True {
-					__ctx.TailApply(__defun__concat, V1683, V1685)
+					__e.TailApply(__defun__concat, V1683, V1685)
 					return
 				} else {
-					__ctx.Return(V1685)
+					__e.Return(V1685)
 					return
 				}
 			}

--- a/cmd/shen/sequent.go
+++ b/cmd/shen/sequent.go
@@ -60,12 +60,12 @@ var __defun__shen_4update_1demodulation_1function Obj       // shen.update-demod
 var __defun__shen_4default_1rule Obj                        // shen.default-rule
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5949 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg5949)
+		__e.Return(reg5949)
 		return
 	}, 0))
-	__defun__shen_4datatype_1error = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4datatype_1error = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1692 := __args[0]
 		_ = V1692
 		reg5950 := PrimIsPair(V1692)
@@ -109,279 +109,279 @@ func init() {
 			reg5967 := MakeString("datatype syntax error here:\n\n ")
 			reg5968 := MakeNumber(50)
 			reg5969 := PrimHead(V1692)
-			reg5970 := __e.Call(__defun__shen_4next_150, reg5968, reg5969)
+			reg5970 := Call(__e, __defun__shen_4next_150, reg5968, reg5969)
 			reg5971 := MakeString("\n")
 			reg5972 := MakeSymbol("shen.a")
-			reg5973 := __e.Call(__defun__shen_4app, reg5970, reg5971, reg5972)
+			reg5973 := Call(__e, __defun__shen_4app, reg5970, reg5971, reg5972)
 			reg5974 := PrimStringConcat(reg5967, reg5973)
 			reg5975 := PrimSimpleError(reg5974)
-			__ctx.Return(reg5975)
+			__e.Return(reg5975)
 			return
 		} else {
 			reg5976 := MakeSymbol("shen.datatype-error")
-			__ctx.TailApply(__defun__shen_4f__error, reg5976)
+			__e.TailApply(__defun__shen_4f__error, reg5976)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.datatype-error", value: __defun__shen_4datatype_1error})
 
-	__defun__shen_4_5datatype_1rules_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5datatype_1rules_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1694 := __args[0]
 		_ = V1694
-		reg5978 := __e.Call(__defun__shen_4_5datatype_1rule_6, V1694)
+		reg5978 := Call(__e, __defun__shen_4_5datatype_1rule_6, V1694)
 		Parse__shen_4_5datatype_1rule_6 := reg5978
 		_ = Parse__shen_4_5datatype_1rule_6
-		reg5979 := __e.Call(__defun__fail)
+		reg5979 := Call(__e, __defun__fail)
 		reg5980 := PrimEqual(reg5979, Parse__shen_4_5datatype_1rule_6)
 		reg5981 := PrimNot(reg5980)
 		var reg5994 Obj
 		if reg5981 == True {
-			reg5982 := __e.Call(__defun__shen_4_5datatype_1rules_6, Parse__shen_4_5datatype_1rule_6)
+			reg5982 := Call(__e, __defun__shen_4_5datatype_1rules_6, Parse__shen_4_5datatype_1rule_6)
 			Parse__shen_4_5datatype_1rules_6 := reg5982
 			_ = Parse__shen_4_5datatype_1rules_6
-			reg5983 := __e.Call(__defun__fail)
+			reg5983 := Call(__e, __defun__fail)
 			reg5984 := PrimEqual(reg5983, Parse__shen_4_5datatype_1rules_6)
 			reg5985 := PrimNot(reg5984)
 			var reg5992 Obj
 			if reg5985 == True {
 				reg5986 := PrimHead(Parse__shen_4_5datatype_1rules_6)
-				reg5987 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5datatype_1rule_6)
-				reg5988 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5datatype_1rules_6)
+				reg5987 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5datatype_1rule_6)
+				reg5988 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5datatype_1rules_6)
 				reg5989 := PrimCons(reg5987, reg5988)
-				reg5990 := __e.Call(__defun__shen_4pair, reg5986, reg5989)
+				reg5990 := Call(__e, __defun__shen_4pair, reg5986, reg5989)
 				reg5992 = reg5990
 			} else {
-				reg5991 := __e.Call(__defun__fail)
+				reg5991 := Call(__e, __defun__fail)
 				reg5992 = reg5991
 			}
 			reg5994 = reg5992
 		} else {
-			reg5993 := __e.Call(__defun__fail)
+			reg5993 := Call(__e, __defun__fail)
 			reg5994 = reg5993
 		}
 		YaccParse := reg5994
 		_ = YaccParse
-		reg5995 := __e.Call(__defun__fail)
+		reg5995 := Call(__e, __defun__fail)
 		reg5996 := PrimEqual(YaccParse, reg5995)
 		if reg5996 == True {
-			reg5997 := __e.Call(__defun___5e_6, V1694)
+			reg5997 := Call(__e, __defun___5e_6, V1694)
 			Parse___5e_6 := reg5997
 			_ = Parse___5e_6
-			reg5998 := __e.Call(__defun__fail)
+			reg5998 := Call(__e, __defun__fail)
 			reg5999 := PrimEqual(reg5998, Parse___5e_6)
 			reg6000 := PrimNot(reg5999)
 			if reg6000 == True {
 				reg6001 := PrimHead(Parse___5e_6)
 				reg6002 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg6001, reg6002)
+				__e.TailApply(__defun__shen_4pair, reg6001, reg6002)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<datatype-rules>", value: __defun__shen_4_5datatype_1rules_6})
 
-	__defun__shen_4_5datatype_1rule_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5datatype_1rule_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1696 := __args[0]
 		_ = V1696
-		reg6005 := __e.Call(__defun__shen_4_5side_1conditions_6, V1696)
+		reg6005 := Call(__e, __defun__shen_4_5side_1conditions_6, V1696)
 		Parse__shen_4_5side_1conditions_6 := reg6005
 		_ = Parse__shen_4_5side_1conditions_6
-		reg6006 := __e.Call(__defun__fail)
+		reg6006 := Call(__e, __defun__fail)
 		reg6007 := PrimEqual(reg6006, Parse__shen_4_5side_1conditions_6)
 		reg6008 := PrimNot(reg6007)
 		var reg6039 Obj
 		if reg6008 == True {
-			reg6009 := __e.Call(__defun__shen_4_5premises_6, Parse__shen_4_5side_1conditions_6)
+			reg6009 := Call(__e, __defun__shen_4_5premises_6, Parse__shen_4_5side_1conditions_6)
 			Parse__shen_4_5premises_6 := reg6009
 			_ = Parse__shen_4_5premises_6
-			reg6010 := __e.Call(__defun__fail)
+			reg6010 := Call(__e, __defun__fail)
 			reg6011 := PrimEqual(reg6010, Parse__shen_4_5premises_6)
 			reg6012 := PrimNot(reg6011)
 			var reg6037 Obj
 			if reg6012 == True {
-				reg6013 := __e.Call(__defun__shen_4_5singleunderline_6, Parse__shen_4_5premises_6)
+				reg6013 := Call(__e, __defun__shen_4_5singleunderline_6, Parse__shen_4_5premises_6)
 				Parse__shen_4_5singleunderline_6 := reg6013
 				_ = Parse__shen_4_5singleunderline_6
-				reg6014 := __e.Call(__defun__fail)
+				reg6014 := Call(__e, __defun__fail)
 				reg6015 := PrimEqual(reg6014, Parse__shen_4_5singleunderline_6)
 				reg6016 := PrimNot(reg6015)
 				var reg6035 Obj
 				if reg6016 == True {
-					reg6017 := __e.Call(__defun__shen_4_5conclusion_6, Parse__shen_4_5singleunderline_6)
+					reg6017 := Call(__e, __defun__shen_4_5conclusion_6, Parse__shen_4_5singleunderline_6)
 					Parse__shen_4_5conclusion_6 := reg6017
 					_ = Parse__shen_4_5conclusion_6
-					reg6018 := __e.Call(__defun__fail)
+					reg6018 := Call(__e, __defun__fail)
 					reg6019 := PrimEqual(reg6018, Parse__shen_4_5conclusion_6)
 					reg6020 := PrimNot(reg6019)
 					var reg6033 Obj
 					if reg6020 == True {
 						reg6021 := PrimHead(Parse__shen_4_5conclusion_6)
 						reg6022 := MakeSymbol("shen.single")
-						reg6023 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5side_1conditions_6)
-						reg6024 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5premises_6)
-						reg6025 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5conclusion_6)
+						reg6023 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5side_1conditions_6)
+						reg6024 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5premises_6)
+						reg6025 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5conclusion_6)
 						reg6026 := Nil
 						reg6027 := PrimCons(reg6025, reg6026)
 						reg6028 := PrimCons(reg6024, reg6027)
 						reg6029 := PrimCons(reg6023, reg6028)
-						reg6030 := __e.Call(__defun__shen_4sequent, reg6022, reg6029)
-						reg6031 := __e.Call(__defun__shen_4pair, reg6021, reg6030)
+						reg6030 := Call(__e, __defun__shen_4sequent, reg6022, reg6029)
+						reg6031 := Call(__e, __defun__shen_4pair, reg6021, reg6030)
 						reg6033 = reg6031
 					} else {
-						reg6032 := __e.Call(__defun__fail)
+						reg6032 := Call(__e, __defun__fail)
 						reg6033 = reg6032
 					}
 					reg6035 = reg6033
 				} else {
-					reg6034 := __e.Call(__defun__fail)
+					reg6034 := Call(__e, __defun__fail)
 					reg6035 = reg6034
 				}
 				reg6037 = reg6035
 			} else {
-				reg6036 := __e.Call(__defun__fail)
+				reg6036 := Call(__e, __defun__fail)
 				reg6037 = reg6036
 			}
 			reg6039 = reg6037
 		} else {
-			reg6038 := __e.Call(__defun__fail)
+			reg6038 := Call(__e, __defun__fail)
 			reg6039 = reg6038
 		}
 		YaccParse := reg6039
 		_ = YaccParse
-		reg6040 := __e.Call(__defun__fail)
+		reg6040 := Call(__e, __defun__fail)
 		reg6041 := PrimEqual(YaccParse, reg6040)
 		if reg6041 == True {
-			reg6042 := __e.Call(__defun__shen_4_5side_1conditions_6, V1696)
+			reg6042 := Call(__e, __defun__shen_4_5side_1conditions_6, V1696)
 			Parse__shen_4_5side_1conditions_6 := reg6042
 			_ = Parse__shen_4_5side_1conditions_6
-			reg6043 := __e.Call(__defun__fail)
+			reg6043 := Call(__e, __defun__fail)
 			reg6044 := PrimEqual(reg6043, Parse__shen_4_5side_1conditions_6)
 			reg6045 := PrimNot(reg6044)
 			if reg6045 == True {
-				reg6046 := __e.Call(__defun__shen_4_5premises_6, Parse__shen_4_5side_1conditions_6)
+				reg6046 := Call(__e, __defun__shen_4_5premises_6, Parse__shen_4_5side_1conditions_6)
 				Parse__shen_4_5premises_6 := reg6046
 				_ = Parse__shen_4_5premises_6
-				reg6047 := __e.Call(__defun__fail)
+				reg6047 := Call(__e, __defun__fail)
 				reg6048 := PrimEqual(reg6047, Parse__shen_4_5premises_6)
 				reg6049 := PrimNot(reg6048)
 				if reg6049 == True {
-					reg6050 := __e.Call(__defun__shen_4_5doubleunderline_6, Parse__shen_4_5premises_6)
+					reg6050 := Call(__e, __defun__shen_4_5doubleunderline_6, Parse__shen_4_5premises_6)
 					Parse__shen_4_5doubleunderline_6 := reg6050
 					_ = Parse__shen_4_5doubleunderline_6
-					reg6051 := __e.Call(__defun__fail)
+					reg6051 := Call(__e, __defun__fail)
 					reg6052 := PrimEqual(reg6051, Parse__shen_4_5doubleunderline_6)
 					reg6053 := PrimNot(reg6052)
 					if reg6053 == True {
-						reg6054 := __e.Call(__defun__shen_4_5conclusion_6, Parse__shen_4_5doubleunderline_6)
+						reg6054 := Call(__e, __defun__shen_4_5conclusion_6, Parse__shen_4_5doubleunderline_6)
 						Parse__shen_4_5conclusion_6 := reg6054
 						_ = Parse__shen_4_5conclusion_6
-						reg6055 := __e.Call(__defun__fail)
+						reg6055 := Call(__e, __defun__fail)
 						reg6056 := PrimEqual(reg6055, Parse__shen_4_5conclusion_6)
 						reg6057 := PrimNot(reg6056)
 						if reg6057 == True {
 							reg6058 := PrimHead(Parse__shen_4_5conclusion_6)
 							reg6059 := MakeSymbol("shen.double")
-							reg6060 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5side_1conditions_6)
-							reg6061 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5premises_6)
-							reg6062 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5conclusion_6)
+							reg6060 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5side_1conditions_6)
+							reg6061 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5premises_6)
+							reg6062 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5conclusion_6)
 							reg6063 := Nil
 							reg6064 := PrimCons(reg6062, reg6063)
 							reg6065 := PrimCons(reg6061, reg6064)
 							reg6066 := PrimCons(reg6060, reg6065)
-							reg6067 := __e.Call(__defun__shen_4sequent, reg6059, reg6066)
-							__ctx.TailApply(__defun__shen_4pair, reg6058, reg6067)
+							reg6067 := Call(__e, __defun__shen_4sequent, reg6059, reg6066)
+							__e.TailApply(__defun__shen_4pair, reg6058, reg6067)
 							return
 						} else {
-							__ctx.TailApply(__defun__fail)
+							__e.TailApply(__defun__fail)
 							return
 						}
 					} else {
-						__ctx.TailApply(__defun__fail)
+						__e.TailApply(__defun__fail)
 						return
 					}
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<datatype-rule>", value: __defun__shen_4_5datatype_1rule_6})
 
-	__defun__shen_4_5side_1conditions_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5side_1conditions_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1698 := __args[0]
 		_ = V1698
-		reg6073 := __e.Call(__defun__shen_4_5side_1condition_6, V1698)
+		reg6073 := Call(__e, __defun__shen_4_5side_1condition_6, V1698)
 		Parse__shen_4_5side_1condition_6 := reg6073
 		_ = Parse__shen_4_5side_1condition_6
-		reg6074 := __e.Call(__defun__fail)
+		reg6074 := Call(__e, __defun__fail)
 		reg6075 := PrimEqual(reg6074, Parse__shen_4_5side_1condition_6)
 		reg6076 := PrimNot(reg6075)
 		var reg6089 Obj
 		if reg6076 == True {
-			reg6077 := __e.Call(__defun__shen_4_5side_1conditions_6, Parse__shen_4_5side_1condition_6)
+			reg6077 := Call(__e, __defun__shen_4_5side_1conditions_6, Parse__shen_4_5side_1condition_6)
 			Parse__shen_4_5side_1conditions_6 := reg6077
 			_ = Parse__shen_4_5side_1conditions_6
-			reg6078 := __e.Call(__defun__fail)
+			reg6078 := Call(__e, __defun__fail)
 			reg6079 := PrimEqual(reg6078, Parse__shen_4_5side_1conditions_6)
 			reg6080 := PrimNot(reg6079)
 			var reg6087 Obj
 			if reg6080 == True {
 				reg6081 := PrimHead(Parse__shen_4_5side_1conditions_6)
-				reg6082 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5side_1condition_6)
-				reg6083 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5side_1conditions_6)
+				reg6082 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5side_1condition_6)
+				reg6083 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5side_1conditions_6)
 				reg6084 := PrimCons(reg6082, reg6083)
-				reg6085 := __e.Call(__defun__shen_4pair, reg6081, reg6084)
+				reg6085 := Call(__e, __defun__shen_4pair, reg6081, reg6084)
 				reg6087 = reg6085
 			} else {
-				reg6086 := __e.Call(__defun__fail)
+				reg6086 := Call(__e, __defun__fail)
 				reg6087 = reg6086
 			}
 			reg6089 = reg6087
 		} else {
-			reg6088 := __e.Call(__defun__fail)
+			reg6088 := Call(__e, __defun__fail)
 			reg6089 = reg6088
 		}
 		YaccParse := reg6089
 		_ = YaccParse
-		reg6090 := __e.Call(__defun__fail)
+		reg6090 := Call(__e, __defun__fail)
 		reg6091 := PrimEqual(YaccParse, reg6090)
 		if reg6091 == True {
-			reg6092 := __e.Call(__defun___5e_6, V1698)
+			reg6092 := Call(__e, __defun___5e_6, V1698)
 			Parse___5e_6 := reg6092
 			_ = Parse___5e_6
-			reg6093 := __e.Call(__defun__fail)
+			reg6093 := Call(__e, __defun__fail)
 			reg6094 := PrimEqual(reg6093, Parse___5e_6)
 			reg6095 := PrimNot(reg6094)
 			if reg6095 == True {
 				reg6096 := PrimHead(Parse___5e_6)
 				reg6097 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg6096, reg6097)
+				__e.TailApply(__defun__shen_4pair, reg6096, reg6097)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<side-conditions>", value: __defun__shen_4_5side_1conditions_6})
 
-	__defun__shen_4_5side_1condition_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5side_1condition_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1702 := __args[0]
 		_ = V1702
 		reg6100 := PrimHead(V1702)
@@ -389,7 +389,7 @@ func init() {
 		var reg6109 Obj
 		if reg6101 == True {
 			reg6102 := MakeSymbol("if")
-			reg6103 := __e.Call(__defun__shen_4hdhd, V1702)
+			reg6103 := Call(__e, __defun__shen_4hdhd, V1702)
 			reg6104 := PrimEqual(reg6102, reg6103)
 			var reg6107 Obj
 			if reg6104 == True {
@@ -406,39 +406,39 @@ func init() {
 		}
 		var reg6127 Obj
 		if reg6109 == True {
-			reg6110 := __e.Call(__defun__shen_4tlhd, V1702)
-			reg6111 := __e.Call(__defun__shen_4hdtl, V1702)
-			reg6112 := __e.Call(__defun__shen_4pair, reg6110, reg6111)
+			reg6110 := Call(__e, __defun__shen_4tlhd, V1702)
+			reg6111 := Call(__e, __defun__shen_4hdtl, V1702)
+			reg6112 := Call(__e, __defun__shen_4pair, reg6110, reg6111)
 			NewStream1699 := reg6112
 			_ = NewStream1699
-			reg6113 := __e.Call(__defun__shen_4_5expr_6, NewStream1699)
+			reg6113 := Call(__e, __defun__shen_4_5expr_6, NewStream1699)
 			Parse__shen_4_5expr_6 := reg6113
 			_ = Parse__shen_4_5expr_6
-			reg6114 := __e.Call(__defun__fail)
+			reg6114 := Call(__e, __defun__fail)
 			reg6115 := PrimEqual(reg6114, Parse__shen_4_5expr_6)
 			reg6116 := PrimNot(reg6115)
 			var reg6125 Obj
 			if reg6116 == True {
 				reg6117 := PrimHead(Parse__shen_4_5expr_6)
 				reg6118 := MakeSymbol("if")
-				reg6119 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5expr_6)
+				reg6119 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5expr_6)
 				reg6120 := Nil
 				reg6121 := PrimCons(reg6119, reg6120)
 				reg6122 := PrimCons(reg6118, reg6121)
-				reg6123 := __e.Call(__defun__shen_4pair, reg6117, reg6122)
+				reg6123 := Call(__e, __defun__shen_4pair, reg6117, reg6122)
 				reg6125 = reg6123
 			} else {
-				reg6124 := __e.Call(__defun__fail)
+				reg6124 := Call(__e, __defun__fail)
 				reg6125 = reg6124
 			}
 			reg6127 = reg6125
 		} else {
-			reg6126 := __e.Call(__defun__fail)
+			reg6126 := Call(__e, __defun__fail)
 			reg6127 = reg6126
 		}
 		YaccParse := reg6127
 		_ = YaccParse
-		reg6128 := __e.Call(__defun__fail)
+		reg6128 := Call(__e, __defun__fail)
 		reg6129 := PrimEqual(YaccParse, reg6128)
 		if reg6129 == True {
 			reg6130 := PrimHead(V1702)
@@ -446,7 +446,7 @@ func init() {
 			var reg6139 Obj
 			if reg6131 == True {
 				reg6132 := MakeSymbol("let")
-				reg6133 := __e.Call(__defun__shen_4hdhd, V1702)
+				reg6133 := Call(__e, __defun__shen_4hdhd, V1702)
 				reg6134 := PrimEqual(reg6132, reg6133)
 				var reg6137 Obj
 				if reg6134 == True {
@@ -462,89 +462,89 @@ func init() {
 				reg6139 = reg6138
 			}
 			if reg6139 == True {
-				reg6140 := __e.Call(__defun__shen_4tlhd, V1702)
-				reg6141 := __e.Call(__defun__shen_4hdtl, V1702)
-				reg6142 := __e.Call(__defun__shen_4pair, reg6140, reg6141)
+				reg6140 := Call(__e, __defun__shen_4tlhd, V1702)
+				reg6141 := Call(__e, __defun__shen_4hdtl, V1702)
+				reg6142 := Call(__e, __defun__shen_4pair, reg6140, reg6141)
 				NewStream1700 := reg6142
 				_ = NewStream1700
-				reg6143 := __e.Call(__defun__shen_4_5variable_2_6, NewStream1700)
+				reg6143 := Call(__e, __defun__shen_4_5variable_2_6, NewStream1700)
 				Parse__shen_4_5variable_2_6 := reg6143
 				_ = Parse__shen_4_5variable_2_6
-				reg6144 := __e.Call(__defun__fail)
+				reg6144 := Call(__e, __defun__fail)
 				reg6145 := PrimEqual(reg6144, Parse__shen_4_5variable_2_6)
 				reg6146 := PrimNot(reg6145)
 				if reg6146 == True {
-					reg6147 := __e.Call(__defun__shen_4_5expr_6, Parse__shen_4_5variable_2_6)
+					reg6147 := Call(__e, __defun__shen_4_5expr_6, Parse__shen_4_5variable_2_6)
 					Parse__shen_4_5expr_6 := reg6147
 					_ = Parse__shen_4_5expr_6
-					reg6148 := __e.Call(__defun__fail)
+					reg6148 := Call(__e, __defun__fail)
 					reg6149 := PrimEqual(reg6148, Parse__shen_4_5expr_6)
 					reg6150 := PrimNot(reg6149)
 					if reg6150 == True {
 						reg6151 := PrimHead(Parse__shen_4_5expr_6)
 						reg6152 := MakeSymbol("let")
-						reg6153 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5variable_2_6)
-						reg6154 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5expr_6)
+						reg6153 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5variable_2_6)
+						reg6154 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5expr_6)
 						reg6155 := Nil
 						reg6156 := PrimCons(reg6154, reg6155)
 						reg6157 := PrimCons(reg6153, reg6156)
 						reg6158 := PrimCons(reg6152, reg6157)
-						__ctx.TailApply(__defun__shen_4pair, reg6151, reg6158)
+						__e.TailApply(__defun__shen_4pair, reg6151, reg6158)
 						return
 					} else {
-						__ctx.TailApply(__defun__fail)
+						__e.TailApply(__defun__fail)
 						return
 					}
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<side-condition>", value: __defun__shen_4_5side_1condition_6})
 
-	__defun__shen_4_5variable_2_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5variable_2_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1704 := __args[0]
 		_ = V1704
 		reg6163 := PrimHead(V1704)
 		reg6164 := PrimIsPair(reg6163)
 		if reg6164 == True {
-			reg6165 := __e.Call(__defun__shen_4hdhd, V1704)
+			reg6165 := Call(__e, __defun__shen_4hdhd, V1704)
 			Parse__X := reg6165
 			_ = Parse__X
 			reg6166 := PrimIsVariable(Parse__X)
 			if reg6166 == True {
-				reg6167 := __e.Call(__defun__shen_4tlhd, V1704)
-				reg6168 := __e.Call(__defun__shen_4hdtl, V1704)
-				reg6169 := __e.Call(__defun__shen_4pair, reg6167, reg6168)
+				reg6167 := Call(__e, __defun__shen_4tlhd, V1704)
+				reg6168 := Call(__e, __defun__shen_4hdtl, V1704)
+				reg6169 := Call(__e, __defun__shen_4pair, reg6167, reg6168)
 				reg6170 := PrimHead(reg6169)
-				__ctx.TailApply(__defun__shen_4pair, reg6170, Parse__X)
+				__e.TailApply(__defun__shen_4pair, reg6170, Parse__X)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<variable?>", value: __defun__shen_4_5variable_2_6})
 
-	__defun__shen_4_5expr_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5expr_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1706 := __args[0]
 		_ = V1706
 		reg6174 := PrimHead(V1706)
 		reg6175 := PrimIsPair(reg6174)
 		if reg6175 == True {
-			reg6176 := __e.Call(__defun__shen_4hdhd, V1706)
+			reg6176 := Call(__e, __defun__shen_4hdhd, V1706)
 			Parse__X := reg6176
 			_ = Parse__X
 			reg6177 := MakeSymbol(">>")
@@ -552,19 +552,19 @@ func init() {
 			reg6179 := Nil
 			reg6180 := PrimCons(reg6178, reg6179)
 			reg6181 := PrimCons(reg6177, reg6180)
-			reg6182 := __e.Call(__defun__element_2, Parse__X, reg6181)
+			reg6182 := Call(__e, __defun__element_2, Parse__X, reg6181)
 			var reg6194 Obj
 			if reg6182 == True {
 				reg6183 := True
 				reg6194 = reg6183
 			} else {
-				reg6184 := __e.Call(__defun__shen_4singleunderline_2, Parse__X)
+				reg6184 := Call(__e, __defun__shen_4singleunderline_2, Parse__X)
 				var reg6190 Obj
 				if reg6184 == True {
 					reg6185 := True
 					reg6190 = reg6185
 				} else {
-					reg6186 := __e.Call(__defun__shen_4doubleunderline_2, Parse__X)
+					reg6186 := Call(__e, __defun__shen_4doubleunderline_2, Parse__X)
 					var reg6189 Obj
 					if reg6186 == True {
 						reg6187 := True
@@ -587,25 +587,25 @@ func init() {
 			}
 			reg6195 := PrimNot(reg6194)
 			if reg6195 == True {
-				reg6196 := __e.Call(__defun__shen_4tlhd, V1706)
-				reg6197 := __e.Call(__defun__shen_4hdtl, V1706)
-				reg6198 := __e.Call(__defun__shen_4pair, reg6196, reg6197)
+				reg6196 := Call(__e, __defun__shen_4tlhd, V1706)
+				reg6197 := Call(__e, __defun__shen_4hdtl, V1706)
+				reg6198 := Call(__e, __defun__shen_4pair, reg6196, reg6197)
 				reg6199 := PrimHead(reg6198)
-				reg6200 := __e.Call(__defun__shen_4remove_1bar, Parse__X)
-				__ctx.TailApply(__defun__shen_4pair, reg6199, reg6200)
+				reg6200 := Call(__e, __defun__shen_4remove_1bar, Parse__X)
+				__e.TailApply(__defun__shen_4pair, reg6199, reg6200)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<expr>", value: __defun__shen_4_5expr_6})
 
-	__defun__shen_4remove_1bar = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4remove_1bar = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1708 := __args[0]
 		_ = V1708
 		reg6204 := PrimIsPair(V1708)
@@ -689,131 +689,131 @@ func init() {
 			reg6241 := PrimTail(reg6240)
 			reg6242 := PrimHead(reg6241)
 			reg6243 := PrimCons(reg6239, reg6242)
-			__ctx.Return(reg6243)
+			__e.Return(reg6243)
 			return
 		} else {
 			reg6244 := PrimIsPair(V1708)
 			if reg6244 == True {
 				reg6245 := PrimHead(V1708)
-				reg6246 := __e.Call(__defun__shen_4remove_1bar, reg6245)
+				reg6246 := Call(__e, __defun__shen_4remove_1bar, reg6245)
 				reg6247 := PrimTail(V1708)
-				reg6248 := __e.Call(__defun__shen_4remove_1bar, reg6247)
+				reg6248 := Call(__e, __defun__shen_4remove_1bar, reg6247)
 				reg6249 := PrimCons(reg6246, reg6248)
-				__ctx.Return(reg6249)
+				__e.Return(reg6249)
 				return
 			} else {
-				__ctx.Return(V1708)
+				__e.Return(V1708)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.remove-bar", value: __defun__shen_4remove_1bar})
 
-	__defun__shen_4_5premises_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5premises_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1710 := __args[0]
 		_ = V1710
-		reg6250 := __e.Call(__defun__shen_4_5premise_6, V1710)
+		reg6250 := Call(__e, __defun__shen_4_5premise_6, V1710)
 		Parse__shen_4_5premise_6 := reg6250
 		_ = Parse__shen_4_5premise_6
-		reg6251 := __e.Call(__defun__fail)
+		reg6251 := Call(__e, __defun__fail)
 		reg6252 := PrimEqual(reg6251, Parse__shen_4_5premise_6)
 		reg6253 := PrimNot(reg6252)
 		var reg6272 Obj
 		if reg6253 == True {
-			reg6254 := __e.Call(__defun__shen_4_5semicolon_1symbol_6, Parse__shen_4_5premise_6)
+			reg6254 := Call(__e, __defun__shen_4_5semicolon_1symbol_6, Parse__shen_4_5premise_6)
 			Parse__shen_4_5semicolon_1symbol_6 := reg6254
 			_ = Parse__shen_4_5semicolon_1symbol_6
-			reg6255 := __e.Call(__defun__fail)
+			reg6255 := Call(__e, __defun__fail)
 			reg6256 := PrimEqual(reg6255, Parse__shen_4_5semicolon_1symbol_6)
 			reg6257 := PrimNot(reg6256)
 			var reg6270 Obj
 			if reg6257 == True {
-				reg6258 := __e.Call(__defun__shen_4_5premises_6, Parse__shen_4_5semicolon_1symbol_6)
+				reg6258 := Call(__e, __defun__shen_4_5premises_6, Parse__shen_4_5semicolon_1symbol_6)
 				Parse__shen_4_5premises_6 := reg6258
 				_ = Parse__shen_4_5premises_6
-				reg6259 := __e.Call(__defun__fail)
+				reg6259 := Call(__e, __defun__fail)
 				reg6260 := PrimEqual(reg6259, Parse__shen_4_5premises_6)
 				reg6261 := PrimNot(reg6260)
 				var reg6268 Obj
 				if reg6261 == True {
 					reg6262 := PrimHead(Parse__shen_4_5premises_6)
-					reg6263 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5premise_6)
-					reg6264 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5premises_6)
+					reg6263 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5premise_6)
+					reg6264 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5premises_6)
 					reg6265 := PrimCons(reg6263, reg6264)
-					reg6266 := __e.Call(__defun__shen_4pair, reg6262, reg6265)
+					reg6266 := Call(__e, __defun__shen_4pair, reg6262, reg6265)
 					reg6268 = reg6266
 				} else {
-					reg6267 := __e.Call(__defun__fail)
+					reg6267 := Call(__e, __defun__fail)
 					reg6268 = reg6267
 				}
 				reg6270 = reg6268
 			} else {
-				reg6269 := __e.Call(__defun__fail)
+				reg6269 := Call(__e, __defun__fail)
 				reg6270 = reg6269
 			}
 			reg6272 = reg6270
 		} else {
-			reg6271 := __e.Call(__defun__fail)
+			reg6271 := Call(__e, __defun__fail)
 			reg6272 = reg6271
 		}
 		YaccParse := reg6272
 		_ = YaccParse
-		reg6273 := __e.Call(__defun__fail)
+		reg6273 := Call(__e, __defun__fail)
 		reg6274 := PrimEqual(YaccParse, reg6273)
 		if reg6274 == True {
-			reg6275 := __e.Call(__defun___5e_6, V1710)
+			reg6275 := Call(__e, __defun___5e_6, V1710)
 			Parse___5e_6 := reg6275
 			_ = Parse___5e_6
-			reg6276 := __e.Call(__defun__fail)
+			reg6276 := Call(__e, __defun__fail)
 			reg6277 := PrimEqual(reg6276, Parse___5e_6)
 			reg6278 := PrimNot(reg6277)
 			if reg6278 == True {
 				reg6279 := PrimHead(Parse___5e_6)
 				reg6280 := Nil
-				__ctx.TailApply(__defun__shen_4pair, reg6279, reg6280)
+				__e.TailApply(__defun__shen_4pair, reg6279, reg6280)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<premises>", value: __defun__shen_4_5premises_6})
 
-	__defun__shen_4_5semicolon_1symbol_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5semicolon_1symbol_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1712 := __args[0]
 		_ = V1712
 		reg6283 := PrimHead(V1712)
 		reg6284 := PrimIsPair(reg6283)
 		if reg6284 == True {
-			reg6285 := __e.Call(__defun__shen_4hdhd, V1712)
+			reg6285 := Call(__e, __defun__shen_4hdhd, V1712)
 			Parse__X := reg6285
 			_ = Parse__X
 			reg6286 := MakeSymbol(";")
 			reg6287 := PrimEqual(Parse__X, reg6286)
 			if reg6287 == True {
-				reg6288 := __e.Call(__defun__shen_4tlhd, V1712)
-				reg6289 := __e.Call(__defun__shen_4hdtl, V1712)
-				reg6290 := __e.Call(__defun__shen_4pair, reg6288, reg6289)
+				reg6288 := Call(__e, __defun__shen_4tlhd, V1712)
+				reg6289 := Call(__e, __defun__shen_4hdtl, V1712)
+				reg6290 := Call(__e, __defun__shen_4pair, reg6288, reg6289)
 				reg6291 := PrimHead(reg6290)
 				reg6292 := MakeSymbol("shen.skip")
-				__ctx.TailApply(__defun__shen_4pair, reg6291, reg6292)
+				__e.TailApply(__defun__shen_4pair, reg6291, reg6292)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<semicolon-symbol>", value: __defun__shen_4_5semicolon_1symbol_6})
 
-	__defun__shen_4_5premise_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5premise_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1716 := __args[0]
 		_ = V1716
 		reg6296 := PrimHead(V1716)
@@ -821,7 +821,7 @@ func init() {
 		var reg6305 Obj
 		if reg6297 == True {
 			reg6298 := MakeSymbol("!")
-			reg6299 := __e.Call(__defun__shen_4hdhd, V1716)
+			reg6299 := Call(__e, __defun__shen_4hdhd, V1716)
 			reg6300 := PrimEqual(reg6298, reg6299)
 			var reg6303 Obj
 			if reg6300 == True {
@@ -838,28 +838,28 @@ func init() {
 		}
 		var reg6313 Obj
 		if reg6305 == True {
-			reg6306 := __e.Call(__defun__shen_4tlhd, V1716)
-			reg6307 := __e.Call(__defun__shen_4hdtl, V1716)
-			reg6308 := __e.Call(__defun__shen_4pair, reg6306, reg6307)
+			reg6306 := Call(__e, __defun__shen_4tlhd, V1716)
+			reg6307 := Call(__e, __defun__shen_4hdtl, V1716)
+			reg6308 := Call(__e, __defun__shen_4pair, reg6306, reg6307)
 			NewStream1713 := reg6308
 			_ = NewStream1713
 			reg6309 := PrimHead(NewStream1713)
 			reg6310 := MakeSymbol("!")
-			reg6311 := __e.Call(__defun__shen_4pair, reg6309, reg6310)
+			reg6311 := Call(__e, __defun__shen_4pair, reg6309, reg6310)
 			reg6313 = reg6311
 		} else {
-			reg6312 := __e.Call(__defun__fail)
+			reg6312 := Call(__e, __defun__fail)
 			reg6313 = reg6312
 		}
 		YaccParse := reg6313
 		_ = YaccParse
-		reg6314 := __e.Call(__defun__fail)
+		reg6314 := Call(__e, __defun__fail)
 		reg6315 := PrimEqual(YaccParse, reg6314)
 		if reg6315 == True {
-			reg6316 := __e.Call(__defun__shen_4_5formulae_6, V1716)
+			reg6316 := Call(__e, __defun__shen_4_5formulae_6, V1716)
 			Parse__shen_4_5formulae_6 := reg6316
 			_ = Parse__shen_4_5formulae_6
-			reg6317 := __e.Call(__defun__fail)
+			reg6317 := Call(__e, __defun__fail)
 			reg6318 := PrimEqual(reg6317, Parse__shen_4_5formulae_6)
 			reg6319 := PrimNot(reg6318)
 			var reg6347 Obj
@@ -869,7 +869,7 @@ func init() {
 				var reg6329 Obj
 				if reg6321 == True {
 					reg6322 := MakeSymbol(">>")
-					reg6323 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5formulae_6)
+					reg6323 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5formulae_6)
 					reg6324 := PrimEqual(reg6322, reg6323)
 					var reg6327 Obj
 					if reg6324 == True {
@@ -886,79 +886,79 @@ func init() {
 				}
 				var reg6345 Obj
 				if reg6329 == True {
-					reg6330 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5formulae_6)
-					reg6331 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formulae_6)
-					reg6332 := __e.Call(__defun__shen_4pair, reg6330, reg6331)
+					reg6330 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5formulae_6)
+					reg6331 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formulae_6)
+					reg6332 := Call(__e, __defun__shen_4pair, reg6330, reg6331)
 					NewStream1714 := reg6332
 					_ = NewStream1714
-					reg6333 := __e.Call(__defun__shen_4_5formula_6, NewStream1714)
+					reg6333 := Call(__e, __defun__shen_4_5formula_6, NewStream1714)
 					Parse__shen_4_5formula_6 := reg6333
 					_ = Parse__shen_4_5formula_6
-					reg6334 := __e.Call(__defun__fail)
+					reg6334 := Call(__e, __defun__fail)
 					reg6335 := PrimEqual(reg6334, Parse__shen_4_5formula_6)
 					reg6336 := PrimNot(reg6335)
 					var reg6343 Obj
 					if reg6336 == True {
 						reg6337 := PrimHead(Parse__shen_4_5formula_6)
-						reg6338 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formulae_6)
-						reg6339 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formula_6)
-						reg6340 := __e.Call(__defun__shen_4sequent, reg6338, reg6339)
-						reg6341 := __e.Call(__defun__shen_4pair, reg6337, reg6340)
+						reg6338 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formulae_6)
+						reg6339 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formula_6)
+						reg6340 := Call(__e, __defun__shen_4sequent, reg6338, reg6339)
+						reg6341 := Call(__e, __defun__shen_4pair, reg6337, reg6340)
 						reg6343 = reg6341
 					} else {
-						reg6342 := __e.Call(__defun__fail)
+						reg6342 := Call(__e, __defun__fail)
 						reg6343 = reg6342
 					}
 					reg6345 = reg6343
 				} else {
-					reg6344 := __e.Call(__defun__fail)
+					reg6344 := Call(__e, __defun__fail)
 					reg6345 = reg6344
 				}
 				reg6347 = reg6345
 			} else {
-				reg6346 := __e.Call(__defun__fail)
+				reg6346 := Call(__e, __defun__fail)
 				reg6347 = reg6346
 			}
 			YaccParse := reg6347
 			_ = YaccParse
-			reg6348 := __e.Call(__defun__fail)
+			reg6348 := Call(__e, __defun__fail)
 			reg6349 := PrimEqual(YaccParse, reg6348)
 			if reg6349 == True {
-				reg6350 := __e.Call(__defun__shen_4_5formula_6, V1716)
+				reg6350 := Call(__e, __defun__shen_4_5formula_6, V1716)
 				Parse__shen_4_5formula_6 := reg6350
 				_ = Parse__shen_4_5formula_6
-				reg6351 := __e.Call(__defun__fail)
+				reg6351 := Call(__e, __defun__fail)
 				reg6352 := PrimEqual(reg6351, Parse__shen_4_5formula_6)
 				reg6353 := PrimNot(reg6352)
 				if reg6353 == True {
 					reg6354 := PrimHead(Parse__shen_4_5formula_6)
 					reg6355 := Nil
-					reg6356 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formula_6)
-					reg6357 := __e.Call(__defun__shen_4sequent, reg6355, reg6356)
-					__ctx.TailApply(__defun__shen_4pair, reg6354, reg6357)
+					reg6356 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formula_6)
+					reg6357 := Call(__e, __defun__shen_4sequent, reg6355, reg6356)
+					__e.TailApply(__defun__shen_4pair, reg6354, reg6357)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.Return(YaccParse)
+				__e.Return(YaccParse)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<premise>", value: __defun__shen_4_5premise_6})
 
-	__defun__shen_4_5conclusion_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5conclusion_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1719 := __args[0]
 		_ = V1719
-		reg6360 := __e.Call(__defun__shen_4_5formulae_6, V1719)
+		reg6360 := Call(__e, __defun__shen_4_5formulae_6, V1719)
 		Parse__shen_4_5formulae_6 := reg6360
 		_ = Parse__shen_4_5formulae_6
-		reg6361 := __e.Call(__defun__fail)
+		reg6361 := Call(__e, __defun__fail)
 		reg6362 := PrimEqual(reg6361, Parse__shen_4_5formulae_6)
 		reg6363 := PrimNot(reg6362)
 		var reg6397 Obj
@@ -968,7 +968,7 @@ func init() {
 			var reg6373 Obj
 			if reg6365 == True {
 				reg6366 := MakeSymbol(">>")
-				reg6367 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5formulae_6)
+				reg6367 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5formulae_6)
 				reg6368 := PrimEqual(reg6366, reg6367)
 				var reg6371 Obj
 				if reg6368 == True {
@@ -985,241 +985,241 @@ func init() {
 			}
 			var reg6395 Obj
 			if reg6373 == True {
-				reg6374 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5formulae_6)
-				reg6375 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formulae_6)
-				reg6376 := __e.Call(__defun__shen_4pair, reg6374, reg6375)
+				reg6374 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5formulae_6)
+				reg6375 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formulae_6)
+				reg6376 := Call(__e, __defun__shen_4pair, reg6374, reg6375)
 				NewStream1717 := reg6376
 				_ = NewStream1717
-				reg6377 := __e.Call(__defun__shen_4_5formula_6, NewStream1717)
+				reg6377 := Call(__e, __defun__shen_4_5formula_6, NewStream1717)
 				Parse__shen_4_5formula_6 := reg6377
 				_ = Parse__shen_4_5formula_6
-				reg6378 := __e.Call(__defun__fail)
+				reg6378 := Call(__e, __defun__fail)
 				reg6379 := PrimEqual(reg6378, Parse__shen_4_5formula_6)
 				reg6380 := PrimNot(reg6379)
 				var reg6393 Obj
 				if reg6380 == True {
-					reg6381 := __e.Call(__defun__shen_4_5semicolon_1symbol_6, Parse__shen_4_5formula_6)
+					reg6381 := Call(__e, __defun__shen_4_5semicolon_1symbol_6, Parse__shen_4_5formula_6)
 					Parse__shen_4_5semicolon_1symbol_6 := reg6381
 					_ = Parse__shen_4_5semicolon_1symbol_6
-					reg6382 := __e.Call(__defun__fail)
+					reg6382 := Call(__e, __defun__fail)
 					reg6383 := PrimEqual(reg6382, Parse__shen_4_5semicolon_1symbol_6)
 					reg6384 := PrimNot(reg6383)
 					var reg6391 Obj
 					if reg6384 == True {
 						reg6385 := PrimHead(Parse__shen_4_5semicolon_1symbol_6)
-						reg6386 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formulae_6)
-						reg6387 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formula_6)
-						reg6388 := __e.Call(__defun__shen_4sequent, reg6386, reg6387)
-						reg6389 := __e.Call(__defun__shen_4pair, reg6385, reg6388)
+						reg6386 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formulae_6)
+						reg6387 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formula_6)
+						reg6388 := Call(__e, __defun__shen_4sequent, reg6386, reg6387)
+						reg6389 := Call(__e, __defun__shen_4pair, reg6385, reg6388)
 						reg6391 = reg6389
 					} else {
-						reg6390 := __e.Call(__defun__fail)
+						reg6390 := Call(__e, __defun__fail)
 						reg6391 = reg6390
 					}
 					reg6393 = reg6391
 				} else {
-					reg6392 := __e.Call(__defun__fail)
+					reg6392 := Call(__e, __defun__fail)
 					reg6393 = reg6392
 				}
 				reg6395 = reg6393
 			} else {
-				reg6394 := __e.Call(__defun__fail)
+				reg6394 := Call(__e, __defun__fail)
 				reg6395 = reg6394
 			}
 			reg6397 = reg6395
 		} else {
-			reg6396 := __e.Call(__defun__fail)
+			reg6396 := Call(__e, __defun__fail)
 			reg6397 = reg6396
 		}
 		YaccParse := reg6397
 		_ = YaccParse
-		reg6398 := __e.Call(__defun__fail)
+		reg6398 := Call(__e, __defun__fail)
 		reg6399 := PrimEqual(YaccParse, reg6398)
 		if reg6399 == True {
-			reg6400 := __e.Call(__defun__shen_4_5formula_6, V1719)
+			reg6400 := Call(__e, __defun__shen_4_5formula_6, V1719)
 			Parse__shen_4_5formula_6 := reg6400
 			_ = Parse__shen_4_5formula_6
-			reg6401 := __e.Call(__defun__fail)
+			reg6401 := Call(__e, __defun__fail)
 			reg6402 := PrimEqual(reg6401, Parse__shen_4_5formula_6)
 			reg6403 := PrimNot(reg6402)
 			if reg6403 == True {
-				reg6404 := __e.Call(__defun__shen_4_5semicolon_1symbol_6, Parse__shen_4_5formula_6)
+				reg6404 := Call(__e, __defun__shen_4_5semicolon_1symbol_6, Parse__shen_4_5formula_6)
 				Parse__shen_4_5semicolon_1symbol_6 := reg6404
 				_ = Parse__shen_4_5semicolon_1symbol_6
-				reg6405 := __e.Call(__defun__fail)
+				reg6405 := Call(__e, __defun__fail)
 				reg6406 := PrimEqual(reg6405, Parse__shen_4_5semicolon_1symbol_6)
 				reg6407 := PrimNot(reg6406)
 				if reg6407 == True {
 					reg6408 := PrimHead(Parse__shen_4_5semicolon_1symbol_6)
 					reg6409 := Nil
-					reg6410 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formula_6)
-					reg6411 := __e.Call(__defun__shen_4sequent, reg6409, reg6410)
-					__ctx.TailApply(__defun__shen_4pair, reg6408, reg6411)
+					reg6410 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formula_6)
+					reg6411 := Call(__e, __defun__shen_4sequent, reg6409, reg6410)
+					__e.TailApply(__defun__shen_4pair, reg6408, reg6411)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<conclusion>", value: __defun__shen_4_5conclusion_6})
 
-	__defun__shen_4sequent = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4sequent = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1722 := __args[0]
 		_ = V1722
 		V1723 := __args[1]
 		_ = V1723
-		__ctx.TailApply(__defun___8p, V1722, V1723)
+		__e.TailApply(__defun___8p, V1722, V1723)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.sequent", value: __defun__shen_4sequent})
 
-	__defun__shen_4_5formulae_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5formulae_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1725 := __args[0]
 		_ = V1725
-		reg6416 := __e.Call(__defun__shen_4_5formula_6, V1725)
+		reg6416 := Call(__e, __defun__shen_4_5formula_6, V1725)
 		Parse__shen_4_5formula_6 := reg6416
 		_ = Parse__shen_4_5formula_6
-		reg6417 := __e.Call(__defun__fail)
+		reg6417 := Call(__e, __defun__fail)
 		reg6418 := PrimEqual(reg6417, Parse__shen_4_5formula_6)
 		reg6419 := PrimNot(reg6418)
 		var reg6438 Obj
 		if reg6419 == True {
-			reg6420 := __e.Call(__defun__shen_4_5comma_1symbol_6, Parse__shen_4_5formula_6)
+			reg6420 := Call(__e, __defun__shen_4_5comma_1symbol_6, Parse__shen_4_5formula_6)
 			Parse__shen_4_5comma_1symbol_6 := reg6420
 			_ = Parse__shen_4_5comma_1symbol_6
-			reg6421 := __e.Call(__defun__fail)
+			reg6421 := Call(__e, __defun__fail)
 			reg6422 := PrimEqual(reg6421, Parse__shen_4_5comma_1symbol_6)
 			reg6423 := PrimNot(reg6422)
 			var reg6436 Obj
 			if reg6423 == True {
-				reg6424 := __e.Call(__defun__shen_4_5formulae_6, Parse__shen_4_5comma_1symbol_6)
+				reg6424 := Call(__e, __defun__shen_4_5formulae_6, Parse__shen_4_5comma_1symbol_6)
 				Parse__shen_4_5formulae_6 := reg6424
 				_ = Parse__shen_4_5formulae_6
-				reg6425 := __e.Call(__defun__fail)
+				reg6425 := Call(__e, __defun__fail)
 				reg6426 := PrimEqual(reg6425, Parse__shen_4_5formulae_6)
 				reg6427 := PrimNot(reg6426)
 				var reg6434 Obj
 				if reg6427 == True {
 					reg6428 := PrimHead(Parse__shen_4_5formulae_6)
-					reg6429 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formula_6)
-					reg6430 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formulae_6)
+					reg6429 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formula_6)
+					reg6430 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formulae_6)
 					reg6431 := PrimCons(reg6429, reg6430)
-					reg6432 := __e.Call(__defun__shen_4pair, reg6428, reg6431)
+					reg6432 := Call(__e, __defun__shen_4pair, reg6428, reg6431)
 					reg6434 = reg6432
 				} else {
-					reg6433 := __e.Call(__defun__fail)
+					reg6433 := Call(__e, __defun__fail)
 					reg6434 = reg6433
 				}
 				reg6436 = reg6434
 			} else {
-				reg6435 := __e.Call(__defun__fail)
+				reg6435 := Call(__e, __defun__fail)
 				reg6436 = reg6435
 			}
 			reg6438 = reg6436
 		} else {
-			reg6437 := __e.Call(__defun__fail)
+			reg6437 := Call(__e, __defun__fail)
 			reg6438 = reg6437
 		}
 		YaccParse := reg6438
 		_ = YaccParse
-		reg6439 := __e.Call(__defun__fail)
+		reg6439 := Call(__e, __defun__fail)
 		reg6440 := PrimEqual(YaccParse, reg6439)
 		if reg6440 == True {
-			reg6441 := __e.Call(__defun__shen_4_5formula_6, V1725)
+			reg6441 := Call(__e, __defun__shen_4_5formula_6, V1725)
 			Parse__shen_4_5formula_6 := reg6441
 			_ = Parse__shen_4_5formula_6
-			reg6442 := __e.Call(__defun__fail)
+			reg6442 := Call(__e, __defun__fail)
 			reg6443 := PrimEqual(reg6442, Parse__shen_4_5formula_6)
 			reg6444 := PrimNot(reg6443)
 			var reg6451 Obj
 			if reg6444 == True {
 				reg6445 := PrimHead(Parse__shen_4_5formula_6)
-				reg6446 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5formula_6)
+				reg6446 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5formula_6)
 				reg6447 := Nil
 				reg6448 := PrimCons(reg6446, reg6447)
-				reg6449 := __e.Call(__defun__shen_4pair, reg6445, reg6448)
+				reg6449 := Call(__e, __defun__shen_4pair, reg6445, reg6448)
 				reg6451 = reg6449
 			} else {
-				reg6450 := __e.Call(__defun__fail)
+				reg6450 := Call(__e, __defun__fail)
 				reg6451 = reg6450
 			}
 			YaccParse := reg6451
 			_ = YaccParse
-			reg6452 := __e.Call(__defun__fail)
+			reg6452 := Call(__e, __defun__fail)
 			reg6453 := PrimEqual(YaccParse, reg6452)
 			if reg6453 == True {
-				reg6454 := __e.Call(__defun___5e_6, V1725)
+				reg6454 := Call(__e, __defun___5e_6, V1725)
 				Parse___5e_6 := reg6454
 				_ = Parse___5e_6
-				reg6455 := __e.Call(__defun__fail)
+				reg6455 := Call(__e, __defun__fail)
 				reg6456 := PrimEqual(reg6455, Parse___5e_6)
 				reg6457 := PrimNot(reg6456)
 				if reg6457 == True {
 					reg6458 := PrimHead(Parse___5e_6)
 					reg6459 := Nil
-					__ctx.TailApply(__defun__shen_4pair, reg6458, reg6459)
+					__e.TailApply(__defun__shen_4pair, reg6458, reg6459)
 					return
 				} else {
-					__ctx.TailApply(__defun__fail)
+					__e.TailApply(__defun__fail)
 					return
 				}
 			} else {
-				__ctx.Return(YaccParse)
+				__e.Return(YaccParse)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<formulae>", value: __defun__shen_4_5formulae_6})
 
-	__defun__shen_4_5comma_1symbol_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5comma_1symbol_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1727 := __args[0]
 		_ = V1727
 		reg6462 := PrimHead(V1727)
 		reg6463 := PrimIsPair(reg6462)
 		if reg6463 == True {
-			reg6464 := __e.Call(__defun__shen_4hdhd, V1727)
+			reg6464 := Call(__e, __defun__shen_4hdhd, V1727)
 			Parse__X := reg6464
 			_ = Parse__X
 			reg6465 := MakeString(",")
 			reg6466 := PrimIntern(reg6465)
 			reg6467 := PrimEqual(Parse__X, reg6466)
 			if reg6467 == True {
-				reg6468 := __e.Call(__defun__shen_4tlhd, V1727)
-				reg6469 := __e.Call(__defun__shen_4hdtl, V1727)
-				reg6470 := __e.Call(__defun__shen_4pair, reg6468, reg6469)
+				reg6468 := Call(__e, __defun__shen_4tlhd, V1727)
+				reg6469 := Call(__e, __defun__shen_4hdtl, V1727)
+				reg6470 := Call(__e, __defun__shen_4pair, reg6468, reg6469)
 				reg6471 := PrimHead(reg6470)
 				reg6472 := MakeSymbol("shen.skip")
-				__ctx.TailApply(__defun__shen_4pair, reg6471, reg6472)
+				__e.TailApply(__defun__shen_4pair, reg6471, reg6472)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<comma-symbol>", value: __defun__shen_4_5comma_1symbol_6})
 
-	__defun__shen_4_5formula_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5formula_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1730 := __args[0]
 		_ = V1730
-		reg6476 := __e.Call(__defun__shen_4_5expr_6, V1730)
+		reg6476 := Call(__e, __defun__shen_4_5expr_6, V1730)
 		Parse__shen_4_5expr_6 := reg6476
 		_ = Parse__shen_4_5expr_6
-		reg6477 := __e.Call(__defun__fail)
+		reg6477 := Call(__e, __defun__fail)
 		reg6478 := PrimEqual(reg6477, Parse__shen_4_5expr_6)
 		reg6479 := PrimNot(reg6478)
 		var reg6513 Obj
@@ -1229,7 +1229,7 @@ func init() {
 			var reg6489 Obj
 			if reg6481 == True {
 				reg6482 := MakeSymbol(":")
-				reg6483 := __e.Call(__defun__shen_4hdhd, Parse__shen_4_5expr_6)
+				reg6483 := Call(__e, __defun__shen_4hdhd, Parse__shen_4_5expr_6)
 				reg6484 := PrimEqual(reg6482, reg6483)
 				var reg6487 Obj
 				if reg6484 == True {
@@ -1246,182 +1246,182 @@ func init() {
 			}
 			var reg6511 Obj
 			if reg6489 == True {
-				reg6490 := __e.Call(__defun__shen_4tlhd, Parse__shen_4_5expr_6)
-				reg6491 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5expr_6)
-				reg6492 := __e.Call(__defun__shen_4pair, reg6490, reg6491)
+				reg6490 := Call(__e, __defun__shen_4tlhd, Parse__shen_4_5expr_6)
+				reg6491 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5expr_6)
+				reg6492 := Call(__e, __defun__shen_4pair, reg6490, reg6491)
 				NewStream1728 := reg6492
 				_ = NewStream1728
-				reg6493 := __e.Call(__defun__shen_4_5type_6, NewStream1728)
+				reg6493 := Call(__e, __defun__shen_4_5type_6, NewStream1728)
 				Parse__shen_4_5type_6 := reg6493
 				_ = Parse__shen_4_5type_6
-				reg6494 := __e.Call(__defun__fail)
+				reg6494 := Call(__e, __defun__fail)
 				reg6495 := PrimEqual(reg6494, Parse__shen_4_5type_6)
 				reg6496 := PrimNot(reg6495)
 				var reg6509 Obj
 				if reg6496 == True {
 					reg6497 := PrimHead(Parse__shen_4_5type_6)
-					reg6498 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5expr_6)
-					reg6499 := __e.Call(__defun__shen_4curry, reg6498)
+					reg6498 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5expr_6)
+					reg6499 := Call(__e, __defun__shen_4curry, reg6498)
 					reg6500 := MakeSymbol(":")
-					reg6501 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5type_6)
-					reg6502 := __e.Call(__defun__shen_4demodulate, reg6501)
+					reg6501 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5type_6)
+					reg6502 := Call(__e, __defun__shen_4demodulate, reg6501)
 					reg6503 := Nil
 					reg6504 := PrimCons(reg6502, reg6503)
 					reg6505 := PrimCons(reg6500, reg6504)
 					reg6506 := PrimCons(reg6499, reg6505)
-					reg6507 := __e.Call(__defun__shen_4pair, reg6497, reg6506)
+					reg6507 := Call(__e, __defun__shen_4pair, reg6497, reg6506)
 					reg6509 = reg6507
 				} else {
-					reg6508 := __e.Call(__defun__fail)
+					reg6508 := Call(__e, __defun__fail)
 					reg6509 = reg6508
 				}
 				reg6511 = reg6509
 			} else {
-				reg6510 := __e.Call(__defun__fail)
+				reg6510 := Call(__e, __defun__fail)
 				reg6511 = reg6510
 			}
 			reg6513 = reg6511
 		} else {
-			reg6512 := __e.Call(__defun__fail)
+			reg6512 := Call(__e, __defun__fail)
 			reg6513 = reg6512
 		}
 		YaccParse := reg6513
 		_ = YaccParse
-		reg6514 := __e.Call(__defun__fail)
+		reg6514 := Call(__e, __defun__fail)
 		reg6515 := PrimEqual(YaccParse, reg6514)
 		if reg6515 == True {
-			reg6516 := __e.Call(__defun__shen_4_5expr_6, V1730)
+			reg6516 := Call(__e, __defun__shen_4_5expr_6, V1730)
 			Parse__shen_4_5expr_6 := reg6516
 			_ = Parse__shen_4_5expr_6
-			reg6517 := __e.Call(__defun__fail)
+			reg6517 := Call(__e, __defun__fail)
 			reg6518 := PrimEqual(reg6517, Parse__shen_4_5expr_6)
 			reg6519 := PrimNot(reg6518)
 			if reg6519 == True {
 				reg6520 := PrimHead(Parse__shen_4_5expr_6)
-				reg6521 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5expr_6)
-				__ctx.TailApply(__defun__shen_4pair, reg6520, reg6521)
+				reg6521 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5expr_6)
+				__e.TailApply(__defun__shen_4pair, reg6520, reg6521)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<formula>", value: __defun__shen_4_5formula_6})
 
-	__defun__shen_4_5type_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5type_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1732 := __args[0]
 		_ = V1732
-		reg6524 := __e.Call(__defun__shen_4_5expr_6, V1732)
+		reg6524 := Call(__e, __defun__shen_4_5expr_6, V1732)
 		Parse__shen_4_5expr_6 := reg6524
 		_ = Parse__shen_4_5expr_6
-		reg6525 := __e.Call(__defun__fail)
+		reg6525 := Call(__e, __defun__fail)
 		reg6526 := PrimEqual(reg6525, Parse__shen_4_5expr_6)
 		reg6527 := PrimNot(reg6526)
 		if reg6527 == True {
 			reg6528 := PrimHead(Parse__shen_4_5expr_6)
-			reg6529 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5expr_6)
-			reg6530 := __e.Call(__defun__shen_4curry_1type, reg6529)
-			__ctx.TailApply(__defun__shen_4pair, reg6528, reg6530)
+			reg6529 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5expr_6)
+			reg6530 := Call(__e, __defun__shen_4curry_1type, reg6529)
+			__e.TailApply(__defun__shen_4pair, reg6528, reg6530)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<type>", value: __defun__shen_4_5type_6})
 
-	__defun__shen_4_5doubleunderline_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5doubleunderline_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1734 := __args[0]
 		_ = V1734
 		reg6533 := PrimHead(V1734)
 		reg6534 := PrimIsPair(reg6533)
 		if reg6534 == True {
-			reg6535 := __e.Call(__defun__shen_4hdhd, V1734)
+			reg6535 := Call(__e, __defun__shen_4hdhd, V1734)
 			Parse__X := reg6535
 			_ = Parse__X
-			reg6536 := __e.Call(__defun__shen_4doubleunderline_2, Parse__X)
+			reg6536 := Call(__e, __defun__shen_4doubleunderline_2, Parse__X)
 			if reg6536 == True {
-				reg6537 := __e.Call(__defun__shen_4tlhd, V1734)
-				reg6538 := __e.Call(__defun__shen_4hdtl, V1734)
-				reg6539 := __e.Call(__defun__shen_4pair, reg6537, reg6538)
+				reg6537 := Call(__e, __defun__shen_4tlhd, V1734)
+				reg6538 := Call(__e, __defun__shen_4hdtl, V1734)
+				reg6539 := Call(__e, __defun__shen_4pair, reg6537, reg6538)
 				reg6540 := PrimHead(reg6539)
-				__ctx.TailApply(__defun__shen_4pair, reg6540, Parse__X)
+				__e.TailApply(__defun__shen_4pair, reg6540, Parse__X)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<doubleunderline>", value: __defun__shen_4_5doubleunderline_6})
 
-	__defun__shen_4_5singleunderline_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5singleunderline_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1736 := __args[0]
 		_ = V1736
 		reg6544 := PrimHead(V1736)
 		reg6545 := PrimIsPair(reg6544)
 		if reg6545 == True {
-			reg6546 := __e.Call(__defun__shen_4hdhd, V1736)
+			reg6546 := Call(__e, __defun__shen_4hdhd, V1736)
 			Parse__X := reg6546
 			_ = Parse__X
-			reg6547 := __e.Call(__defun__shen_4singleunderline_2, Parse__X)
+			reg6547 := Call(__e, __defun__shen_4singleunderline_2, Parse__X)
 			if reg6547 == True {
-				reg6548 := __e.Call(__defun__shen_4tlhd, V1736)
-				reg6549 := __e.Call(__defun__shen_4hdtl, V1736)
-				reg6550 := __e.Call(__defun__shen_4pair, reg6548, reg6549)
+				reg6548 := Call(__e, __defun__shen_4tlhd, V1736)
+				reg6549 := Call(__e, __defun__shen_4hdtl, V1736)
+				reg6550 := Call(__e, __defun__shen_4pair, reg6548, reg6549)
 				reg6551 := PrimHead(reg6550)
-				__ctx.TailApply(__defun__shen_4pair, reg6551, Parse__X)
+				__e.TailApply(__defun__shen_4pair, reg6551, Parse__X)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<singleunderline>", value: __defun__shen_4_5singleunderline_6})
 
-	__defun__shen_4singleunderline_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4singleunderline_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1738 := __args[0]
 		_ = V1738
 		reg6555 := PrimIsSymbol(V1738)
 		if reg6555 == True {
 			reg6556 := PrimStr(V1738)
-			reg6557 := __e.Call(__defun__shen_4sh_2, reg6556)
+			reg6557 := Call(__e, __defun__shen_4sh_2, reg6556)
 			if reg6557 == True {
 				reg6558 := True
-				__ctx.Return(reg6558)
+				__e.Return(reg6558)
 				return
 			} else {
 				reg6559 := False
-				__ctx.Return(reg6559)
+				__e.Return(reg6559)
 				return
 			}
 		} else {
 			reg6560 := False
-			__ctx.Return(reg6560)
+			__e.Return(reg6560)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.singleunderline?", value: __defun__shen_4singleunderline_2})
 
-	__defun__shen_4sh_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4sh_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1740 := __args[0]
 		_ = V1740
 		reg6561 := MakeString("_")
 		reg6562 := PrimEqual(reg6561, V1740)
 		if reg6562 == True {
 			reg6563 := True
-			__ctx.Return(reg6563)
+			__e.Return(reg6563)
 			return
 		} else {
 			reg6564 := MakeNumber(0)
@@ -1430,57 +1430,57 @@ func init() {
 			reg6567 := PrimEqual(reg6565, reg6566)
 			if reg6567 == True {
 				reg6568 := PrimTailString(V1740)
-				reg6569 := __e.Call(__defun__shen_4sh_2, reg6568)
+				reg6569 := Call(__e, __defun__shen_4sh_2, reg6568)
 				if reg6569 == True {
 					reg6570 := True
-					__ctx.Return(reg6570)
+					__e.Return(reg6570)
 					return
 				} else {
 					reg6571 := False
-					__ctx.Return(reg6571)
+					__e.Return(reg6571)
 					return
 				}
 			} else {
 				reg6572 := False
-				__ctx.Return(reg6572)
+				__e.Return(reg6572)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.sh?", value: __defun__shen_4sh_2})
 
-	__defun__shen_4doubleunderline_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4doubleunderline_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1742 := __args[0]
 		_ = V1742
 		reg6573 := PrimIsSymbol(V1742)
 		if reg6573 == True {
 			reg6574 := PrimStr(V1742)
-			reg6575 := __e.Call(__defun__shen_4dh_2, reg6574)
+			reg6575 := Call(__e, __defun__shen_4dh_2, reg6574)
 			if reg6575 == True {
 				reg6576 := True
-				__ctx.Return(reg6576)
+				__e.Return(reg6576)
 				return
 			} else {
 				reg6577 := False
-				__ctx.Return(reg6577)
+				__e.Return(reg6577)
 				return
 			}
 		} else {
 			reg6578 := False
-			__ctx.Return(reg6578)
+			__e.Return(reg6578)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.doubleunderline?", value: __defun__shen_4doubleunderline_2})
 
-	__defun__shen_4dh_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dh_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1744 := __args[0]
 		_ = V1744
 		reg6579 := MakeString("=")
 		reg6580 := PrimEqual(reg6579, V1744)
 		if reg6580 == True {
 			reg6581 := True
-			__ctx.Return(reg6581)
+			__e.Return(reg6581)
 			return
 		} else {
 			reg6582 := MakeNumber(0)
@@ -1489,38 +1489,38 @@ func init() {
 			reg6585 := PrimEqual(reg6583, reg6584)
 			if reg6585 == True {
 				reg6586 := PrimTailString(V1744)
-				reg6587 := __e.Call(__defun__shen_4dh_2, reg6586)
+				reg6587 := Call(__e, __defun__shen_4dh_2, reg6586)
 				if reg6587 == True {
 					reg6588 := True
-					__ctx.Return(reg6588)
+					__e.Return(reg6588)
 					return
 				} else {
 					reg6589 := False
-					__ctx.Return(reg6589)
+					__e.Return(reg6589)
 					return
 				}
 			} else {
 				reg6590 := False
-				__ctx.Return(reg6590)
+				__e.Return(reg6590)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.dh?", value: __defun__shen_4dh_2})
 
-	__defun__shen_4process_1datatype = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4process_1datatype = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1747 := __args[0]
 		_ = V1747
 		V1748 := __args[1]
 		_ = V1748
-		reg6591 := __e.Call(__defun__shen_4rules_1_6horn_1clauses, V1747, V1748)
-		reg6592 := __e.Call(__defun__shen_4s_1prolog, reg6591)
-		__ctx.TailApply(__defun__shen_4remember_1datatype, reg6592)
+		reg6591 := Call(__e, __defun__shen_4rules_1_6horn_1clauses, V1747, V1748)
+		reg6592 := Call(__e, __defun__shen_4s_1prolog, reg6591)
+		__e.TailApply(__defun__shen_4remember_1datatype, reg6592)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.process-datatype", value: __defun__shen_4process_1datatype})
 
-	__defun__shen_4remember_1datatype = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4remember_1datatype = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1754 := __args[0]
 		_ = V1754
 		reg6594 := PrimIsPair(V1754)
@@ -1529,28 +1529,28 @@ func init() {
 			reg6596 := PrimHead(V1754)
 			reg6597 := MakeSymbol("shen.*datatypes*")
 			reg6598 := PrimValue(reg6597)
-			reg6599 := __e.Call(__defun__adjoin, reg6596, reg6598)
+			reg6599 := Call(__e, __defun__adjoin, reg6596, reg6598)
 			reg6600 := PrimSet(reg6595, reg6599)
 			_ = reg6600
 			reg6601 := MakeSymbol("shen.*alldatatypes*")
 			reg6602 := PrimHead(V1754)
 			reg6603 := MakeSymbol("shen.*alldatatypes*")
 			reg6604 := PrimValue(reg6603)
-			reg6605 := __e.Call(__defun__adjoin, reg6602, reg6604)
+			reg6605 := Call(__e, __defun__adjoin, reg6602, reg6604)
 			reg6606 := PrimSet(reg6601, reg6605)
 			_ = reg6606
 			reg6607 := PrimHead(V1754)
-			__ctx.Return(reg6607)
+			__e.Return(reg6607)
 			return
 		} else {
 			reg6608 := MakeSymbol("shen.remember-datatype")
-			__ctx.TailApply(__defun__shen_4f__error, reg6608)
+			__e.TailApply(__defun__shen_4f__error, reg6608)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.remember-datatype", value: __defun__shen_4remember_1datatype})
 
-	__defun__shen_4rules_1_6horn_1clauses = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4rules_1_6horn_1clauses = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1759 := __args[0]
 		_ = V1759
 		V1760 := __args[1]
@@ -1559,19 +1559,19 @@ func init() {
 		reg6611 := PrimEqual(reg6610, V1760)
 		if reg6611 == True {
 			reg6612 := Nil
-			__ctx.Return(reg6612)
+			__e.Return(reg6612)
 			return
 		} else {
 			reg6613 := PrimIsPair(V1760)
 			var reg6629 Obj
 			if reg6613 == True {
 				reg6614 := PrimHead(V1760)
-				reg6615 := __e.Call(__defun__tuple_2, reg6614)
+				reg6615 := Call(__e, __defun__tuple_2, reg6614)
 				var reg6624 Obj
 				if reg6615 == True {
 					reg6616 := MakeSymbol("shen.single")
 					reg6617 := PrimHead(V1760)
-					reg6618 := __e.Call(__defun__fst, reg6617)
+					reg6618 := Call(__e, __defun__fst, reg6617)
 					reg6619 := PrimEqual(reg6616, reg6618)
 					var reg6622 Obj
 					if reg6619 == True {
@@ -1601,24 +1601,24 @@ func init() {
 			}
 			if reg6629 == True {
 				reg6630 := PrimHead(V1760)
-				reg6631 := __e.Call(__defun__snd, reg6630)
-				reg6632 := __e.Call(__defun__shen_4rule_1_6horn_1clause, V1759, reg6631)
+				reg6631 := Call(__e, __defun__snd, reg6630)
+				reg6632 := Call(__e, __defun__shen_4rule_1_6horn_1clause, V1759, reg6631)
 				reg6633 := PrimTail(V1760)
-				reg6634 := __e.Call(__defun__shen_4rules_1_6horn_1clauses, V1759, reg6633)
+				reg6634 := Call(__e, __defun__shen_4rules_1_6horn_1clauses, V1759, reg6633)
 				reg6635 := PrimCons(reg6632, reg6634)
-				__ctx.Return(reg6635)
+				__e.Return(reg6635)
 				return
 			} else {
 				reg6636 := PrimIsPair(V1760)
 				var reg6652 Obj
 				if reg6636 == True {
 					reg6637 := PrimHead(V1760)
-					reg6638 := __e.Call(__defun__tuple_2, reg6637)
+					reg6638 := Call(__e, __defun__tuple_2, reg6637)
 					var reg6647 Obj
 					if reg6638 == True {
 						reg6639 := MakeSymbol("shen.double")
 						reg6640 := PrimHead(V1760)
-						reg6641 := __e.Call(__defun__fst, reg6640)
+						reg6641 := Call(__e, __defun__fst, reg6640)
 						reg6642 := PrimEqual(reg6639, reg6641)
 						var reg6645 Obj
 						if reg6642 == True {
@@ -1648,15 +1648,15 @@ func init() {
 				}
 				if reg6652 == True {
 					reg6653 := PrimHead(V1760)
-					reg6654 := __e.Call(__defun__snd, reg6653)
-					reg6655 := __e.Call(__defun__shen_4double_1_6singles, reg6654)
+					reg6654 := Call(__e, __defun__snd, reg6653)
+					reg6655 := Call(__e, __defun__shen_4double_1_6singles, reg6654)
 					reg6656 := PrimTail(V1760)
-					reg6657 := __e.Call(__defun__append, reg6655, reg6656)
-					__ctx.TailApply(__defun__shen_4rules_1_6horn_1clauses, V1759, reg6657)
+					reg6657 := Call(__e, __defun__append, reg6655, reg6656)
+					__e.TailApply(__defun__shen_4rules_1_6horn_1clauses, V1759, reg6657)
 					return
 				} else {
 					reg6659 := MakeSymbol("shen.rules->horn-clauses")
-					__ctx.TailApply(__defun__shen_4f__error, reg6659)
+					__e.TailApply(__defun__shen_4f__error, reg6659)
 					return
 				}
 			}
@@ -1664,29 +1664,29 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.rules->horn-clauses", value: __defun__shen_4rules_1_6horn_1clauses})
 
-	__defun__shen_4double_1_6singles = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4double_1_6singles = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1762 := __args[0]
 		_ = V1762
-		reg6661 := __e.Call(__defun__shen_4right_1rule, V1762)
-		reg6662 := __e.Call(__defun__shen_4left_1rule, V1762)
+		reg6661 := Call(__e, __defun__shen_4right_1rule, V1762)
+		reg6662 := Call(__e, __defun__shen_4left_1rule, V1762)
 		reg6663 := Nil
 		reg6664 := PrimCons(reg6662, reg6663)
 		reg6665 := PrimCons(reg6661, reg6664)
-		__ctx.Return(reg6665)
+		__e.Return(reg6665)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.double->singles", value: __defun__shen_4double_1_6singles})
 
-	__defun__shen_4right_1rule = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4right_1rule = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1764 := __args[0]
 		_ = V1764
 		reg6666 := MakeSymbol("shen.single")
-		__ctx.TailApply(__defun___8p, reg6666, V1764)
+		__e.TailApply(__defun___8p, reg6666, V1764)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.right-rule", value: __defun__shen_4right_1rule})
 
-	__defun__shen_4left_1rule = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4left_1rule = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1766 := __args[0]
 		_ = V1766
 		reg6668 := PrimIsPair(V1766)
@@ -1704,14 +1704,14 @@ func init() {
 					reg6674 := PrimTail(V1766)
 					reg6675 := PrimTail(reg6674)
 					reg6676 := PrimHead(reg6675)
-					reg6677 := __e.Call(__defun__tuple_2, reg6676)
+					reg6677 := Call(__e, __defun__tuple_2, reg6676)
 					var reg6698 Obj
 					if reg6677 == True {
 						reg6678 := Nil
 						reg6679 := PrimTail(V1766)
 						reg6680 := PrimTail(reg6679)
 						reg6681 := PrimHead(reg6680)
-						reg6682 := __e.Call(__defun__fst, reg6681)
+						reg6682 := Call(__e, __defun__fst, reg6681)
 						reg6683 := PrimEqual(reg6678, reg6682)
 						var reg6693 Obj
 						if reg6683 == True {
@@ -1787,28 +1787,28 @@ func init() {
 		}
 		if reg6713 == True {
 			reg6714 := MakeSymbol("Qv")
-			reg6715 := __e.Call(__defun__gensym, reg6714)
+			reg6715 := Call(__e, __defun__gensym, reg6714)
 			Q := reg6715
 			_ = Q
 			reg6716 := PrimTail(V1766)
 			reg6717 := PrimTail(reg6716)
 			reg6718 := PrimHead(reg6717)
-			reg6719 := __e.Call(__defun__snd, reg6718)
+			reg6719 := Call(__e, __defun__snd, reg6718)
 			reg6720 := Nil
 			reg6721 := PrimCons(reg6719, reg6720)
-			reg6722 := __e.Call(__defun___8p, reg6721, Q)
+			reg6722 := Call(__e, __defun___8p, reg6721, Q)
 			NewConclusion := reg6722
 			_ = NewConclusion
-			reg6723 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg6723 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				__ctx.TailApply(__defun__shen_4right_1_6left, X)
+				__e.TailApply(__defun__shen_4right_1_6left, X)
 				return
 			}, 1)
 			reg6725 := PrimTail(V1766)
 			reg6726 := PrimHead(reg6725)
-			reg6727 := __e.Call(__defun__map, reg6723, reg6726)
-			reg6728 := __e.Call(__defun___8p, reg6727, Q)
+			reg6727 := Call(__e, __defun__map, reg6723, reg6726)
+			reg6728 := Call(__e, __defun___8p, reg6727, Q)
 			reg6729 := Nil
 			reg6730 := PrimCons(reg6728, reg6729)
 			NewPremises := reg6730
@@ -1819,24 +1819,24 @@ func init() {
 			reg6734 := PrimCons(NewConclusion, reg6733)
 			reg6735 := PrimCons(NewPremises, reg6734)
 			reg6736 := PrimCons(reg6732, reg6735)
-			__ctx.TailApply(__defun___8p, reg6731, reg6736)
+			__e.TailApply(__defun___8p, reg6731, reg6736)
 			return
 		} else {
 			reg6738 := MakeSymbol("shen.left-rule")
-			__ctx.TailApply(__defun__shen_4f__error, reg6738)
+			__e.TailApply(__defun__shen_4f__error, reg6738)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.left-rule", value: __defun__shen_4left_1rule})
 
-	__defun__shen_4right_1_6left = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4right_1_6left = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1772 := __args[0]
 		_ = V1772
-		reg6740 := __e.Call(__defun__tuple_2, V1772)
+		reg6740 := Call(__e, __defun__tuple_2, V1772)
 		var reg6748 Obj
 		if reg6740 == True {
 			reg6741 := Nil
-			reg6742 := __e.Call(__defun__fst, V1772)
+			reg6742 := Call(__e, __defun__fst, V1772)
 			reg6743 := PrimEqual(reg6741, reg6742)
 			var reg6746 Obj
 			if reg6743 == True {
@@ -1852,18 +1852,18 @@ func init() {
 			reg6748 = reg6747
 		}
 		if reg6748 == True {
-			__ctx.TailApply(__defun__snd, V1772)
+			__e.TailApply(__defun__snd, V1772)
 			return
 		} else {
 			reg6750 := MakeString("syntax error with ==========\n")
 			reg6751 := PrimSimpleError(reg6750)
-			__ctx.Return(reg6751)
+			__e.Return(reg6751)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.right->left", value: __defun__shen_4right_1_6left})
 
-	__defun__shen_4rule_1_6horn_1clause = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4rule_1_6horn_1clause = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1775 := __args[0]
 		_ = V1775
 		V1776 := __args[1]
@@ -1883,7 +1883,7 @@ func init() {
 					reg6758 := PrimTail(V1776)
 					reg6759 := PrimTail(reg6758)
 					reg6760 := PrimHead(reg6759)
-					reg6761 := __e.Call(__defun__tuple_2, reg6760)
+					reg6761 := Call(__e, __defun__tuple_2, reg6760)
 					var reg6771 Obj
 					if reg6761 == True {
 						reg6762 := Nil
@@ -1947,8 +1947,8 @@ func init() {
 			reg6787 := PrimTail(V1776)
 			reg6788 := PrimTail(reg6787)
 			reg6789 := PrimHead(reg6788)
-			reg6790 := __e.Call(__defun__snd, reg6789)
-			reg6791 := __e.Call(__defun__shen_4rule_1_6horn_1clause_1head, V1775, reg6790)
+			reg6790 := Call(__e, __defun__snd, reg6789)
+			reg6791 := Call(__e, __defun__shen_4rule_1_6horn_1clause_1head, V1775, reg6790)
 			reg6792 := MakeSymbol(":-")
 			reg6793 := PrimHead(V1776)
 			reg6794 := PrimTail(V1776)
@@ -1956,39 +1956,39 @@ func init() {
 			reg6796 := PrimTail(V1776)
 			reg6797 := PrimTail(reg6796)
 			reg6798 := PrimHead(reg6797)
-			reg6799 := __e.Call(__defun__fst, reg6798)
-			reg6800 := __e.Call(__defun__shen_4rule_1_6horn_1clause_1body, reg6793, reg6795, reg6799)
+			reg6799 := Call(__e, __defun__fst, reg6798)
+			reg6800 := Call(__e, __defun__shen_4rule_1_6horn_1clause_1body, reg6793, reg6795, reg6799)
 			reg6801 := Nil
 			reg6802 := PrimCons(reg6800, reg6801)
 			reg6803 := PrimCons(reg6792, reg6802)
 			reg6804 := PrimCons(reg6791, reg6803)
-			__ctx.Return(reg6804)
+			__e.Return(reg6804)
 			return
 		} else {
 			reg6805 := MakeSymbol("shen.rule->horn-clause")
-			__ctx.TailApply(__defun__shen_4f__error, reg6805)
+			__e.TailApply(__defun__shen_4f__error, reg6805)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.rule->horn-clause", value: __defun__shen_4rule_1_6horn_1clause})
 
-	__defun__shen_4rule_1_6horn_1clause_1head = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4rule_1_6horn_1clause_1head = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1779 := __args[0]
 		_ = V1779
 		V1780 := __args[1]
 		_ = V1780
-		reg6807 := __e.Call(__defun__shen_4mode_1ify, V1780)
+		reg6807 := Call(__e, __defun__shen_4mode_1ify, V1780)
 		reg6808 := MakeSymbol("Context_1957")
 		reg6809 := Nil
 		reg6810 := PrimCons(reg6808, reg6809)
 		reg6811 := PrimCons(reg6807, reg6810)
 		reg6812 := PrimCons(V1779, reg6811)
-		__ctx.Return(reg6812)
+		__e.Return(reg6812)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.rule->horn-clause-head", value: __defun__shen_4rule_1_6horn_1clause_1head})
 
-	__defun__shen_4mode_1ify = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4mode_1ify = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1782 := __args[0]
 		_ = V1782
 		reg6813 := PrimIsPair(V1782)
@@ -2088,69 +2088,69 @@ func init() {
 			reg6866 := PrimCons(reg6864, reg6865)
 			reg6867 := PrimCons(reg6863, reg6866)
 			reg6868 := PrimCons(reg6848, reg6867)
-			__ctx.Return(reg6868)
+			__e.Return(reg6868)
 			return
 		} else {
-			__ctx.Return(V1782)
+			__e.Return(V1782)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.mode-ify", value: __defun__shen_4mode_1ify})
 
-	__defun__shen_4rule_1_6horn_1clause_1body = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4rule_1_6horn_1clause_1body = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1786 := __args[0]
 		_ = V1786
 		V1787 := __args[1]
 		_ = V1787
 		V1788 := __args[2]
 		_ = V1788
-		reg6869 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg6869 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4extract__vars, X)
+			__e.TailApply(__defun__shen_4extract__vars, X)
 			return
 		}, 1)
-		reg6871 := __e.Call(__defun__map, reg6869, V1788)
+		reg6871 := Call(__e, __defun__map, reg6869, V1788)
 		Variables := reg6871
 		_ = Variables
-		reg6872 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg6872 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
 			reg6873 := MakeSymbol("shen.cl")
-			__ctx.TailApply(__defun__gensym, reg6873)
+			__e.TailApply(__defun__gensym, reg6873)
 			return
 		}, 1)
-		reg6875 := __e.Call(__defun__map, reg6872, V1788)
+		reg6875 := Call(__e, __defun__map, reg6872, V1788)
 		Predicates := reg6875
 		_ = Predicates
 		reg6876 := MakeSymbol("Context_1957")
 		reg6877 := MakeSymbol("Context1_1957")
-		reg6878 := __e.Call(__defun__shen_4construct_1search_1literals, Predicates, Variables, reg6876, reg6877)
+		reg6878 := Call(__e, __defun__shen_4construct_1search_1literals, Predicates, Variables, reg6876, reg6877)
 		SearchLiterals := reg6878
 		_ = SearchLiterals
-		reg6879 := __e.Call(__defun__shen_4construct_1search_1clauses, Predicates, V1788, Variables)
+		reg6879 := Call(__e, __defun__shen_4construct_1search_1clauses, Predicates, V1788, Variables)
 		SearchClauses := reg6879
 		_ = SearchClauses
-		reg6880 := __e.Call(__defun__shen_4construct_1side_1literals, V1786)
+		reg6880 := Call(__e, __defun__shen_4construct_1side_1literals, V1786)
 		SideLiterals := reg6880
 		_ = SideLiterals
-		reg6881 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg6881 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			reg6882 := __e.Call(__defun__empty_2, V1788)
-			__ctx.TailApply(__defun__shen_4construct_1premiss_1literal, X, reg6882)
+			reg6882 := Call(__e, __defun__empty_2, V1788)
+			__e.TailApply(__defun__shen_4construct_1premiss_1literal, X, reg6882)
 			return
 		}, 1)
-		reg6884 := __e.Call(__defun__map, reg6881, V1787)
+		reg6884 := Call(__e, __defun__map, reg6881, V1787)
 		PremissLiterals := reg6884
 		_ = PremissLiterals
-		reg6885 := __e.Call(__defun__append, SideLiterals, PremissLiterals)
-		__ctx.TailApply(__defun__append, SearchLiterals, reg6885)
+		reg6885 := Call(__e, __defun__append, SideLiterals, PremissLiterals)
+		__e.TailApply(__defun__append, SearchLiterals, reg6885)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.rule->horn-clause-body", value: __defun__shen_4rule_1_6horn_1clause_1body})
 
-	__defun__shen_4construct_1search_1literals = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4construct_1search_1literals = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1797 := __args[0]
 		_ = V1797
 		V1798 := __args[1]
@@ -2180,16 +2180,16 @@ func init() {
 		}
 		if reg6895 == True {
 			reg6896 := Nil
-			__ctx.Return(reg6896)
+			__e.Return(reg6896)
 			return
 		} else {
-			__ctx.TailApply(__defun__shen_4csl_1help, V1797, V1798, V1799, V1800)
+			__e.TailApply(__defun__shen_4csl_1help, V1797, V1798, V1799, V1800)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.construct-search-literals", value: __defun__shen_4construct_1search_1literals})
 
-	__defun__shen_4csl_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4csl_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1807 := __args[0]
 		_ = V1807
 		V1808 := __args[1]
@@ -2226,7 +2226,7 @@ func init() {
 			reg6912 := PrimCons(reg6907, reg6911)
 			reg6913 := Nil
 			reg6914 := PrimCons(reg6912, reg6913)
-			__ctx.Return(reg6914)
+			__e.Return(reg6914)
 			return
 		} else {
 			reg6915 := PrimIsPair(V1807)
@@ -2255,21 +2255,21 @@ func init() {
 				reg6927 := PrimTail(V1807)
 				reg6928 := PrimTail(V1808)
 				reg6929 := MakeSymbol("Context")
-				reg6930 := __e.Call(__defun__gensym, reg6929)
-				reg6931 := __e.Call(__defun__shen_4csl_1help, reg6927, reg6928, V1810, reg6930)
+				reg6930 := Call(__e, __defun__gensym, reg6929)
+				reg6931 := Call(__e, __defun__shen_4csl_1help, reg6927, reg6928, V1810, reg6930)
 				reg6932 := PrimCons(reg6926, reg6931)
-				__ctx.Return(reg6932)
+				__e.Return(reg6932)
 				return
 			} else {
 				reg6933 := MakeSymbol("shen.csl-help")
-				__ctx.TailApply(__defun__shen_4f__error, reg6933)
+				__e.TailApply(__defun__shen_4f__error, reg6933)
 				return
 			}
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.csl-help", value: __defun__shen_4csl_1help})
 
-	__defun__shen_4construct_1search_1clauses = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4construct_1search_1clauses = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1814 := __args[0]
 		_ = V1814
 		V1815 := __args[1]
@@ -2314,7 +2314,7 @@ func init() {
 		}
 		if reg6950 == True {
 			reg6951 := MakeSymbol("shen.skip")
-			__ctx.Return(reg6951)
+			__e.Return(reg6951)
 			return
 		} else {
 			reg6952 := PrimIsPair(V1814)
@@ -2354,47 +2354,47 @@ func init() {
 				reg6965 := PrimHead(V1814)
 				reg6966 := PrimHead(V1815)
 				reg6967 := PrimHead(V1816)
-				reg6968 := __e.Call(__defun__shen_4construct_1search_1clause, reg6965, reg6966, reg6967)
+				reg6968 := Call(__e, __defun__shen_4construct_1search_1clause, reg6965, reg6966, reg6967)
 				_ = reg6968
 				reg6969 := PrimTail(V1814)
 				reg6970 := PrimTail(V1815)
 				reg6971 := PrimTail(V1816)
-				__ctx.TailApply(__defun__shen_4construct_1search_1clauses, reg6969, reg6970, reg6971)
+				__e.TailApply(__defun__shen_4construct_1search_1clauses, reg6969, reg6970, reg6971)
 				return
 			} else {
 				reg6973 := MakeSymbol("shen.construct-search-clauses")
-				__ctx.TailApply(__defun__shen_4f__error, reg6973)
+				__e.TailApply(__defun__shen_4f__error, reg6973)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.construct-search-clauses", value: __defun__shen_4construct_1search_1clauses})
 
-	__defun__shen_4construct_1search_1clause = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4construct_1search_1clause = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1820 := __args[0]
 		_ = V1820
 		V1821 := __args[1]
 		_ = V1821
 		V1822 := __args[2]
 		_ = V1822
-		reg6975 := __e.Call(__defun__shen_4construct_1base_1search_1clause, V1820, V1821, V1822)
-		reg6976 := __e.Call(__defun__shen_4construct_1recursive_1search_1clause, V1820, V1821, V1822)
+		reg6975 := Call(__e, __defun__shen_4construct_1base_1search_1clause, V1820, V1821, V1822)
+		reg6976 := Call(__e, __defun__shen_4construct_1recursive_1search_1clause, V1820, V1821, V1822)
 		reg6977 := Nil
 		reg6978 := PrimCons(reg6976, reg6977)
 		reg6979 := PrimCons(reg6975, reg6978)
-		__ctx.TailApply(__defun__shen_4s_1prolog, reg6979)
+		__e.TailApply(__defun__shen_4s_1prolog, reg6979)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.construct-search-clause", value: __defun__shen_4construct_1search_1clause})
 
-	__defun__shen_4construct_1base_1search_1clause = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4construct_1base_1search_1clause = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1826 := __args[0]
 		_ = V1826
 		V1827 := __args[1]
 		_ = V1827
 		V1828 := __args[2]
 		_ = V1828
-		reg6981 := __e.Call(__defun__shen_4mode_1ify, V1827)
+		reg6981 := Call(__e, __defun__shen_4mode_1ify, V1827)
 		reg6982 := MakeSymbol("In_1957")
 		reg6983 := PrimCons(reg6981, reg6982)
 		reg6984 := MakeSymbol("In_1957")
@@ -2407,12 +2407,12 @@ func init() {
 		reg6991 := PrimCons(reg6989, reg6990)
 		reg6992 := PrimCons(reg6988, reg6991)
 		reg6993 := PrimCons(reg6987, reg6992)
-		__ctx.Return(reg6993)
+		__e.Return(reg6993)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.construct-base-search-clause", value: __defun__shen_4construct_1base_1search_1clause})
 
-	__defun__shen_4construct_1recursive_1search_1clause = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4construct_1recursive_1search_1clause = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1832 := __args[0]
 		_ = V1832
 		V1833 := __args[1]
@@ -2440,19 +2440,19 @@ func init() {
 		reg7012 := PrimCons(reg7010, reg7011)
 		reg7013 := PrimCons(reg7003, reg7012)
 		reg7014 := PrimCons(reg7002, reg7013)
-		__ctx.Return(reg7014)
+		__e.Return(reg7014)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.construct-recursive-search-clause", value: __defun__shen_4construct_1recursive_1search_1clause})
 
-	__defun__shen_4construct_1side_1literals = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4construct_1side_1literals = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1840 := __args[0]
 		_ = V1840
 		reg7015 := Nil
 		reg7016 := PrimEqual(reg7015, V1840)
 		if reg7016 == True {
 			reg7017 := Nil
-			__ctx.Return(reg7017)
+			__e.Return(reg7017)
 			return
 		} else {
 			reg7018 := PrimIsPair(V1840)
@@ -2536,9 +2536,9 @@ func init() {
 				reg7055 := PrimTail(reg7054)
 				reg7056 := PrimCons(reg7053, reg7055)
 				reg7057 := PrimTail(V1840)
-				reg7058 := __e.Call(__defun__shen_4construct_1side_1literals, reg7057)
+				reg7058 := Call(__e, __defun__shen_4construct_1side_1literals, reg7057)
 				reg7059 := PrimCons(reg7056, reg7058)
-				__ctx.Return(reg7059)
+				__e.Return(reg7059)
 				return
 			} else {
 				reg7060 := PrimIsPair(V1840)
@@ -2642,19 +2642,19 @@ func init() {
 					reg7107 := PrimTail(reg7106)
 					reg7108 := PrimCons(reg7105, reg7107)
 					reg7109 := PrimTail(V1840)
-					reg7110 := __e.Call(__defun__shen_4construct_1side_1literals, reg7109)
+					reg7110 := Call(__e, __defun__shen_4construct_1side_1literals, reg7109)
 					reg7111 := PrimCons(reg7108, reg7110)
-					__ctx.Return(reg7111)
+					__e.Return(reg7111)
 					return
 				} else {
 					reg7112 := PrimIsPair(V1840)
 					if reg7112 == True {
 						reg7113 := PrimTail(V1840)
-						__ctx.TailApply(__defun__shen_4construct_1side_1literals, reg7113)
+						__e.TailApply(__defun__shen_4construct_1side_1literals, reg7113)
 						return
 					} else {
 						reg7115 := MakeSymbol("shen.construct-side-literals")
-						__ctx.TailApply(__defun__shen_4f__error, reg7115)
+						__e.TailApply(__defun__shen_4f__error, reg7115)
 						return
 					}
 				}
@@ -2663,23 +2663,23 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.construct-side-literals", value: __defun__shen_4construct_1side_1literals})
 
-	__defun__shen_4construct_1premiss_1literal = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4construct_1premiss_1literal = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1847 := __args[0]
 		_ = V1847
 		V1848 := __args[1]
 		_ = V1848
-		reg7117 := __e.Call(__defun__tuple_2, V1847)
+		reg7117 := Call(__e, __defun__tuple_2, V1847)
 		if reg7117 == True {
 			reg7118 := MakeSymbol("shen.t*")
-			reg7119 := __e.Call(__defun__snd, V1847)
-			reg7120 := __e.Call(__defun__shen_4recursive__cons__form, reg7119)
-			reg7121 := __e.Call(__defun__fst, V1847)
-			reg7122 := __e.Call(__defun__shen_4construct_1context, V1848, reg7121)
+			reg7119 := Call(__e, __defun__snd, V1847)
+			reg7120 := Call(__e, __defun__shen_4recursive__cons__form, reg7119)
+			reg7121 := Call(__e, __defun__fst, V1847)
+			reg7122 := Call(__e, __defun__shen_4construct_1context, V1848, reg7121)
 			reg7123 := Nil
 			reg7124 := PrimCons(reg7122, reg7123)
 			reg7125 := PrimCons(reg7120, reg7124)
 			reg7126 := PrimCons(reg7118, reg7125)
-			__ctx.Return(reg7126)
+			__e.Return(reg7126)
 			return
 		} else {
 			reg7127 := MakeSymbol("!")
@@ -2690,18 +2690,18 @@ func init() {
 				reg7131 := Nil
 				reg7132 := PrimCons(reg7130, reg7131)
 				reg7133 := PrimCons(reg7129, reg7132)
-				__ctx.Return(reg7133)
+				__e.Return(reg7133)
 				return
 			} else {
 				reg7134 := MakeSymbol("shen.construct-premiss-literal")
-				__ctx.TailApply(__defun__shen_4f__error, reg7134)
+				__e.TailApply(__defun__shen_4f__error, reg7134)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.construct-premiss-literal", value: __defun__shen_4construct_1premiss_1literal})
 
-	__defun__shen_4construct_1context = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4construct_1context = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1851 := __args[0]
 		_ = V1851
 		V1852 := __args[1]
@@ -2727,7 +2727,7 @@ func init() {
 		}
 		if reg7144 == True {
 			reg7145 := MakeSymbol("Context_1957")
-			__ctx.Return(reg7145)
+			__e.Return(reg7145)
 			return
 		} else {
 			reg7146 := False
@@ -2751,25 +2751,25 @@ func init() {
 			}
 			if reg7154 == True {
 				reg7155 := MakeSymbol("ContextOut_1957")
-				__ctx.Return(reg7155)
+				__e.Return(reg7155)
 				return
 			} else {
 				reg7156 := PrimIsPair(V1852)
 				if reg7156 == True {
 					reg7157 := MakeSymbol("cons")
 					reg7158 := PrimHead(V1852)
-					reg7159 := __e.Call(__defun__shen_4recursive__cons__form, reg7158)
+					reg7159 := Call(__e, __defun__shen_4recursive__cons__form, reg7158)
 					reg7160 := PrimTail(V1852)
-					reg7161 := __e.Call(__defun__shen_4construct_1context, V1851, reg7160)
+					reg7161 := Call(__e, __defun__shen_4construct_1context, V1851, reg7160)
 					reg7162 := Nil
 					reg7163 := PrimCons(reg7161, reg7162)
 					reg7164 := PrimCons(reg7159, reg7163)
 					reg7165 := PrimCons(reg7157, reg7164)
-					__ctx.Return(reg7165)
+					__e.Return(reg7165)
 					return
 				} else {
 					reg7166 := MakeSymbol("shen.construct-context")
-					__ctx.TailApply(__defun__shen_4f__error, reg7166)
+					__e.TailApply(__defun__shen_4f__error, reg7166)
 					return
 				}
 			}
@@ -2777,135 +2777,135 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.construct-context", value: __defun__shen_4construct_1context})
 
-	__defun__shen_4recursive__cons__form = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4recursive__cons__form = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1854 := __args[0]
 		_ = V1854
 		reg7168 := PrimIsPair(V1854)
 		if reg7168 == True {
 			reg7169 := MakeSymbol("cons")
 			reg7170 := PrimHead(V1854)
-			reg7171 := __e.Call(__defun__shen_4recursive__cons__form, reg7170)
+			reg7171 := Call(__e, __defun__shen_4recursive__cons__form, reg7170)
 			reg7172 := PrimTail(V1854)
-			reg7173 := __e.Call(__defun__shen_4recursive__cons__form, reg7172)
+			reg7173 := Call(__e, __defun__shen_4recursive__cons__form, reg7172)
 			reg7174 := Nil
 			reg7175 := PrimCons(reg7173, reg7174)
 			reg7176 := PrimCons(reg7171, reg7175)
 			reg7177 := PrimCons(reg7169, reg7176)
-			__ctx.Return(reg7177)
+			__e.Return(reg7177)
 			return
 		} else {
-			__ctx.Return(V1854)
+			__e.Return(V1854)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.recursive_cons_form", value: __defun__shen_4recursive__cons__form})
 
-	__defun__preclude = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__preclude = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1856 := __args[0]
 		_ = V1856
-		reg7178 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg7178 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4intern_1type, X)
+			__e.TailApply(__defun__shen_4intern_1type, X)
 			return
 		}, 1)
-		reg7180 := __e.Call(__defun__map, reg7178, V1856)
-		__ctx.TailApply(__defun__shen_4preclude_1h, reg7180)
+		reg7180 := Call(__e, __defun__map, reg7178, V1856)
+		__e.TailApply(__defun__shen_4preclude_1h, reg7180)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "preclude", value: __defun__preclude})
 
-	__defun__shen_4preclude_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4preclude_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1858 := __args[0]
 		_ = V1858
 		reg7182 := MakeSymbol("shen.*datatypes*")
 		reg7183 := MakeSymbol("shen.*datatypes*")
 		reg7184 := PrimValue(reg7183)
-		reg7185 := __e.Call(__defun__difference, reg7184, V1858)
+		reg7185 := Call(__e, __defun__difference, reg7184, V1858)
 		reg7186 := PrimSet(reg7182, reg7185)
 		FilterDatatypes := reg7186
 		_ = FilterDatatypes
 		reg7187 := MakeSymbol("shen.*datatypes*")
 		reg7188 := PrimValue(reg7187)
-		__ctx.Return(reg7188)
+		__e.Return(reg7188)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.preclude-h", value: __defun__shen_4preclude_1h})
 
-	__defun__include = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__include = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1860 := __args[0]
 		_ = V1860
-		reg7189 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg7189 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4intern_1type, X)
+			__e.TailApply(__defun__shen_4intern_1type, X)
 			return
 		}, 1)
-		reg7191 := __e.Call(__defun__map, reg7189, V1860)
-		__ctx.TailApply(__defun__shen_4include_1h, reg7191)
+		reg7191 := Call(__e, __defun__map, reg7189, V1860)
+		__e.TailApply(__defun__shen_4include_1h, reg7191)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "include", value: __defun__include})
 
-	__defun__shen_4include_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4include_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1862 := __args[0]
 		_ = V1862
 		reg7193 := MakeSymbol("shen.*alldatatypes*")
 		reg7194 := PrimValue(reg7193)
-		reg7195 := __e.Call(__defun__intersection, V1862, reg7194)
+		reg7195 := Call(__e, __defun__intersection, V1862, reg7194)
 		ValidTypes := reg7195
 		_ = ValidTypes
 		reg7196 := MakeSymbol("shen.*datatypes*")
 		reg7197 := MakeSymbol("shen.*datatypes*")
 		reg7198 := PrimValue(reg7197)
-		reg7199 := __e.Call(__defun__union, ValidTypes, reg7198)
+		reg7199 := Call(__e, __defun__union, ValidTypes, reg7198)
 		reg7200 := PrimSet(reg7196, reg7199)
 		NewDatatypes := reg7200
 		_ = NewDatatypes
 		reg7201 := MakeSymbol("shen.*datatypes*")
 		reg7202 := PrimValue(reg7201)
-		__ctx.Return(reg7202)
+		__e.Return(reg7202)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.include-h", value: __defun__shen_4include_1h})
 
-	__defun__preclude_1all_1but = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__preclude_1all_1but = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1864 := __args[0]
 		_ = V1864
 		reg7203 := MakeSymbol("shen.*alldatatypes*")
 		reg7204 := PrimValue(reg7203)
-		reg7205 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg7205 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4intern_1type, X)
+			__e.TailApply(__defun__shen_4intern_1type, X)
 			return
 		}, 1)
-		reg7207 := __e.Call(__defun__map, reg7205, V1864)
-		reg7208 := __e.Call(__defun__difference, reg7204, reg7207)
-		__ctx.TailApply(__defun__shen_4preclude_1h, reg7208)
+		reg7207 := Call(__e, __defun__map, reg7205, V1864)
+		reg7208 := Call(__e, __defun__difference, reg7204, reg7207)
+		__e.TailApply(__defun__shen_4preclude_1h, reg7208)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "preclude-all-but", value: __defun__preclude_1all_1but})
 
-	__defun__include_1all_1but = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__include_1all_1but = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1866 := __args[0]
 		_ = V1866
 		reg7210 := MakeSymbol("shen.*alldatatypes*")
 		reg7211 := PrimValue(reg7210)
-		reg7212 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg7212 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4intern_1type, X)
+			__e.TailApply(__defun__shen_4intern_1type, X)
 			return
 		}, 1)
-		reg7214 := __e.Call(__defun__map, reg7212, V1866)
-		reg7215 := __e.Call(__defun__difference, reg7211, reg7214)
-		__ctx.TailApply(__defun__shen_4include_1h, reg7215)
+		reg7214 := Call(__e, __defun__map, reg7212, V1866)
+		reg7215 := Call(__e, __defun__difference, reg7211, reg7214)
+		__e.TailApply(__defun__shen_4include_1h, reg7215)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "include-all-but", value: __defun__include_1all_1but})
 
-	__defun__shen_4synonyms_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4synonyms_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1872 := __args[0]
 		_ = V1872
 		reg7217 := Nil
@@ -2913,16 +2913,16 @@ func init() {
 		if reg7218 == True {
 			reg7219 := MakeSymbol("shen.*tc*")
 			reg7220 := PrimValue(reg7219)
-			reg7221 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg7221 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				__ctx.TailApply(__defun__shen_4demod_1rule, X)
+				__e.TailApply(__defun__shen_4demod_1rule, X)
 				return
 			}, 1)
 			reg7223 := MakeSymbol("shen.*synonyms*")
 			reg7224 := PrimValue(reg7223)
-			reg7225 := __e.Call(__defun__mapcan, reg7221, reg7224)
-			__ctx.TailApply(__defun__shen_4update_1demodulation_1function, reg7220, reg7225)
+			reg7225 := Call(__e, __defun__mapcan, reg7221, reg7224)
+			__e.TailApply(__defun__shen_4update_1demodulation_1function, reg7220, reg7225)
 			return
 		} else {
 			reg7227 := PrimIsPair(V1872)
@@ -2946,13 +2946,13 @@ func init() {
 			if reg7234 == True {
 				reg7235 := PrimTail(V1872)
 				reg7236 := PrimHead(reg7235)
-				reg7237 := __e.Call(__defun__shen_4extract__vars, reg7236)
+				reg7237 := Call(__e, __defun__shen_4extract__vars, reg7236)
 				reg7238 := PrimHead(V1872)
-				reg7239 := __e.Call(__defun__shen_4extract__vars, reg7238)
-				reg7240 := __e.Call(__defun__difference, reg7237, reg7239)
+				reg7239 := Call(__e, __defun__shen_4extract__vars, reg7238)
+				reg7240 := Call(__e, __defun__difference, reg7237, reg7239)
 				Vs := reg7240
 				_ = Vs
-				reg7241 := __e.Call(__defun__empty_2, Vs)
+				reg7241 := Call(__e, __defun__empty_2, Vs)
 				if reg7241 == True {
 					reg7242 := PrimHead(V1872)
 					reg7243 := PrimTail(V1872)
@@ -2961,50 +2961,50 @@ func init() {
 					reg7246 := PrimCons(reg7244, reg7245)
 					reg7247 := PrimCons(reg7242, reg7246)
 					reg7248 := MakeSymbol("shen.*synonyms*")
-					reg7249 := __e.Call(__defun__shen_4pushnew, reg7247, reg7248)
+					reg7249 := Call(__e, __defun__shen_4pushnew, reg7247, reg7248)
 					_ = reg7249
 					reg7250 := PrimTail(V1872)
 					reg7251 := PrimTail(reg7250)
-					__ctx.TailApply(__defun__shen_4synonyms_1help, reg7251)
+					__e.TailApply(__defun__shen_4synonyms_1help, reg7251)
 					return
 				} else {
 					reg7253 := PrimTail(V1872)
 					reg7254 := PrimHead(reg7253)
-					__ctx.TailApply(__defun__shen_4free__variable__warnings, reg7254, Vs)
+					__e.TailApply(__defun__shen_4free__variable__warnings, reg7254, Vs)
 					return
 				}
 			} else {
 				reg7256 := MakeString("odd number of synonyms\n")
 				reg7257 := PrimSimpleError(reg7256)
-				__ctx.Return(reg7257)
+				__e.Return(reg7257)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.synonyms-help", value: __defun__shen_4synonyms_1help})
 
-	__defun__shen_4pushnew = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4pushnew = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1875 := __args[0]
 		_ = V1875
 		V1876 := __args[1]
 		_ = V1876
 		reg7258 := PrimValue(V1876)
-		reg7259 := __e.Call(__defun__element_2, V1875, reg7258)
+		reg7259 := Call(__e, __defun__element_2, V1875, reg7258)
 		if reg7259 == True {
 			reg7260 := PrimValue(V1876)
-			__ctx.Return(reg7260)
+			__e.Return(reg7260)
 			return
 		} else {
 			reg7261 := PrimValue(V1876)
 			reg7262 := PrimCons(V1875, reg7261)
 			reg7263 := PrimSet(V1876, reg7262)
-			__ctx.Return(reg7263)
+			__e.Return(reg7263)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.pushnew", value: __defun__shen_4pushnew})
 
-	__defun__shen_4demod_1rule = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4demod_1rule = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1878 := __args[0]
 		_ = V1878
 		reg7264 := PrimIsPair(V1878)
@@ -3046,26 +3046,26 @@ func init() {
 		}
 		if reg7280 == True {
 			reg7281 := PrimHead(V1878)
-			reg7282 := __e.Call(__defun__shen_4rcons__form, reg7281)
+			reg7282 := Call(__e, __defun__shen_4rcons__form, reg7281)
 			reg7283 := MakeSymbol("->")
 			reg7284 := PrimTail(V1878)
 			reg7285 := PrimHead(reg7284)
-			reg7286 := __e.Call(__defun__shen_4rcons__form, reg7285)
+			reg7286 := Call(__e, __defun__shen_4rcons__form, reg7285)
 			reg7287 := Nil
 			reg7288 := PrimCons(reg7286, reg7287)
 			reg7289 := PrimCons(reg7283, reg7288)
 			reg7290 := PrimCons(reg7282, reg7289)
-			__ctx.Return(reg7290)
+			__e.Return(reg7290)
 			return
 		} else {
 			reg7291 := MakeSymbol("shen.demod-rule")
-			__ctx.TailApply(__defun__shen_4f__error, reg7291)
+			__e.TailApply(__defun__shen_4f__error, reg7291)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.demod-rule", value: __defun__shen_4demod_1rule})
 
-	__defun__shen_4lambda_1of_1defun = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lambda_1of_1defun = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1884 := __args[0]
 		_ = V1884
 		reg7293 := PrimIsPair(V1884)
@@ -3213,39 +3213,39 @@ func init() {
 			reg7364 := PrimTail(reg7363)
 			reg7365 := PrimCons(reg7361, reg7364)
 			reg7366 := PrimCons(reg7357, reg7365)
-			__ctx.TailApply(__defun__eval, reg7366)
+			__e.TailApply(__defun__eval, reg7366)
 			return
 		} else {
 			reg7368 := MakeSymbol("shen.lambda-of-defun")
-			__ctx.TailApply(__defun__shen_4f__error, reg7368)
+			__e.TailApply(__defun__shen_4f__error, reg7368)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.lambda-of-defun", value: __defun__shen_4lambda_1of_1defun})
 
-	__defun__shen_4update_1demodulation_1function = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4update_1demodulation_1function = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1887 := __args[0]
 		_ = V1887
 		V1888 := __args[1]
 		_ = V1888
 		reg7370 := MakeSymbol("-")
-		reg7371 := __e.Call(__defun__tc, reg7370)
+		reg7371 := Call(__e, __defun__tc, reg7370)
 		_ = reg7371
 		reg7372 := MakeSymbol("shen.*demodulation-function*")
 		reg7373 := MakeSymbol("define")
 		reg7374 := MakeSymbol("shen.demod")
-		reg7375 := __e.Call(__defun__shen_4default_1rule)
-		reg7376 := __e.Call(__defun__append, V1888, reg7375)
+		reg7375 := Call(__e, __defun__shen_4default_1rule)
+		reg7376 := Call(__e, __defun__append, V1888, reg7375)
 		reg7377 := PrimCons(reg7374, reg7376)
 		reg7378 := PrimCons(reg7373, reg7377)
-		reg7379 := __e.Call(__defun__shen_4elim_1def, reg7378)
-		reg7380 := __e.Call(__defun__shen_4lambda_1of_1defun, reg7379)
+		reg7379 := Call(__e, __defun__shen_4elim_1def, reg7378)
+		reg7380 := Call(__e, __defun__shen_4lambda_1of_1defun, reg7379)
 		reg7381 := PrimSet(reg7372, reg7380)
 		_ = reg7381
 		var reg7385 Obj
 		if V1887 == True {
 			reg7382 := MakeSymbol("+")
-			reg7383 := __e.Call(__defun__tc, reg7382)
+			reg7383 := Call(__e, __defun__tc, reg7382)
 			reg7385 = reg7383
 		} else {
 			reg7384 := MakeSymbol("shen.skip")
@@ -3253,12 +3253,12 @@ func init() {
 		}
 		_ = reg7385
 		reg7386 := MakeSymbol("synonyms")
-		__ctx.Return(reg7386)
+		__e.Return(reg7386)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.update-demodulation-function", value: __defun__shen_4update_1demodulation_1function})
 
-	__defun__shen_4default_1rule = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4default_1rule = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg7387 := MakeSymbol("X")
 		reg7388 := MakeSymbol("->")
 		reg7389 := MakeSymbol("X")
@@ -3266,7 +3266,7 @@ func init() {
 		reg7391 := PrimCons(reg7389, reg7390)
 		reg7392 := PrimCons(reg7388, reg7391)
 		reg7393 := PrimCons(reg7387, reg7392)
-		__ctx.Return(reg7393)
+		__e.Return(reg7393)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.default-rule", value: __defun__shen_4default_1rule})

--- a/cmd/shen/stub.go
+++ b/cmd/shen/stub.go
@@ -21,6 +21,6 @@ func Regist(e *kl.KLambda) {
 	}
 
 	for _, expr := range __initExprs {
-		e.Call(expr)
+		kl.Call(e, expr)
 	}
 }

--- a/cmd/shen/sys.go
+++ b/cmd/shen/sys.go
@@ -114,61 +114,61 @@ var __defun__function Obj                    // function
 var __defun__shen_4lookup_1func Obj          // shen.lookup-func
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg4475 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg4475)
+		__e.Return(reg4475)
 		return
 	}, 0))
-	__defun__thaw = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__thaw = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1890 := __args[0]
 		_ = V1890
-		__ctx.TailApply(V1890)
+		__e.TailApply(V1890)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "thaw", value: __defun__thaw})
 
-	__defun__eval = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__eval = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1892 := __args[0]
 		_ = V1892
-		reg4477 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg4477 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			Y := __args[0]
 			_ = Y
-			__ctx.TailApply(__defun__macroexpand, Y)
+			__e.TailApply(__defun__macroexpand, Y)
 			return
 		}, 1)
-		reg4479 := __e.Call(__defun__shen_4walk, reg4477, V1892)
+		reg4479 := Call(__e, __defun__shen_4walk, reg4477, V1892)
 		Macroexpand := reg4479
 		_ = Macroexpand
-		reg4480 := __e.Call(__defun__shen_4packaged_2, Macroexpand)
+		reg4480 := Call(__e, __defun__shen_4packaged_2, Macroexpand)
 		if reg4480 == True {
-			reg4481 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg4481 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Z := __args[0]
 				_ = Z
-				__ctx.TailApply(__defun__shen_4eval_1without_1macros, Z)
+				__e.TailApply(__defun__shen_4eval_1without_1macros, Z)
 				return
 			}, 1)
-			reg4483 := __e.Call(__defun__shen_4package_1contents, Macroexpand)
-			__ctx.TailApply(__defun__map, reg4481, reg4483)
+			reg4483 := Call(__e, __defun__shen_4package_1contents, Macroexpand)
+			__e.TailApply(__defun__map, reg4481, reg4483)
 			return
 		} else {
-			__ctx.TailApply(__defun__shen_4eval_1without_1macros, Macroexpand)
+			__e.TailApply(__defun__shen_4eval_1without_1macros, Macroexpand)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "eval", value: __defun__eval})
 
-	__defun__shen_4eval_1without_1macros = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4eval_1without_1macros = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1894 := __args[0]
 		_ = V1894
-		reg4486 := __e.Call(__defun__shen_4proc_1input_7, V1894)
-		reg4487 := __e.Call(__defun__shen_4elim_1def, reg4486)
+		reg4486 := Call(__e, __defun__shen_4proc_1input_7, V1894)
+		reg4487 := Call(__e, __defun__shen_4elim_1def, reg4486)
 		reg4488 := PrimEvalKL(__e, reg4487)
-		__ctx.Return(reg4488)
+		__e.Return(reg4488)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.eval-without-macros", value: __defun__shen_4eval_1without_1macros})
 
-	__defun__shen_4proc_1input_7 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4proc_1input_7 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1896 := __args[0]
 		_ = V1896
 		reg4489 := PrimIsPair(V1896)
@@ -249,12 +249,12 @@ func init() {
 			reg4523 := MakeSymbol("input+")
 			reg4524 := PrimTail(V1896)
 			reg4525 := PrimHead(reg4524)
-			reg4526 := __e.Call(__defun__shen_4rcons__form, reg4525)
+			reg4526 := Call(__e, __defun__shen_4rcons__form, reg4525)
 			reg4527 := PrimTail(V1896)
 			reg4528 := PrimTail(reg4527)
 			reg4529 := PrimCons(reg4526, reg4528)
 			reg4530 := PrimCons(reg4523, reg4529)
-			__ctx.Return(reg4530)
+			__e.Return(reg4530)
 			return
 		} else {
 			reg4531 := PrimIsPair(V1896)
@@ -335,26 +335,26 @@ func init() {
 				reg4565 := MakeSymbol("shen.read+")
 				reg4566 := PrimTail(V1896)
 				reg4567 := PrimHead(reg4566)
-				reg4568 := __e.Call(__defun__shen_4rcons__form, reg4567)
+				reg4568 := Call(__e, __defun__shen_4rcons__form, reg4567)
 				reg4569 := PrimTail(V1896)
 				reg4570 := PrimTail(reg4569)
 				reg4571 := PrimCons(reg4568, reg4570)
 				reg4572 := PrimCons(reg4565, reg4571)
-				__ctx.Return(reg4572)
+				__e.Return(reg4572)
 				return
 			} else {
 				reg4573 := PrimIsPair(V1896)
 				if reg4573 == True {
-					reg4574 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg4574 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						Z := __args[0]
 						_ = Z
-						__ctx.TailApply(__defun__shen_4proc_1input_7, Z)
+						__e.TailApply(__defun__shen_4proc_1input_7, Z)
 						return
 					}, 1)
-					__ctx.TailApply(__defun__map, reg4574, V1896)
+					__e.TailApply(__defun__map, reg4574, V1896)
 					return
 				} else {
-					__ctx.Return(V1896)
+					__e.Return(V1896)
 					return
 				}
 			}
@@ -362,7 +362,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.proc-input+", value: __defun__shen_4proc_1input_7})
 
-	__defun__shen_4elim_1def = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4elim_1def = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1898 := __args[0]
 		_ = V1898
 		reg4577 := PrimIsPair(V1898)
@@ -406,7 +406,7 @@ func init() {
 			reg4594 := PrimHead(reg4593)
 			reg4595 := PrimTail(V1898)
 			reg4596 := PrimTail(reg4595)
-			__ctx.TailApply(__defun__shen_4shen_1_6kl, reg4594, reg4596)
+			__e.TailApply(__defun__shen_4shen_1_6kl, reg4594, reg4596)
 			return
 		} else {
 			reg4598 := PrimIsPair(V1898)
@@ -460,18 +460,18 @@ func init() {
 				reg4623 := PrimHead(reg4622)
 				reg4624 := PrimTail(V1898)
 				reg4625 := PrimTail(reg4624)
-				reg4626 := __e.Call(__defun__append, reg4625, Default)
+				reg4626 := Call(__e, __defun__append, reg4625, Default)
 				reg4627 := PrimCons(reg4623, reg4626)
 				reg4628 := PrimCons(reg4621, reg4627)
-				reg4629 := __e.Call(__defun__shen_4elim_1def, reg4628)
+				reg4629 := Call(__e, __defun__shen_4elim_1def, reg4628)
 				Def := reg4629
 				_ = Def
 				reg4630 := PrimTail(V1898)
 				reg4631 := PrimHead(reg4630)
-				reg4632 := __e.Call(__defun__shen_4add_1macro, reg4631)
+				reg4632 := Call(__e, __defun__shen_4add_1macro, reg4631)
 				MacroAdd := reg4632
 				_ = MacroAdd
-				__ctx.Return(Def)
+				__e.Return(Def)
 				return
 			} else {
 				reg4633 := PrimIsPair(V1898)
@@ -511,22 +511,22 @@ func init() {
 					reg4648 = reg4647
 				}
 				if reg4648 == True {
-					reg4649 := __e.Call(__defun__shen_4yacc, V1898)
-					__ctx.TailApply(__defun__shen_4elim_1def, reg4649)
+					reg4649 := Call(__e, __defun__shen_4yacc, V1898)
+					__e.TailApply(__defun__shen_4elim_1def, reg4649)
 					return
 				} else {
 					reg4651 := PrimIsPair(V1898)
 					if reg4651 == True {
-						reg4652 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+						reg4652 := MakeNative(func(__e Evaluator, __args ...Obj) {
 							Z := __args[0]
 							_ = Z
-							__ctx.TailApply(__defun__shen_4elim_1def, Z)
+							__e.TailApply(__defun__shen_4elim_1def, Z)
 							return
 						}, 1)
-						__ctx.TailApply(__defun__map, reg4652, V1898)
+						__e.TailApply(__defun__map, reg4652, V1898)
 						return
 					} else {
-						__ctx.Return(V1898)
+						__e.Return(V1898)
 						return
 					}
 				}
@@ -535,7 +535,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.elim-def", value: __defun__shen_4elim_1def})
 
-	__defun__shen_4add_1macro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4add_1macro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1900 := __args[0]
 		_ = V1900
 		reg4655 := MakeSymbol("shen.*macroreg*")
@@ -545,29 +545,29 @@ func init() {
 		reg4657 := MakeSymbol("shen.*macroreg*")
 		reg4658 := MakeSymbol("shen.*macroreg*")
 		reg4659 := PrimValue(reg4658)
-		reg4660 := __e.Call(__defun__adjoin, V1900, reg4659)
+		reg4660 := Call(__e, __defun__adjoin, V1900, reg4659)
 		reg4661 := PrimSet(reg4657, reg4660)
 		NewMacroReg := reg4661
 		_ = NewMacroReg
 		reg4662 := PrimEqual(MacroReg, NewMacroReg)
 		if reg4662 == True {
 			reg4663 := MakeSymbol("shen.skip")
-			__ctx.Return(reg4663)
+			__e.Return(reg4663)
 			return
 		} else {
 			reg4664 := MakeSymbol("*macros*")
-			reg4665 := __e.Call(__defun__function, V1900)
+			reg4665 := Call(__e, __defun__function, V1900)
 			reg4666 := MakeSymbol("*macros*")
 			reg4667 := PrimValue(reg4666)
 			reg4668 := PrimCons(reg4665, reg4667)
 			reg4669 := PrimSet(reg4664, reg4668)
-			__ctx.Return(reg4669)
+			__e.Return(reg4669)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.add-macro", value: __defun__shen_4add_1macro})
 
-	__defun__shen_4packaged_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4packaged_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1908 := __args[0]
 		_ = V1908
 		reg4670 := PrimIsPair(V1908)
@@ -626,73 +626,73 @@ func init() {
 		}
 		if reg4693 == True {
 			reg4694 := True
-			__ctx.Return(reg4694)
+			__e.Return(reg4694)
 			return
 		} else {
 			reg4695 := False
-			__ctx.Return(reg4695)
+			__e.Return(reg4695)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.packaged?", value: __defun__shen_4packaged_2})
 
-	__defun__external = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__external = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1910 := __args[0]
 		_ = V1910
-		reg4696 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg4696 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg4697 := MakeSymbol("shen.external-symbols")
 			reg4698 := MakeSymbol("*property-vector*")
 			reg4699 := PrimValue(reg4698)
-			__ctx.TailApply(__defun__get, V1910, reg4697, reg4699)
+			__e.TailApply(__defun__get, V1910, reg4697, reg4699)
 			return
 		}, 0)
-		reg4701 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg4701 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg4702 := MakeString("package ")
 			reg4703 := MakeString(" has not been used.\n")
 			reg4704 := MakeSymbol("shen.a")
-			reg4705 := __e.Call(__defun__shen_4app, V1910, reg4703, reg4704)
+			reg4705 := Call(__e, __defun__shen_4app, V1910, reg4703, reg4704)
 			reg4706 := PrimStringConcat(reg4702, reg4705)
 			reg4707 := PrimSimpleError(reg4706)
-			__ctx.Return(reg4707)
+			__e.Return(reg4707)
 			return
 		}, 1)
-		reg4708 := __e.Try(reg4696).Catch(reg4701)
-		__ctx.Return(reg4708)
+		reg4708 := Try(__e, reg4696).Catch(reg4701)
+		__e.Return(reg4708)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "external", value: __defun__external})
 
-	__defun__internal = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__internal = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1912 := __args[0]
 		_ = V1912
-		reg4709 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg4709 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg4710 := MakeSymbol("shen.internal-symbols")
 			reg4711 := MakeSymbol("*property-vector*")
 			reg4712 := PrimValue(reg4711)
-			__ctx.TailApply(__defun__get, V1912, reg4710, reg4712)
+			__e.TailApply(__defun__get, V1912, reg4710, reg4712)
 			return
 		}, 0)
-		reg4714 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg4714 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg4715 := MakeString("package ")
 			reg4716 := MakeString(" has not been used.\n")
 			reg4717 := MakeSymbol("shen.a")
-			reg4718 := __e.Call(__defun__shen_4app, V1912, reg4716, reg4717)
+			reg4718 := Call(__e, __defun__shen_4app, V1912, reg4716, reg4717)
 			reg4719 := PrimStringConcat(reg4715, reg4718)
 			reg4720 := PrimSimpleError(reg4719)
-			__ctx.Return(reg4720)
+			__e.Return(reg4720)
 			return
 		}, 1)
-		reg4721 := __e.Try(reg4709).Catch(reg4714)
-		__ctx.Return(reg4721)
+		reg4721 := Try(__e, reg4709).Catch(reg4714)
+		__e.Return(reg4721)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "internal", value: __defun__internal})
 
-	__defun__shen_4package_1contents = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4package_1contents = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1916 := __args[0]
 		_ = V1916
 		reg4722 := PrimIsPair(V1916)
@@ -772,7 +772,7 @@ func init() {
 			reg4755 := PrimTail(V1916)
 			reg4756 := PrimTail(reg4755)
 			reg4757 := PrimTail(reg4756)
-			__ctx.Return(reg4757)
+			__e.Return(reg4757)
 			return
 		} else {
 			reg4758 := PrimIsPair(V1916)
@@ -838,7 +838,7 @@ func init() {
 				reg4787 := PrimIntern(reg4786)
 				PackageNameDot := reg4787
 				_ = PackageNameDot
-				reg4788 := __e.Call(__defun__explode, PackageNameDot)
+				reg4788 := Call(__e, __defun__explode, PackageNameDot)
 				ExpPackageNameDot := reg4788
 				_ = ExpPackageNameDot
 				reg4789 := PrimTail(V1916)
@@ -849,41 +849,41 @@ func init() {
 				reg4794 := PrimTail(V1916)
 				reg4795 := PrimTail(reg4794)
 				reg4796 := PrimTail(reg4795)
-				__ctx.TailApply(__defun__shen_4packageh, reg4790, reg4793, reg4796, ExpPackageNameDot)
+				__e.TailApply(__defun__shen_4packageh, reg4790, reg4793, reg4796, ExpPackageNameDot)
 				return
 			} else {
 				reg4798 := MakeSymbol("shen.package-contents")
-				__ctx.TailApply(__defun__shen_4f__error, reg4798)
+				__e.TailApply(__defun__shen_4f__error, reg4798)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.package-contents", value: __defun__shen_4package_1contents})
 
-	__defun__shen_4walk = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4walk = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1919 := __args[0]
 		_ = V1919
 		V1920 := __args[1]
 		_ = V1920
 		reg4800 := PrimIsPair(V1920)
 		if reg4800 == True {
-			reg4801 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg4801 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Z := __args[0]
 				_ = Z
-				__ctx.TailApply(__defun__shen_4walk, V1919, Z)
+				__e.TailApply(__defun__shen_4walk, V1919, Z)
 				return
 			}, 1)
-			reg4803 := __e.Call(__defun__map, reg4801, V1920)
-			__ctx.TailApply(V1919, reg4803)
+			reg4803 := Call(__e, __defun__map, reg4801, V1920)
+			__e.TailApply(V1919, reg4803)
 			return
 		} else {
-			__ctx.TailApply(V1919, V1920)
+			__e.TailApply(V1919, V1920)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.walk", value: __defun__shen_4walk})
 
-	__defun__compile = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__compile = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1924 := __args[0]
 		_ = V1924
 		V1925 := __args[1]
@@ -894,10 +894,10 @@ func init() {
 		reg4807 := Nil
 		reg4808 := PrimCons(reg4806, reg4807)
 		reg4809 := PrimCons(V1925, reg4808)
-		reg4810 := __e.Call(V1924, reg4809)
+		reg4810 := Call(__e, V1924, reg4809)
 		O := reg4810
 		_ = O
-		reg4811 := __e.Call(__defun__fail)
+		reg4811 := Call(__e, __defun__fail)
 		reg4812 := PrimEqual(reg4811, O)
 		var reg4820 Obj
 		if reg4812 == True {
@@ -905,7 +905,7 @@ func init() {
 			reg4820 = reg4813
 		} else {
 			reg4814 := PrimHead(O)
-			reg4815 := __e.Call(__defun__empty_2, reg4814)
+			reg4815 := Call(__e, __defun__empty_2, reg4814)
 			reg4816 := PrimNot(reg4815)
 			var reg4819 Obj
 			if reg4816 == True {
@@ -918,85 +918,85 @@ func init() {
 			reg4820 = reg4819
 		}
 		if reg4820 == True {
-			__ctx.TailApply(V1926, O)
+			__e.TailApply(V1926, O)
 			return
 		} else {
-			__ctx.TailApply(__defun__shen_4hdtl, O)
+			__e.TailApply(__defun__shen_4hdtl, O)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "compile", value: __defun__compile})
 
-	__defun__fail_1if = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__fail_1if = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1929 := __args[0]
 		_ = V1929
 		V1930 := __args[1]
 		_ = V1930
-		reg4823 := __e.Call(V1929, V1930)
+		reg4823 := Call(__e, V1929, V1930)
 		if reg4823 == True {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		} else {
-			__ctx.Return(V1930)
+			__e.Return(V1930)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "fail-if", value: __defun__fail_1if})
 
-	__defun___8s = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun___8s = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1933 := __args[0]
 		_ = V1933
 		V1934 := __args[1]
 		_ = V1934
 		reg4825 := PrimStringConcat(V1933, V1934)
-		__ctx.Return(reg4825)
+		__e.Return(reg4825)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "@s", value: __defun___8s})
 
-	__defun__tc_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__tc_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg4826 := MakeSymbol("shen.*tc*")
 		reg4827 := PrimValue(reg4826)
-		__ctx.Return(reg4827)
+		__e.Return(reg4827)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "tc?", value: __defun__tc_2})
 
-	__defun__ps = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__ps = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1936 := __args[0]
 		_ = V1936
-		reg4828 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg4828 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg4829 := MakeSymbol("shen.source")
 			reg4830 := MakeSymbol("*property-vector*")
 			reg4831 := PrimValue(reg4830)
-			__ctx.TailApply(__defun__get, V1936, reg4829, reg4831)
+			__e.TailApply(__defun__get, V1936, reg4829, reg4831)
 			return
 		}, 0)
-		reg4833 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg4833 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg4834 := MakeString(" not found.\n")
 			reg4835 := MakeSymbol("shen.a")
-			reg4836 := __e.Call(__defun__shen_4app, V1936, reg4834, reg4835)
+			reg4836 := Call(__e, __defun__shen_4app, V1936, reg4834, reg4835)
 			reg4837 := PrimSimpleError(reg4836)
-			__ctx.Return(reg4837)
+			__e.Return(reg4837)
 			return
 		}, 1)
-		reg4838 := __e.Try(reg4828).Catch(reg4833)
-		__ctx.Return(reg4838)
+		reg4838 := Try(__e, reg4828).Catch(reg4833)
+		__e.Return(reg4838)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "ps", value: __defun__ps})
 
-	__defun__stinput = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__stinput = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg4839 := MakeSymbol("*stinput*")
 		reg4840 := PrimValue(reg4839)
-		__ctx.Return(reg4840)
+		__e.Return(reg4840)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "stinput", value: __defun__stinput})
 
-	__defun__vector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__vector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1938 := __args[0]
 		_ = V1938
 		reg4841 := MakeNumber(1)
@@ -1015,18 +1015,18 @@ func init() {
 			reg4851 = ZeroStamp
 		} else {
 			reg4848 := MakeNumber(1)
-			reg4849 := __e.Call(__defun__fail)
-			reg4850 := __e.Call(__defun__shen_4fillvector, ZeroStamp, reg4848, V1938, reg4849)
+			reg4849 := Call(__e, __defun__fail)
+			reg4850 := Call(__e, __defun__shen_4fillvector, ZeroStamp, reg4848, V1938, reg4849)
 			reg4851 = reg4850
 		}
 		Standard := reg4851
 		_ = Standard
-		__ctx.Return(Standard)
+		__e.Return(Standard)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "vector", value: __defun__vector})
 
-	__defun__shen_4fillvector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4fillvector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1944 := __args[0]
 		_ = V1944
 		V1945 := __args[1]
@@ -1038,37 +1038,37 @@ func init() {
 		reg4852 := PrimEqual(V1946, V1945)
 		if reg4852 == True {
 			reg4853 := PrimVectorSet(V1944, V1946, V1947)
-			__ctx.Return(reg4853)
+			__e.Return(reg4853)
 			return
 		} else {
 			reg4854 := PrimVectorSet(V1944, V1945, V1947)
 			reg4855 := MakeNumber(1)
 			reg4856 := PrimNumberAdd(reg4855, V1945)
-			__ctx.TailApply(__defun__shen_4fillvector, reg4854, reg4856, V1946, V1947)
+			__e.TailApply(__defun__shen_4fillvector, reg4854, reg4856, V1946, V1947)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.fillvector", value: __defun__shen_4fillvector})
 
-	__defun__vector_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__vector_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1949 := __args[0]
 		_ = V1949
 		reg4858 := PrimIsVector(V1949)
 		if reg4858 == True {
-			reg4859 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg4859 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg4860 := MakeNumber(0)
 				reg4861 := PrimVectorGet(V1949, reg4860)
-				__ctx.Return(reg4861)
+				__e.Return(reg4861)
 				return
 			}, 0)
-			reg4862 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg4862 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg4863 := MakeNumber(-1)
-				__ctx.Return(reg4863)
+				__e.Return(reg4863)
 				return
 			}, 1)
-			reg4864 := __e.Try(reg4859).Catch(reg4862)
+			reg4864 := Try(__e, reg4859).Catch(reg4862)
 			X := reg4864
 			_ = X
 			reg4865 := PrimIsNumber(X)
@@ -1091,22 +1091,22 @@ func init() {
 			}
 			if reg4872 == True {
 				reg4873 := True
-				__ctx.Return(reg4873)
+				__e.Return(reg4873)
 				return
 			} else {
 				reg4874 := False
-				__ctx.Return(reg4874)
+				__e.Return(reg4874)
 				return
 			}
 		} else {
 			reg4875 := False
-			__ctx.Return(reg4875)
+			__e.Return(reg4875)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "vector?", value: __defun__vector_2})
 
-	__defun__vector_1_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__vector_1_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1953 := __args[0]
 		_ = V1953
 		V1954 := __args[1]
@@ -1118,17 +1118,17 @@ func init() {
 		if reg4877 == True {
 			reg4878 := MakeString("cannot access 0th element of a vector\n")
 			reg4879 := PrimSimpleError(reg4878)
-			__ctx.Return(reg4879)
+			__e.Return(reg4879)
 			return
 		} else {
 			reg4880 := PrimVectorSet(V1953, V1954, V1955)
-			__ctx.Return(reg4880)
+			__e.Return(reg4880)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "vector->", value: __defun__vector_1_6})
 
-	__defun___5_1vector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun___5_1vector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1958 := __args[0]
 		_ = V1958
 		V1959 := __args[1]
@@ -1138,28 +1138,28 @@ func init() {
 		if reg4882 == True {
 			reg4883 := MakeString("cannot access 0th element of a vector\n")
 			reg4884 := PrimSimpleError(reg4883)
-			__ctx.Return(reg4884)
+			__e.Return(reg4884)
 			return
 		} else {
 			reg4885 := PrimVectorGet(V1958, V1959)
 			VectorElement := reg4885
 			_ = VectorElement
-			reg4886 := __e.Call(__defun__fail)
+			reg4886 := Call(__e, __defun__fail)
 			reg4887 := PrimEqual(VectorElement, reg4886)
 			if reg4887 == True {
 				reg4888 := MakeString("vector element not found\n")
 				reg4889 := PrimSimpleError(reg4888)
-				__ctx.Return(reg4889)
+				__e.Return(reg4889)
 				return
 			} else {
-				__ctx.Return(VectorElement)
+				__e.Return(VectorElement)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "<-vector", value: __defun___5_1vector})
 
-	__defun__shen_4posint_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4posint_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1961 := __args[0]
 		_ = V1961
 		reg4890 := PrimIsInteger(V1961)
@@ -1168,35 +1168,35 @@ func init() {
 			reg4892 := PrimGreatEqual(V1961, reg4891)
 			if reg4892 == True {
 				reg4893 := True
-				__ctx.Return(reg4893)
+				__e.Return(reg4893)
 				return
 			} else {
 				reg4894 := False
-				__ctx.Return(reg4894)
+				__e.Return(reg4894)
 				return
 			}
 		} else {
 			reg4895 := False
-			__ctx.Return(reg4895)
+			__e.Return(reg4895)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.posint?", value: __defun__shen_4posint_2})
 
-	__defun__limit = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__limit = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1963 := __args[0]
 		_ = V1963
 		reg4896 := MakeNumber(0)
 		reg4897 := PrimVectorGet(V1963, reg4896)
-		__ctx.Return(reg4897)
+		__e.Return(reg4897)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "limit", value: __defun__limit})
 
-	__defun__symbol_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__symbol_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1965 := __args[0]
 		_ = V1965
-		reg4898 := __e.Call(__defun__boolean_2, V1965)
+		reg4898 := Call(__e, __defun__boolean_2, V1965)
 		var reg4910 Obj
 		if reg4898 == True {
 			reg4899 := True
@@ -1231,72 +1231,72 @@ func init() {
 		}
 		if reg4910 == True {
 			reg4911 := False
-			__ctx.Return(reg4911)
+			__e.Return(reg4911)
 			return
 		} else {
-			reg4912 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg4912 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg4913 := PrimStr(V1965)
 				String := reg4913
 				_ = String
-				__ctx.TailApply(__defun__shen_4analyse_1symbol_2, String)
+				__e.TailApply(__defun__shen_4analyse_1symbol_2, String)
 				return
 			}, 0)
-			reg4915 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg4915 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg4916 := False
-				__ctx.Return(reg4916)
+				__e.Return(reg4916)
 				return
 			}, 1)
-			reg4917 := __e.Try(reg4912).Catch(reg4915)
-			__ctx.Return(reg4917)
+			reg4917 := Try(__e, reg4912).Catch(reg4915)
+			__e.Return(reg4917)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "symbol?", value: __defun__symbol_2})
 
-	__defun__shen_4analyse_1symbol_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4analyse_1symbol_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1967 := __args[0]
 		_ = V1967
 		reg4918 := MakeString("")
 		reg4919 := PrimEqual(reg4918, V1967)
 		if reg4919 == True {
 			reg4920 := False
-			__ctx.Return(reg4920)
+			__e.Return(reg4920)
 			return
 		} else {
-			reg4921 := __e.Call(__defun__shen_4_7string_2, V1967)
+			reg4921 := Call(__e, __defun__shen_4_7string_2, V1967)
 			if reg4921 == True {
 				reg4922 := MakeNumber(0)
 				reg4923 := PrimPos(V1967, reg4922)
-				reg4924 := __e.Call(__defun__shen_4alpha_2, reg4923)
+				reg4924 := Call(__e, __defun__shen_4alpha_2, reg4923)
 				if reg4924 == True {
 					reg4925 := PrimTailString(V1967)
-					reg4926 := __e.Call(__defun__shen_4alphanums_2, reg4925)
+					reg4926 := Call(__e, __defun__shen_4alphanums_2, reg4925)
 					if reg4926 == True {
 						reg4927 := True
-						__ctx.Return(reg4927)
+						__e.Return(reg4927)
 						return
 					} else {
 						reg4928 := False
-						__ctx.Return(reg4928)
+						__e.Return(reg4928)
 						return
 					}
 				} else {
 					reg4929 := False
-					__ctx.Return(reg4929)
+					__e.Return(reg4929)
 					return
 				}
 			} else {
 				reg4930 := MakeSymbol("shen.analyse-symbol?")
-				__ctx.TailApply(__defun__shen_4f__error, reg4930)
+				__e.TailApply(__defun__shen_4f__error, reg4930)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.analyse-symbol?", value: __defun__shen_4analyse_1symbol_2})
 
-	__defun__shen_4alpha_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4alpha_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1969 := __args[0]
 		_ = V1969
 		reg4932 := MakeString("A")
@@ -1450,76 +1450,76 @@ func init() {
 		reg5080 := PrimCons(reg4934, reg5079)
 		reg5081 := PrimCons(reg4933, reg5080)
 		reg5082 := PrimCons(reg4932, reg5081)
-		__ctx.TailApply(__defun__element_2, V1969, reg5082)
+		__e.TailApply(__defun__element_2, V1969, reg5082)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.alpha?", value: __defun__shen_4alpha_2})
 
-	__defun__shen_4alphanums_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4alphanums_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1971 := __args[0]
 		_ = V1971
 		reg5084 := MakeString("")
 		reg5085 := PrimEqual(reg5084, V1971)
 		if reg5085 == True {
 			reg5086 := True
-			__ctx.Return(reg5086)
+			__e.Return(reg5086)
 			return
 		} else {
-			reg5087 := __e.Call(__defun__shen_4_7string_2, V1971)
+			reg5087 := Call(__e, __defun__shen_4_7string_2, V1971)
 			if reg5087 == True {
 				reg5088 := MakeNumber(0)
 				reg5089 := PrimPos(V1971, reg5088)
-				reg5090 := __e.Call(__defun__shen_4alphanum_2, reg5089)
+				reg5090 := Call(__e, __defun__shen_4alphanum_2, reg5089)
 				if reg5090 == True {
 					reg5091 := PrimTailString(V1971)
-					reg5092 := __e.Call(__defun__shen_4alphanums_2, reg5091)
+					reg5092 := Call(__e, __defun__shen_4alphanums_2, reg5091)
 					if reg5092 == True {
 						reg5093 := True
-						__ctx.Return(reg5093)
+						__e.Return(reg5093)
 						return
 					} else {
 						reg5094 := False
-						__ctx.Return(reg5094)
+						__e.Return(reg5094)
 						return
 					}
 				} else {
 					reg5095 := False
-					__ctx.Return(reg5095)
+					__e.Return(reg5095)
 					return
 				}
 			} else {
 				reg5096 := MakeSymbol("shen.alphanums?")
-				__ctx.TailApply(__defun__shen_4f__error, reg5096)
+				__e.TailApply(__defun__shen_4f__error, reg5096)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.alphanums?", value: __defun__shen_4alphanums_2})
 
-	__defun__shen_4alphanum_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4alphanum_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1973 := __args[0]
 		_ = V1973
-		reg5098 := __e.Call(__defun__shen_4alpha_2, V1973)
+		reg5098 := Call(__e, __defun__shen_4alpha_2, V1973)
 		if reg5098 == True {
 			reg5099 := True
-			__ctx.Return(reg5099)
+			__e.Return(reg5099)
 			return
 		} else {
-			reg5100 := __e.Call(__defun__shen_4digit_2, V1973)
+			reg5100 := Call(__e, __defun__shen_4digit_2, V1973)
 			if reg5100 == True {
 				reg5101 := True
-				__ctx.Return(reg5101)
+				__e.Return(reg5101)
 				return
 			} else {
 				reg5102 := False
-				__ctx.Return(reg5102)
+				__e.Return(reg5102)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.alphanum?", value: __defun__shen_4alphanum_2})
 
-	__defun__shen_4digit_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4digit_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1975 := __args[0]
 		_ = V1975
 		reg5103 := MakeString("1")
@@ -1543,15 +1543,15 @@ func init() {
 		reg5121 := PrimCons(reg5105, reg5120)
 		reg5122 := PrimCons(reg5104, reg5121)
 		reg5123 := PrimCons(reg5103, reg5122)
-		__ctx.TailApply(__defun__element_2, V1975, reg5123)
+		__e.TailApply(__defun__element_2, V1975, reg5123)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.digit?", value: __defun__shen_4digit_2})
 
-	__defun__variable_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__variable_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1977 := __args[0]
 		_ = V1977
-		reg5125 := __e.Call(__defun__boolean_2, V1977)
+		reg5125 := Call(__e, __defun__boolean_2, V1977)
 		var reg5137 Obj
 		if reg5125 == True {
 			reg5126 := True
@@ -1586,64 +1586,64 @@ func init() {
 		}
 		if reg5137 == True {
 			reg5138 := False
-			__ctx.Return(reg5138)
+			__e.Return(reg5138)
 			return
 		} else {
-			reg5139 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5139 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg5140 := PrimStr(V1977)
 				String := reg5140
 				_ = String
-				__ctx.TailApply(__defun__shen_4analyse_1variable_2, String)
+				__e.TailApply(__defun__shen_4analyse_1variable_2, String)
 				return
 			}, 0)
-			reg5142 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5142 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg5143 := False
-				__ctx.Return(reg5143)
+				__e.Return(reg5143)
 				return
 			}, 1)
-			reg5144 := __e.Try(reg5139).Catch(reg5142)
-			__ctx.Return(reg5144)
+			reg5144 := Try(__e, reg5139).Catch(reg5142)
+			__e.Return(reg5144)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "variable?", value: __defun__variable_2})
 
-	__defun__shen_4analyse_1variable_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4analyse_1variable_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1979 := __args[0]
 		_ = V1979
-		reg5145 := __e.Call(__defun__shen_4_7string_2, V1979)
+		reg5145 := Call(__e, __defun__shen_4_7string_2, V1979)
 		if reg5145 == True {
 			reg5146 := MakeNumber(0)
 			reg5147 := PrimPos(V1979, reg5146)
-			reg5148 := __e.Call(__defun__shen_4uppercase_2, reg5147)
+			reg5148 := Call(__e, __defun__shen_4uppercase_2, reg5147)
 			if reg5148 == True {
 				reg5149 := PrimTailString(V1979)
-				reg5150 := __e.Call(__defun__shen_4alphanums_2, reg5149)
+				reg5150 := Call(__e, __defun__shen_4alphanums_2, reg5149)
 				if reg5150 == True {
 					reg5151 := True
-					__ctx.Return(reg5151)
+					__e.Return(reg5151)
 					return
 				} else {
 					reg5152 := False
-					__ctx.Return(reg5152)
+					__e.Return(reg5152)
 					return
 				}
 			} else {
 				reg5153 := False
-				__ctx.Return(reg5153)
+				__e.Return(reg5153)
 				return
 			}
 		} else {
 			reg5154 := MakeSymbol("shen.analyse-variable?")
-			__ctx.TailApply(__defun__shen_4f__error, reg5154)
+			__e.TailApply(__defun__shen_4f__error, reg5154)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.analyse-variable?", value: __defun__shen_4analyse_1variable_2})
 
-	__defun__shen_4uppercase_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4uppercase_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1981 := __args[0]
 		_ = V1981
 		reg5156 := MakeString("A")
@@ -1699,12 +1699,12 @@ func init() {
 		reg5206 := PrimCons(reg5158, reg5205)
 		reg5207 := PrimCons(reg5157, reg5206)
 		reg5208 := PrimCons(reg5156, reg5207)
-		__ctx.TailApply(__defun__element_2, V1981, reg5208)
+		__e.TailApply(__defun__element_2, V1981, reg5208)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.uppercase?", value: __defun__shen_4uppercase_2})
 
-	__defun__gensym = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__gensym = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1983 := __args[0]
 		_ = V1983
 		reg5210 := MakeSymbol("shen.*gensym*")
@@ -1713,12 +1713,12 @@ func init() {
 		reg5213 := PrimValue(reg5212)
 		reg5214 := PrimNumberAdd(reg5211, reg5213)
 		reg5215 := PrimSet(reg5210, reg5214)
-		__ctx.TailApply(__defun__concat, V1983, reg5215)
+		__e.TailApply(__defun__concat, V1983, reg5215)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "gensym", value: __defun__gensym})
 
-	__defun__concat = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__concat = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1986 := __args[0]
 		_ = V1986
 		V1987 := __args[1]
@@ -1727,12 +1727,12 @@ func init() {
 		reg5218 := PrimStr(V1987)
 		reg5219 := PrimStringConcat(reg5217, reg5218)
 		reg5220 := PrimIntern(reg5219)
-		__ctx.Return(reg5220)
+		__e.Return(reg5220)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "concat", value: __defun__concat})
 
-	__defun___8p = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun___8p = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1990 := __args[0]
 		_ = V1990
 		V1991 := __args[1]
@@ -1754,70 +1754,70 @@ func init() {
 		reg5229 := PrimVectorSet(Vector, reg5228, V1991)
 		Snd := reg5229
 		_ = Snd
-		__ctx.Return(Vector)
+		__e.Return(Vector)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "@p", value: __defun___8p})
 
-	__defun__fst = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__fst = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1993 := __args[0]
 		_ = V1993
 		reg5230 := MakeNumber(1)
 		reg5231 := PrimVectorGet(V1993, reg5230)
-		__ctx.Return(reg5231)
+		__e.Return(reg5231)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "fst", value: __defun__fst})
 
-	__defun__snd = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__snd = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1995 := __args[0]
 		_ = V1995
 		reg5232 := MakeNumber(2)
 		reg5233 := PrimVectorGet(V1995, reg5232)
-		__ctx.Return(reg5233)
+		__e.Return(reg5233)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "snd", value: __defun__snd})
 
-	__defun__tuple_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__tuple_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V1997 := __args[0]
 		_ = V1997
 		reg5234 := PrimIsVector(V1997)
 		if reg5234 == True {
 			reg5235 := MakeSymbol("shen.tuple")
-			reg5236 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5236 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg5237 := MakeNumber(0)
 				reg5238 := PrimVectorGet(V1997, reg5237)
-				__ctx.Return(reg5238)
+				__e.Return(reg5238)
 				return
 			}, 0)
-			reg5239 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5239 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg5240 := MakeSymbol("shen.not-tuple")
-				__ctx.Return(reg5240)
+				__e.Return(reg5240)
 				return
 			}, 1)
-			reg5241 := __e.Try(reg5236).Catch(reg5239)
+			reg5241 := Try(__e, reg5236).Catch(reg5239)
 			reg5242 := PrimEqual(reg5235, reg5241)
 			if reg5242 == True {
 				reg5243 := True
-				__ctx.Return(reg5243)
+				__e.Return(reg5243)
 				return
 			} else {
 				reg5244 := False
-				__ctx.Return(reg5244)
+				__e.Return(reg5244)
 				return
 			}
 		} else {
 			reg5245 := False
-			__ctx.Return(reg5245)
+			__e.Return(reg5245)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "tuple?", value: __defun__tuple_2})
 
-	__defun__append = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__append = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2000 := __args[0]
 		_ = V2000
 		V2001 := __args[1]
@@ -1825,57 +1825,57 @@ func init() {
 		reg5246 := Nil
 		reg5247 := PrimEqual(reg5246, V2000)
 		if reg5247 == True {
-			__ctx.Return(V2001)
+			__e.Return(V2001)
 			return
 		} else {
 			reg5248 := PrimIsPair(V2000)
 			if reg5248 == True {
 				reg5249 := PrimHead(V2000)
 				reg5250 := PrimTail(V2000)
-				reg5251 := __e.Call(__defun__append, reg5250, V2001)
+				reg5251 := Call(__e, __defun__append, reg5250, V2001)
 				reg5252 := PrimCons(reg5249, reg5251)
-				__ctx.Return(reg5252)
+				__e.Return(reg5252)
 				return
 			} else {
 				reg5253 := MakeSymbol("append")
-				__ctx.TailApply(__defun__shen_4f__error, reg5253)
+				__e.TailApply(__defun__shen_4f__error, reg5253)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "append", value: __defun__append})
 
-	__defun___8v = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun___8v = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2004 := __args[0]
 		_ = V2004
 		V2005 := __args[1]
 		_ = V2005
-		reg5255 := __e.Call(__defun__limit, V2005)
+		reg5255 := Call(__e, __defun__limit, V2005)
 		Limit := reg5255
 		_ = Limit
 		reg5256 := MakeNumber(1)
 		reg5257 := PrimNumberAdd(Limit, reg5256)
-		reg5258 := __e.Call(__defun__vector, reg5257)
+		reg5258 := Call(__e, __defun__vector, reg5257)
 		NewVector := reg5258
 		_ = NewVector
 		reg5259 := MakeNumber(1)
-		reg5260 := __e.Call(__defun__vector_1_6, NewVector, reg5259, V2004)
+		reg5260 := Call(__e, __defun__vector_1_6, NewVector, reg5259, V2004)
 		X_7NewVector := reg5260
 		_ = X_7NewVector
 		reg5261 := MakeNumber(0)
 		reg5262 := PrimEqual(Limit, reg5261)
 		if reg5262 == True {
-			__ctx.Return(X_7NewVector)
+			__e.Return(X_7NewVector)
 			return
 		} else {
 			reg5263 := MakeNumber(1)
-			__ctx.TailApply(__defun__shen_4_8v_1help, V2005, reg5263, Limit, X_7NewVector)
+			__e.TailApply(__defun__shen_4_8v_1help, V2005, reg5263, Limit, X_7NewVector)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "@v", value: __defun___8v})
 
-	__defun__shen_4_8v_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_8v_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2011 := __args[0]
 		_ = V2011
 		V2012 := __args[1]
@@ -1888,21 +1888,21 @@ func init() {
 		if reg5265 == True {
 			reg5266 := MakeNumber(1)
 			reg5267 := PrimNumberAdd(V2013, reg5266)
-			__ctx.TailApply(__defun__shen_4copyfromvector, V2011, V2014, V2013, reg5267)
+			__e.TailApply(__defun__shen_4copyfromvector, V2011, V2014, V2013, reg5267)
 			return
 		} else {
 			reg5269 := MakeNumber(1)
 			reg5270 := PrimNumberAdd(V2012, reg5269)
 			reg5271 := MakeNumber(1)
 			reg5272 := PrimNumberAdd(V2012, reg5271)
-			reg5273 := __e.Call(__defun__shen_4copyfromvector, V2011, V2014, V2012, reg5272)
-			__ctx.TailApply(__defun__shen_4_8v_1help, V2011, reg5270, V2013, reg5273)
+			reg5273 := Call(__e, __defun__shen_4copyfromvector, V2011, V2014, V2012, reg5272)
+			__e.TailApply(__defun__shen_4_8v_1help, V2011, reg5270, V2013, reg5273)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.@v-help", value: __defun__shen_4_8v_1help})
 
-	__defun__shen_4copyfromvector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4copyfromvector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2019 := __args[0]
 		_ = V2019
 		V2020 := __args[1]
@@ -1911,53 +1911,53 @@ func init() {
 		_ = V2021
 		V2022 := __args[3]
 		_ = V2022
-		reg5275 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			reg5276 := __e.Call(__defun___5_1vector, V2019, V2021)
-			__ctx.TailApply(__defun__vector_1_6, V2020, V2022, reg5276)
+		reg5275 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			reg5276 := Call(__e, __defun___5_1vector, V2019, V2021)
+			__e.TailApply(__defun__vector_1_6, V2020, V2022, reg5276)
 			return
 		}, 0)
-		reg5278 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5278 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
-			__ctx.Return(V2020)
+			__e.Return(V2020)
 			return
 		}, 1)
-		reg5279 := __e.Try(reg5275).Catch(reg5278)
-		__ctx.Return(reg5279)
+		reg5279 := Try(__e, reg5275).Catch(reg5278)
+		__e.Return(reg5279)
 		return
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.copyfromvector", value: __defun__shen_4copyfromvector})
 
-	__defun__hdv = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__hdv = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2024 := __args[0]
 		_ = V2024
-		reg5280 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5280 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg5281 := MakeNumber(1)
-			__ctx.TailApply(__defun___5_1vector, V2024, reg5281)
+			__e.TailApply(__defun___5_1vector, V2024, reg5281)
 			return
 		}, 0)
-		reg5283 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5283 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg5284 := MakeString("hdv needs a non-empty vector as an argument; not ")
 			reg5285 := MakeString("\n")
 			reg5286 := MakeSymbol("shen.s")
-			reg5287 := __e.Call(__defun__shen_4app, V2024, reg5285, reg5286)
+			reg5287 := Call(__e, __defun__shen_4app, V2024, reg5285, reg5286)
 			reg5288 := PrimStringConcat(reg5284, reg5287)
 			reg5289 := PrimSimpleError(reg5288)
-			__ctx.Return(reg5289)
+			__e.Return(reg5289)
 			return
 		}, 1)
-		reg5290 := __e.Try(reg5280).Catch(reg5283)
-		__ctx.Return(reg5290)
+		reg5290 := Try(__e, reg5280).Catch(reg5283)
+		__e.Return(reg5290)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "hdv", value: __defun__hdv})
 
-	__defun__tlv = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__tlv = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2026 := __args[0]
 		_ = V2026
-		reg5291 := __e.Call(__defun__limit, V2026)
+		reg5291 := Call(__e, __defun__limit, V2026)
 		Limit := reg5291
 		_ = Limit
 		reg5292 := MakeNumber(0)
@@ -1965,33 +1965,33 @@ func init() {
 		if reg5293 == True {
 			reg5294 := MakeString("cannot take the tail of the empty vector\n")
 			reg5295 := PrimSimpleError(reg5294)
-			__ctx.Return(reg5295)
+			__e.Return(reg5295)
 			return
 		} else {
 			reg5296 := MakeNumber(1)
 			reg5297 := PrimEqual(Limit, reg5296)
 			if reg5297 == True {
 				reg5298 := MakeNumber(0)
-				__ctx.TailApply(__defun__vector, reg5298)
+				__e.TailApply(__defun__vector, reg5298)
 				return
 			} else {
 				reg5300 := MakeNumber(1)
 				reg5301 := PrimNumberSubtract(Limit, reg5300)
-				reg5302 := __e.Call(__defun__vector, reg5301)
+				reg5302 := Call(__e, __defun__vector, reg5301)
 				NewVector := reg5302
 				_ = NewVector
 				reg5303 := MakeNumber(2)
 				reg5304 := MakeNumber(1)
 				reg5305 := PrimNumberSubtract(Limit, reg5304)
-				reg5306 := __e.Call(__defun__vector, reg5305)
-				__ctx.TailApply(__defun__shen_4tlv_1help, V2026, reg5303, Limit, reg5306)
+				reg5306 := Call(__e, __defun__vector, reg5305)
+				__e.TailApply(__defun__shen_4tlv_1help, V2026, reg5303, Limit, reg5306)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "tlv", value: __defun__tlv})
 
-	__defun__shen_4tlv_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4tlv_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2032 := __args[0]
 		_ = V2032
 		V2033 := __args[1]
@@ -2004,21 +2004,21 @@ func init() {
 		if reg5308 == True {
 			reg5309 := MakeNumber(1)
 			reg5310 := PrimNumberSubtract(V2034, reg5309)
-			__ctx.TailApply(__defun__shen_4copyfromvector, V2032, V2035, V2034, reg5310)
+			__e.TailApply(__defun__shen_4copyfromvector, V2032, V2035, V2034, reg5310)
 			return
 		} else {
 			reg5312 := MakeNumber(1)
 			reg5313 := PrimNumberAdd(V2033, reg5312)
 			reg5314 := MakeNumber(1)
 			reg5315 := PrimNumberSubtract(V2033, reg5314)
-			reg5316 := __e.Call(__defun__shen_4copyfromvector, V2032, V2035, V2033, reg5315)
-			__ctx.TailApply(__defun__shen_4tlv_1help, V2032, reg5313, V2034, reg5316)
+			reg5316 := Call(__e, __defun__shen_4copyfromvector, V2032, V2035, V2033, reg5315)
+			__e.TailApply(__defun__shen_4tlv_1help, V2032, reg5313, V2034, reg5316)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.tlv-help", value: __defun__shen_4tlv_1help})
 
-	__defun__assoc = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__assoc = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2047 := __args[0]
 		_ = V2047
 		V2048 := __args[1]
@@ -2027,7 +2027,7 @@ func init() {
 		reg5319 := PrimEqual(reg5318, V2048)
 		if reg5319 == True {
 			reg5320 := Nil
-			__ctx.Return(reg5320)
+			__e.Return(reg5320)
 			return
 		} else {
 			reg5321 := PrimIsPair(V2048)
@@ -2068,17 +2068,17 @@ func init() {
 			}
 			if reg5336 == True {
 				reg5337 := PrimHead(V2048)
-				__ctx.Return(reg5337)
+				__e.Return(reg5337)
 				return
 			} else {
 				reg5338 := PrimIsPair(V2048)
 				if reg5338 == True {
 					reg5339 := PrimTail(V2048)
-					__ctx.TailApply(__defun__assoc, V2047, reg5339)
+					__e.TailApply(__defun__assoc, V2047, reg5339)
 					return
 				} else {
 					reg5341 := MakeSymbol("assoc")
-					__ctx.TailApply(__defun__shen_4f__error, reg5341)
+					__e.TailApply(__defun__shen_4f__error, reg5341)
 					return
 				}
 			}
@@ -2086,7 +2086,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "assoc", value: __defun__assoc})
 
-	__defun__shen_4assoc_1set = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4assoc_1set = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2055 := __args[0]
 		_ = V2055
 		V2056 := __args[1]
@@ -2099,7 +2099,7 @@ func init() {
 			reg5345 := PrimCons(V2055, V2056)
 			reg5346 := Nil
 			reg5347 := PrimCons(reg5345, reg5346)
-			__ctx.Return(reg5347)
+			__e.Return(reg5347)
 			return
 		} else {
 			reg5348 := PrimIsPair(V2057)
@@ -2144,20 +2144,20 @@ func init() {
 				reg5366 := PrimCons(reg5365, V2056)
 				reg5367 := PrimTail(V2057)
 				reg5368 := PrimCons(reg5366, reg5367)
-				__ctx.Return(reg5368)
+				__e.Return(reg5368)
 				return
 			} else {
 				reg5369 := PrimIsPair(V2057)
 				if reg5369 == True {
 					reg5370 := PrimHead(V2057)
 					reg5371 := PrimTail(V2057)
-					reg5372 := __e.Call(__defun__shen_4assoc_1set, V2055, V2056, reg5371)
+					reg5372 := Call(__e, __defun__shen_4assoc_1set, V2055, V2056, reg5371)
 					reg5373 := PrimCons(reg5370, reg5372)
-					__ctx.Return(reg5373)
+					__e.Return(reg5373)
 					return
 				} else {
 					reg5374 := MakeSymbol("shen.assoc-set")
-					__ctx.TailApply(__defun__shen_4f__error, reg5374)
+					__e.TailApply(__defun__shen_4f__error, reg5374)
 					return
 				}
 			}
@@ -2165,7 +2165,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.assoc-set", value: __defun__shen_4assoc_1set})
 
-	__defun__shen_4assoc_1rm = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4assoc_1rm = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2063 := __args[0]
 		_ = V2063
 		V2064 := __args[1]
@@ -2174,7 +2174,7 @@ func init() {
 		reg5377 := PrimEqual(reg5376, V2064)
 		if reg5377 == True {
 			reg5378 := Nil
-			__ctx.Return(reg5378)
+			__e.Return(reg5378)
 			return
 		} else {
 			reg5379 := PrimIsPair(V2064)
@@ -2215,20 +2215,20 @@ func init() {
 			}
 			if reg5394 == True {
 				reg5395 := PrimTail(V2064)
-				__ctx.Return(reg5395)
+				__e.Return(reg5395)
 				return
 			} else {
 				reg5396 := PrimIsPair(V2064)
 				if reg5396 == True {
 					reg5397 := PrimHead(V2064)
 					reg5398 := PrimTail(V2064)
-					reg5399 := __e.Call(__defun__shen_4assoc_1rm, V2063, reg5398)
+					reg5399 := Call(__e, __defun__shen_4assoc_1rm, V2063, reg5398)
 					reg5400 := PrimCons(reg5397, reg5399)
-					__ctx.Return(reg5400)
+					__e.Return(reg5400)
 					return
 				} else {
 					reg5401 := MakeSymbol("shen.assoc-rm")
-					__ctx.TailApply(__defun__shen_4f__error, reg5401)
+					__e.TailApply(__defun__shen_4f__error, reg5401)
 					return
 				}
 			}
@@ -2236,54 +2236,54 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.assoc-rm", value: __defun__shen_4assoc_1rm})
 
-	__defun__boolean_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__boolean_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2070 := __args[0]
 		_ = V2070
 		reg5403 := True
 		reg5404 := PrimEqual(reg5403, V2070)
 		if reg5404 == True {
 			reg5405 := True
-			__ctx.Return(reg5405)
+			__e.Return(reg5405)
 			return
 		} else {
 			reg5406 := False
 			reg5407 := PrimEqual(reg5406, V2070)
 			if reg5407 == True {
 				reg5408 := True
-				__ctx.Return(reg5408)
+				__e.Return(reg5408)
 				return
 			} else {
 				reg5409 := False
-				__ctx.Return(reg5409)
+				__e.Return(reg5409)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "boolean?", value: __defun__boolean_2})
 
-	__defun__nl = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__nl = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2072 := __args[0]
 		_ = V2072
 		reg5410 := MakeNumber(0)
 		reg5411 := PrimEqual(reg5410, V2072)
 		if reg5411 == True {
 			reg5412 := MakeNumber(0)
-			__ctx.Return(reg5412)
+			__e.Return(reg5412)
 			return
 		} else {
 			reg5413 := MakeString("\n")
-			reg5414 := __e.Call(__defun__stoutput)
-			reg5415 := __e.Call(__defun__shen_4prhush, reg5413, reg5414)
+			reg5414 := Call(__e, __defun__stoutput)
+			reg5415 := Call(__e, __defun__shen_4prhush, reg5413, reg5414)
 			_ = reg5415
 			reg5416 := MakeNumber(1)
 			reg5417 := PrimNumberSubtract(V2072, reg5416)
-			__ctx.TailApply(__defun__nl, reg5417)
+			__e.TailApply(__defun__nl, reg5417)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "nl", value: __defun__nl})
 
-	__defun__difference = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__difference = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2077 := __args[0]
 		_ = V2077
 		V2078 := __args[1]
@@ -2292,45 +2292,45 @@ func init() {
 		reg5420 := PrimEqual(reg5419, V2077)
 		if reg5420 == True {
 			reg5421 := Nil
-			__ctx.Return(reg5421)
+			__e.Return(reg5421)
 			return
 		} else {
 			reg5422 := PrimIsPair(V2077)
 			if reg5422 == True {
 				reg5423 := PrimHead(V2077)
-				reg5424 := __e.Call(__defun__element_2, reg5423, V2078)
+				reg5424 := Call(__e, __defun__element_2, reg5423, V2078)
 				if reg5424 == True {
 					reg5425 := PrimTail(V2077)
-					__ctx.TailApply(__defun__difference, reg5425, V2078)
+					__e.TailApply(__defun__difference, reg5425, V2078)
 					return
 				} else {
 					reg5427 := PrimHead(V2077)
 					reg5428 := PrimTail(V2077)
-					reg5429 := __e.Call(__defun__difference, reg5428, V2078)
+					reg5429 := Call(__e, __defun__difference, reg5428, V2078)
 					reg5430 := PrimCons(reg5427, reg5429)
-					__ctx.Return(reg5430)
+					__e.Return(reg5430)
 					return
 				}
 			} else {
 				reg5431 := MakeSymbol("difference")
-				__ctx.TailApply(__defun__shen_4f__error, reg5431)
+				__e.TailApply(__defun__shen_4f__error, reg5431)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "difference", value: __defun__difference})
 
-	__defun__do = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__do = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2081 := __args[0]
 		_ = V2081
 		V2082 := __args[1]
 		_ = V2082
-		__ctx.Return(V2082)
+		__e.Return(V2082)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "do", value: __defun__do})
 
-	__defun__element_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__element_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2094 := __args[0]
 		_ = V2094
 		V2095 := __args[1]
@@ -2339,7 +2339,7 @@ func init() {
 		reg5434 := PrimEqual(reg5433, V2095)
 		if reg5434 == True {
 			reg5435 := False
-			__ctx.Return(reg5435)
+			__e.Return(reg5435)
 			return
 		} else {
 			reg5436 := PrimIsPair(V2095)
@@ -2362,17 +2362,17 @@ func init() {
 			}
 			if reg5443 == True {
 				reg5444 := True
-				__ctx.Return(reg5444)
+				__e.Return(reg5444)
 				return
 			} else {
 				reg5445 := PrimIsPair(V2095)
 				if reg5445 == True {
 					reg5446 := PrimTail(V2095)
-					__ctx.TailApply(__defun__element_2, V2094, reg5446)
+					__e.TailApply(__defun__element_2, V2094, reg5446)
 					return
 				} else {
 					reg5448 := MakeSymbol("element?")
-					__ctx.TailApply(__defun__shen_4f__error, reg5448)
+					__e.TailApply(__defun__shen_4f__error, reg5448)
 					return
 				}
 			}
@@ -2380,35 +2380,35 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "element?", value: __defun__element_2})
 
-	__defun__empty_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__empty_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2101 := __args[0]
 		_ = V2101
 		reg5450 := Nil
 		reg5451 := PrimEqual(reg5450, V2101)
 		if reg5451 == True {
 			reg5452 := True
-			__ctx.Return(reg5452)
+			__e.Return(reg5452)
 			return
 		} else {
 			reg5453 := False
-			__ctx.Return(reg5453)
+			__e.Return(reg5453)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "empty?", value: __defun__empty_2})
 
-	__defun__fix = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__fix = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2104 := __args[0]
 		_ = V2104
 		V2105 := __args[1]
 		_ = V2105
-		reg5454 := __e.Call(V2104, V2105)
-		__ctx.TailApply(__defun__shen_4fix_1help, V2104, V2105, reg5454)
+		reg5454 := Call(__e, V2104, V2105)
+		__e.TailApply(__defun__shen_4fix_1help, V2104, V2105, reg5454)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "fix", value: __defun__fix})
 
-	__defun__shen_4fix_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4fix_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2116 := __args[0]
 		_ = V2116
 		V2117 := __args[1]
@@ -2417,17 +2417,17 @@ func init() {
 		_ = V2118
 		reg5456 := PrimEqual(V2118, V2117)
 		if reg5456 == True {
-			__ctx.Return(V2118)
+			__e.Return(V2118)
 			return
 		} else {
-			reg5457 := __e.Call(V2116, V2118)
-			__ctx.TailApply(__defun__shen_4fix_1help, V2116, V2118, reg5457)
+			reg5457 := Call(__e, V2116, V2118)
+			__e.TailApply(__defun__shen_4fix_1help, V2116, V2118, reg5457)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.fix-help", value: __defun__shen_4fix_1help})
 
-	__defun__put = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__put = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2123 := __args[0]
 		_ = V2123
 		V2124 := __args[1]
@@ -2436,135 +2436,135 @@ func init() {
 		_ = V2125
 		V2126 := __args[3]
 		_ = V2126
-		reg5459 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			__ctx.TailApply(__defun__shen_4_5_1dict, V2126, V2123)
+		reg5459 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			__e.TailApply(__defun__shen_4_5_1dict, V2126, V2123)
 			return
 		}, 0)
-		reg5461 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5461 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg5462 := Nil
-			__ctx.Return(reg5462)
+			__e.Return(reg5462)
 			return
 		}, 1)
-		reg5463 := __e.Try(reg5459).Catch(reg5461)
+		reg5463 := Try(__e, reg5459).Catch(reg5461)
 		Curr := reg5463
 		_ = Curr
-		reg5464 := __e.Call(__defun__shen_4assoc_1set, V2124, V2125, Curr)
+		reg5464 := Call(__e, __defun__shen_4assoc_1set, V2124, V2125, Curr)
 		Added := reg5464
 		_ = Added
-		reg5465 := __e.Call(__defun__shen_4dict_1_6, V2126, V2123, Added)
+		reg5465 := Call(__e, __defun__shen_4dict_1_6, V2126, V2123, Added)
 		Update := reg5465
 		_ = Update
-		__ctx.Return(V2125)
+		__e.Return(V2125)
 		return
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "put", value: __defun__put})
 
-	__defun__unput = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__unput = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2130 := __args[0]
 		_ = V2130
 		V2131 := __args[1]
 		_ = V2131
 		V2132 := __args[2]
 		_ = V2132
-		reg5466 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			__ctx.TailApply(__defun__shen_4_5_1dict, V2132, V2130)
+		reg5466 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			__e.TailApply(__defun__shen_4_5_1dict, V2132, V2130)
 			return
 		}, 0)
-		reg5468 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5468 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg5469 := Nil
-			__ctx.Return(reg5469)
+			__e.Return(reg5469)
 			return
 		}, 1)
-		reg5470 := __e.Try(reg5466).Catch(reg5468)
+		reg5470 := Try(__e, reg5466).Catch(reg5468)
 		Curr := reg5470
 		_ = Curr
-		reg5471 := __e.Call(__defun__shen_4assoc_1rm, V2131, Curr)
+		reg5471 := Call(__e, __defun__shen_4assoc_1rm, V2131, Curr)
 		Removed := reg5471
 		_ = Removed
-		reg5472 := __e.Call(__defun__shen_4dict_1_6, V2132, V2130, Removed)
+		reg5472 := Call(__e, __defun__shen_4dict_1_6, V2132, V2130, Removed)
 		Update := reg5472
 		_ = Update
-		__ctx.Return(V2130)
+		__e.Return(V2130)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "unput", value: __defun__unput})
 
-	__defun__get = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__get = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2136 := __args[0]
 		_ = V2136
 		V2137 := __args[1]
 		_ = V2137
 		V2138 := __args[2]
 		_ = V2138
-		reg5473 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			__ctx.TailApply(__defun__shen_4_5_1dict, V2138, V2136)
+		reg5473 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			__e.TailApply(__defun__shen_4_5_1dict, V2138, V2136)
 			return
 		}, 0)
-		reg5475 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5475 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg5476 := Nil
-			__ctx.Return(reg5476)
+			__e.Return(reg5476)
 			return
 		}, 1)
-		reg5477 := __e.Try(reg5473).Catch(reg5475)
+		reg5477 := Try(__e, reg5473).Catch(reg5475)
 		Entry := reg5477
 		_ = Entry
-		reg5478 := __e.Call(__defun__assoc, V2137, Entry)
+		reg5478 := Call(__e, __defun__assoc, V2137, Entry)
 		Result := reg5478
 		_ = Result
-		reg5479 := __e.Call(__defun__empty_2, Result)
+		reg5479 := Call(__e, __defun__empty_2, Result)
 		if reg5479 == True {
 			reg5480 := MakeString("value not found\n")
 			reg5481 := PrimSimpleError(reg5480)
-			__ctx.Return(reg5481)
+			__e.Return(reg5481)
 			return
 		} else {
 			reg5482 := PrimTail(Result)
-			__ctx.Return(reg5482)
+			__e.Return(reg5482)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "get", value: __defun__get})
 
-	__defun__hash = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__hash = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2141 := __args[0]
 		_ = V2141
 		V2142 := __args[1]
 		_ = V2142
-		reg5483 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5483 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
 			reg5484 := PrimStringToNumber(X)
-			__ctx.Return(reg5484)
+			__e.Return(reg5484)
 			return
 		}, 1)
-		reg5485 := __e.Call(__defun__explode, V2141)
-		reg5486 := __e.Call(__defun__map, reg5483, reg5485)
-		reg5487 := __e.Call(__defun__sum, reg5486)
-		__ctx.TailApply(__defun__shen_4mod, reg5487, V2142)
+		reg5485 := Call(__e, __defun__explode, V2141)
+		reg5486 := Call(__e, __defun__map, reg5483, reg5485)
+		reg5487 := Call(__e, __defun__sum, reg5486)
+		__e.TailApply(__defun__shen_4mod, reg5487, V2142)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "hash", value: __defun__hash})
 
-	__defun__shen_4mod = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4mod = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2145 := __args[0]
 		_ = V2145
 		V2146 := __args[1]
 		_ = V2146
 		reg5489 := Nil
 		reg5490 := PrimCons(V2146, reg5489)
-		reg5491 := __e.Call(__defun__shen_4multiples, V2145, reg5490)
-		__ctx.TailApply(__defun__shen_4modh, V2145, reg5491)
+		reg5491 := Call(__e, __defun__shen_4multiples, V2145, reg5490)
+		__e.TailApply(__defun__shen_4modh, V2145, reg5491)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.mod", value: __defun__shen_4mod})
 
-	__defun__shen_4multiples = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4multiples = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2149 := __args[0]
 		_ = V2149
 		V2150 := __args[1]
@@ -2589,7 +2589,7 @@ func init() {
 		}
 		if reg5500 == True {
 			reg5501 := PrimTail(V2150)
-			__ctx.Return(reg5501)
+			__e.Return(reg5501)
 			return
 		} else {
 			reg5502 := PrimIsPair(V2150)
@@ -2598,18 +2598,18 @@ func init() {
 				reg5504 := PrimHead(V2150)
 				reg5505 := PrimNumberMultiply(reg5503, reg5504)
 				reg5506 := PrimCons(reg5505, V2150)
-				__ctx.TailApply(__defun__shen_4multiples, V2149, reg5506)
+				__e.TailApply(__defun__shen_4multiples, V2149, reg5506)
 				return
 			} else {
 				reg5508 := MakeSymbol("shen.multiples")
-				__ctx.TailApply(__defun__shen_4f__error, reg5508)
+				__e.TailApply(__defun__shen_4f__error, reg5508)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.multiples", value: __defun__shen_4multiples})
 
-	__defun__shen_4modh = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4modh = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2155 := __args[0]
 		_ = V2155
 		V2156 := __args[1]
@@ -2618,13 +2618,13 @@ func init() {
 		reg5511 := PrimEqual(reg5510, V2155)
 		if reg5511 == True {
 			reg5512 := MakeNumber(0)
-			__ctx.Return(reg5512)
+			__e.Return(reg5512)
 			return
 		} else {
 			reg5513 := Nil
 			reg5514 := PrimEqual(reg5513, V2156)
 			if reg5514 == True {
-				__ctx.Return(V2155)
+				__e.Return(V2155)
 				return
 			} else {
 				reg5515 := PrimIsPair(V2156)
@@ -2647,13 +2647,13 @@ func init() {
 				}
 				if reg5522 == True {
 					reg5523 := PrimTail(V2156)
-					reg5524 := __e.Call(__defun__empty_2, reg5523)
+					reg5524 := Call(__e, __defun__empty_2, reg5523)
 					if reg5524 == True {
-						__ctx.Return(V2155)
+						__e.Return(V2155)
 						return
 					} else {
 						reg5525 := PrimTail(V2156)
-						__ctx.TailApply(__defun__shen_4modh, V2155, reg5525)
+						__e.TailApply(__defun__shen_4modh, V2155, reg5525)
 						return
 					}
 				} else {
@@ -2661,11 +2661,11 @@ func init() {
 					if reg5527 == True {
 						reg5528 := PrimHead(V2156)
 						reg5529 := PrimNumberSubtract(V2155, reg5528)
-						__ctx.TailApply(__defun__shen_4modh, reg5529, V2156)
+						__e.TailApply(__defun__shen_4modh, reg5529, V2156)
 						return
 					} else {
 						reg5531 := MakeSymbol("shen.modh")
-						__ctx.TailApply(__defun__shen_4f__error, reg5531)
+						__e.TailApply(__defun__shen_4f__error, reg5531)
 						return
 					}
 				}
@@ -2674,78 +2674,78 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.modh", value: __defun__shen_4modh})
 
-	__defun__sum = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__sum = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2158 := __args[0]
 		_ = V2158
 		reg5533 := Nil
 		reg5534 := PrimEqual(reg5533, V2158)
 		if reg5534 == True {
 			reg5535 := MakeNumber(0)
-			__ctx.Return(reg5535)
+			__e.Return(reg5535)
 			return
 		} else {
 			reg5536 := PrimIsPair(V2158)
 			if reg5536 == True {
 				reg5537 := PrimHead(V2158)
 				reg5538 := PrimTail(V2158)
-				reg5539 := __e.Call(__defun__sum, reg5538)
+				reg5539 := Call(__e, __defun__sum, reg5538)
 				reg5540 := PrimNumberAdd(reg5537, reg5539)
-				__ctx.Return(reg5540)
+				__e.Return(reg5540)
 				return
 			} else {
 				reg5541 := MakeSymbol("sum")
-				__ctx.TailApply(__defun__shen_4f__error, reg5541)
+				__e.TailApply(__defun__shen_4f__error, reg5541)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "sum", value: __defun__sum})
 
-	__defun__head = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__head = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2166 := __args[0]
 		_ = V2166
 		reg5543 := PrimIsPair(V2166)
 		if reg5543 == True {
 			reg5544 := PrimHead(V2166)
-			__ctx.Return(reg5544)
+			__e.Return(reg5544)
 			return
 		} else {
 			reg5545 := MakeString("head expects a non-empty list")
 			reg5546 := PrimSimpleError(reg5545)
-			__ctx.Return(reg5546)
+			__e.Return(reg5546)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "head", value: __defun__head})
 
-	__defun__tail = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__tail = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2174 := __args[0]
 		_ = V2174
 		reg5547 := PrimIsPair(V2174)
 		if reg5547 == True {
 			reg5548 := PrimTail(V2174)
-			__ctx.Return(reg5548)
+			__e.Return(reg5548)
 			return
 		} else {
 			reg5549 := MakeString("tail expects a non-empty list")
 			reg5550 := PrimSimpleError(reg5549)
-			__ctx.Return(reg5550)
+			__e.Return(reg5550)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "tail", value: __defun__tail})
 
-	__defun__hdstr = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__hdstr = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2176 := __args[0]
 		_ = V2176
 		reg5551 := MakeNumber(0)
 		reg5552 := PrimPos(V2176, reg5551)
-		__ctx.Return(reg5552)
+		__e.Return(reg5552)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "hdstr", value: __defun__hdstr})
 
-	__defun__intersection = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__intersection = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2181 := __args[0]
 		_ = V2181
 		V2182 := __args[1]
@@ -2754,44 +2754,44 @@ func init() {
 		reg5554 := PrimEqual(reg5553, V2181)
 		if reg5554 == True {
 			reg5555 := Nil
-			__ctx.Return(reg5555)
+			__e.Return(reg5555)
 			return
 		} else {
 			reg5556 := PrimIsPair(V2181)
 			if reg5556 == True {
 				reg5557 := PrimHead(V2181)
-				reg5558 := __e.Call(__defun__element_2, reg5557, V2182)
+				reg5558 := Call(__e, __defun__element_2, reg5557, V2182)
 				if reg5558 == True {
 					reg5559 := PrimHead(V2181)
 					reg5560 := PrimTail(V2181)
-					reg5561 := __e.Call(__defun__intersection, reg5560, V2182)
+					reg5561 := Call(__e, __defun__intersection, reg5560, V2182)
 					reg5562 := PrimCons(reg5559, reg5561)
-					__ctx.Return(reg5562)
+					__e.Return(reg5562)
 					return
 				} else {
 					reg5563 := PrimTail(V2181)
-					__ctx.TailApply(__defun__intersection, reg5563, V2182)
+					__e.TailApply(__defun__intersection, reg5563, V2182)
 					return
 				}
 			} else {
 				reg5565 := MakeSymbol("intersection")
-				__ctx.TailApply(__defun__shen_4f__error, reg5565)
+				__e.TailApply(__defun__shen_4f__error, reg5565)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "intersection", value: __defun__intersection})
 
-	__defun__reverse = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__reverse = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2184 := __args[0]
 		_ = V2184
 		reg5567 := Nil
-		__ctx.TailApply(__defun__shen_4reverse__help, V2184, reg5567)
+		__e.TailApply(__defun__shen_4reverse__help, V2184, reg5567)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "reverse", value: __defun__reverse})
 
-	__defun__shen_4reverse__help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4reverse__help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2187 := __args[0]
 		_ = V2187
 		V2188 := __args[1]
@@ -2799,7 +2799,7 @@ func init() {
 		reg5569 := Nil
 		reg5570 := PrimEqual(reg5569, V2187)
 		if reg5570 == True {
-			__ctx.Return(V2188)
+			__e.Return(V2188)
 			return
 		} else {
 			reg5571 := PrimIsPair(V2187)
@@ -2807,18 +2807,18 @@ func init() {
 				reg5572 := PrimTail(V2187)
 				reg5573 := PrimHead(V2187)
 				reg5574 := PrimCons(reg5573, V2188)
-				__ctx.TailApply(__defun__shen_4reverse__help, reg5572, reg5574)
+				__e.TailApply(__defun__shen_4reverse__help, reg5572, reg5574)
 				return
 			} else {
 				reg5576 := MakeSymbol("shen.reverse_help")
-				__ctx.TailApply(__defun__shen_4f__error, reg5576)
+				__e.TailApply(__defun__shen_4f__error, reg5576)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.reverse_help", value: __defun__shen_4reverse__help})
 
-	__defun__union = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__union = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2191 := __args[0]
 		_ = V2191
 		V2192 := __args[1]
@@ -2826,95 +2826,95 @@ func init() {
 		reg5578 := Nil
 		reg5579 := PrimEqual(reg5578, V2191)
 		if reg5579 == True {
-			__ctx.Return(V2192)
+			__e.Return(V2192)
 			return
 		} else {
 			reg5580 := PrimIsPair(V2191)
 			if reg5580 == True {
 				reg5581 := PrimHead(V2191)
-				reg5582 := __e.Call(__defun__element_2, reg5581, V2192)
+				reg5582 := Call(__e, __defun__element_2, reg5581, V2192)
 				if reg5582 == True {
 					reg5583 := PrimTail(V2191)
-					__ctx.TailApply(__defun__union, reg5583, V2192)
+					__e.TailApply(__defun__union, reg5583, V2192)
 					return
 				} else {
 					reg5585 := PrimHead(V2191)
 					reg5586 := PrimTail(V2191)
-					reg5587 := __e.Call(__defun__union, reg5586, V2192)
+					reg5587 := Call(__e, __defun__union, reg5586, V2192)
 					reg5588 := PrimCons(reg5585, reg5587)
-					__ctx.Return(reg5588)
+					__e.Return(reg5588)
 					return
 				}
 			} else {
 				reg5589 := MakeSymbol("union")
-				__ctx.TailApply(__defun__shen_4f__error, reg5589)
+				__e.TailApply(__defun__shen_4f__error, reg5589)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "union", value: __defun__union})
 
-	__defun__y_1or_1n_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__y_1or_1n_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2194 := __args[0]
 		_ = V2194
-		reg5591 := __e.Call(__defun__shen_4proc_1nl, V2194)
-		reg5592 := __e.Call(__defun__stoutput)
-		reg5593 := __e.Call(__defun__shen_4prhush, reg5591, reg5592)
+		reg5591 := Call(__e, __defun__shen_4proc_1nl, V2194)
+		reg5592 := Call(__e, __defun__stoutput)
+		reg5593 := Call(__e, __defun__shen_4prhush, reg5591, reg5592)
 		Message := reg5593
 		_ = Message
 		reg5594 := MakeString(" (y/n) ")
-		reg5595 := __e.Call(__defun__stoutput)
-		reg5596 := __e.Call(__defun__shen_4prhush, reg5594, reg5595)
+		reg5595 := Call(__e, __defun__stoutput)
+		reg5596 := Call(__e, __defun__shen_4prhush, reg5594, reg5595)
 		Y_1or_1N := reg5596
 		_ = Y_1or_1N
-		reg5597 := __e.Call(__defun__stinput)
-		reg5598 := __e.Call(__defun__read, reg5597)
+		reg5597 := Call(__e, __defun__stinput)
+		reg5598 := Call(__e, __defun__read, reg5597)
 		reg5599 := MakeString("")
 		reg5600 := MakeSymbol("shen.s")
-		reg5601 := __e.Call(__defun__shen_4app, reg5598, reg5599, reg5600)
+		reg5601 := Call(__e, __defun__shen_4app, reg5598, reg5599, reg5600)
 		Input := reg5601
 		_ = Input
 		reg5602 := MakeString("y")
 		reg5603 := PrimEqual(reg5602, Input)
 		if reg5603 == True {
 			reg5604 := True
-			__ctx.Return(reg5604)
+			__e.Return(reg5604)
 			return
 		} else {
 			reg5605 := MakeString("n")
 			reg5606 := PrimEqual(reg5605, Input)
 			if reg5606 == True {
 				reg5607 := False
-				__ctx.Return(reg5607)
+				__e.Return(reg5607)
 				return
 			} else {
 				reg5608 := MakeString("please answer y or n\n")
-				reg5609 := __e.Call(__defun__stoutput)
-				reg5610 := __e.Call(__defun__shen_4prhush, reg5608, reg5609)
+				reg5609 := Call(__e, __defun__stoutput)
+				reg5610 := Call(__e, __defun__shen_4prhush, reg5608, reg5609)
 				_ = reg5610
-				__ctx.TailApply(__defun__y_1or_1n_2, V2194)
+				__e.TailApply(__defun__y_1or_1n_2, V2194)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "y-or-n?", value: __defun__y_1or_1n_2})
 
-	__defun__not = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__not = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2196 := __args[0]
 		_ = V2196
 		if V2196 == True {
 			reg5612 := False
-			__ctx.Return(reg5612)
+			__e.Return(reg5612)
 			return
 		} else {
 			reg5613 := True
-			__ctx.Return(reg5613)
+			__e.Return(reg5613)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "not", value: __defun__not})
 
-	__defun__subst = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__subst = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2209 := __args[0]
 		_ = V2209
 		V2210 := __args[1]
@@ -2923,67 +2923,67 @@ func init() {
 		_ = V2211
 		reg5614 := PrimEqual(V2211, V2210)
 		if reg5614 == True {
-			__ctx.Return(V2209)
+			__e.Return(V2209)
 			return
 		} else {
 			reg5615 := PrimIsPair(V2211)
 			if reg5615 == True {
-				reg5616 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg5616 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					W := __args[0]
 					_ = W
-					__ctx.TailApply(__defun__subst, V2209, V2210, W)
+					__e.TailApply(__defun__subst, V2209, V2210, W)
 					return
 				}, 1)
-				__ctx.TailApply(__defun__map, reg5616, V2211)
+				__e.TailApply(__defun__map, reg5616, V2211)
 				return
 			} else {
-				__ctx.Return(V2211)
+				__e.Return(V2211)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "subst", value: __defun__subst})
 
-	__defun__explode = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__explode = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2213 := __args[0]
 		_ = V2213
 		reg5619 := MakeString("")
 		reg5620 := MakeSymbol("shen.a")
-		reg5621 := __e.Call(__defun__shen_4app, V2213, reg5619, reg5620)
-		__ctx.TailApply(__defun__shen_4explode_1h, reg5621)
+		reg5621 := Call(__e, __defun__shen_4app, V2213, reg5619, reg5620)
+		__e.TailApply(__defun__shen_4explode_1h, reg5621)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "explode", value: __defun__explode})
 
-	__defun__shen_4explode_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4explode_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2215 := __args[0]
 		_ = V2215
 		reg5623 := MakeString("")
 		reg5624 := PrimEqual(reg5623, V2215)
 		if reg5624 == True {
 			reg5625 := Nil
-			__ctx.Return(reg5625)
+			__e.Return(reg5625)
 			return
 		} else {
-			reg5626 := __e.Call(__defun__shen_4_7string_2, V2215)
+			reg5626 := Call(__e, __defun__shen_4_7string_2, V2215)
 			if reg5626 == True {
 				reg5627 := MakeNumber(0)
 				reg5628 := PrimPos(V2215, reg5627)
 				reg5629 := PrimTailString(V2215)
-				reg5630 := __e.Call(__defun__shen_4explode_1h, reg5629)
+				reg5630 := Call(__e, __defun__shen_4explode_1h, reg5629)
 				reg5631 := PrimCons(reg5628, reg5630)
-				__ctx.Return(reg5631)
+				__e.Return(reg5631)
 				return
 			} else {
 				reg5632 := MakeSymbol("shen.explode-h")
-				__ctx.TailApply(__defun__shen_4f__error, reg5632)
+				__e.TailApply(__defun__shen_4f__error, reg5632)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.explode-h", value: __defun__shen_4explode_1h})
 
-	__defun__cd = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__cd = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2217 := __args[0]
 		_ = V2217
 		reg5634 := MakeSymbol("*home-directory*")
@@ -2996,16 +2996,16 @@ func init() {
 		} else {
 			reg5638 := MakeString("/")
 			reg5639 := MakeSymbol("shen.a")
-			reg5640 := __e.Call(__defun__shen_4app, V2217, reg5638, reg5639)
+			reg5640 := Call(__e, __defun__shen_4app, V2217, reg5638, reg5639)
 			reg5641 = reg5640
 		}
 		reg5642 := PrimSet(reg5634, reg5641)
-		__ctx.Return(reg5642)
+		__e.Return(reg5642)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "cd", value: __defun__cd})
 
-	__defun__shen_4for_1each = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4for_1each = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2220 := __args[0]
 		_ = V2220
 		V2221 := __args[1]
@@ -3014,28 +3014,28 @@ func init() {
 		reg5644 := PrimEqual(reg5643, V2221)
 		if reg5644 == True {
 			reg5645 := True
-			__ctx.Return(reg5645)
+			__e.Return(reg5645)
 			return
 		} else {
 			reg5646 := PrimIsPair(V2221)
 			if reg5646 == True {
 				reg5647 := PrimHead(V2221)
-				reg5648 := __e.Call(V2220, reg5647)
+				reg5648 := Call(__e, V2220, reg5647)
 				__ := reg5648
 				_ = __
 				reg5649 := PrimTail(V2221)
-				__ctx.TailApply(__defun__shen_4for_1each, V2220, reg5649)
+				__e.TailApply(__defun__shen_4for_1each, V2220, reg5649)
 				return
 			} else {
 				reg5651 := MakeSymbol("shen.for-each")
-				__ctx.TailApply(__defun__shen_4f__error, reg5651)
+				__e.TailApply(__defun__shen_4f__error, reg5651)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.for-each", value: __defun__shen_4for_1each})
 
-	__defun__map = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__map = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2226 := __args[0]
 		_ = V2226
 		V2227 := __args[1]
@@ -3044,36 +3044,36 @@ func init() {
 		reg5654 := PrimEqual(reg5653, V2227)
 		if reg5654 == True {
 			reg5655 := Nil
-			__ctx.Return(reg5655)
+			__e.Return(reg5655)
 			return
 		} else {
 			reg5656 := PrimIsPair(V2227)
 			if reg5656 == True {
 				reg5657 := PrimHead(V2227)
-				reg5658 := __e.Call(V2226, reg5657)
+				reg5658 := Call(__e, V2226, reg5657)
 				reg5659 := PrimTail(V2227)
-				reg5660 := __e.Call(__defun__map, V2226, reg5659)
+				reg5660 := Call(__e, __defun__map, V2226, reg5659)
 				reg5661 := PrimCons(reg5658, reg5660)
-				__ctx.Return(reg5661)
+				__e.Return(reg5661)
 				return
 			} else {
-				__ctx.TailApply(V2226, V2227)
+				__e.TailApply(V2226, V2227)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "map", value: __defun__map})
 
-	__defun__length = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__length = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2229 := __args[0]
 		_ = V2229
 		reg5663 := MakeNumber(0)
-		__ctx.TailApply(__defun__shen_4length_1h, V2229, reg5663)
+		__e.TailApply(__defun__shen_4length_1h, V2229, reg5663)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "length", value: __defun__length})
 
-	__defun__shen_4length_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4length_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2232 := __args[0]
 		_ = V2232
 		V2233 := __args[1]
@@ -3081,19 +3081,19 @@ func init() {
 		reg5665 := Nil
 		reg5666 := PrimEqual(reg5665, V2232)
 		if reg5666 == True {
-			__ctx.Return(V2233)
+			__e.Return(V2233)
 			return
 		} else {
 			reg5667 := PrimTail(V2232)
 			reg5668 := MakeNumber(1)
 			reg5669 := PrimNumberAdd(V2233, reg5668)
-			__ctx.TailApply(__defun__shen_4length_1h, reg5667, reg5669)
+			__e.TailApply(__defun__shen_4length_1h, reg5667, reg5669)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.length-h", value: __defun__shen_4length_1h})
 
-	__defun__occurrences = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__occurrences = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2245 := __args[0]
 		_ = V2245
 		V2246 := __args[1]
@@ -3101,28 +3101,28 @@ func init() {
 		reg5671 := PrimEqual(V2246, V2245)
 		if reg5671 == True {
 			reg5672 := MakeNumber(1)
-			__ctx.Return(reg5672)
+			__e.Return(reg5672)
 			return
 		} else {
 			reg5673 := PrimIsPair(V2246)
 			if reg5673 == True {
 				reg5674 := PrimHead(V2246)
-				reg5675 := __e.Call(__defun__occurrences, V2245, reg5674)
+				reg5675 := Call(__e, __defun__occurrences, V2245, reg5674)
 				reg5676 := PrimTail(V2246)
-				reg5677 := __e.Call(__defun__occurrences, V2245, reg5676)
+				reg5677 := Call(__e, __defun__occurrences, V2245, reg5676)
 				reg5678 := PrimNumberAdd(reg5675, reg5677)
-				__ctx.Return(reg5678)
+				__e.Return(reg5678)
 				return
 			} else {
 				reg5679 := MakeNumber(0)
-				__ctx.Return(reg5679)
+				__e.Return(reg5679)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "occurrences", value: __defun__occurrences})
 
-	__defun__nth = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__nth = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2253 := __args[0]
 		_ = V2253
 		V2254 := __args[1]
@@ -3147,7 +3147,7 @@ func init() {
 		}
 		if reg5687 == True {
 			reg5688 := PrimHead(V2254)
-			__ctx.Return(reg5688)
+			__e.Return(reg5688)
 			return
 		} else {
 			reg5689 := PrimIsPair(V2254)
@@ -3155,72 +3155,72 @@ func init() {
 				reg5690 := MakeNumber(1)
 				reg5691 := PrimNumberSubtract(V2253, reg5690)
 				reg5692 := PrimTail(V2254)
-				__ctx.TailApply(__defun__nth, reg5691, reg5692)
+				__e.TailApply(__defun__nth, reg5691, reg5692)
 				return
 			} else {
 				reg5694 := MakeString("nth applied to ")
 				reg5695 := MakeString(", ")
 				reg5696 := MakeString("\n")
 				reg5697 := MakeSymbol("shen.a")
-				reg5698 := __e.Call(__defun__shen_4app, V2254, reg5696, reg5697)
+				reg5698 := Call(__e, __defun__shen_4app, V2254, reg5696, reg5697)
 				reg5699 := PrimStringConcat(reg5695, reg5698)
 				reg5700 := MakeSymbol("shen.a")
-				reg5701 := __e.Call(__defun__shen_4app, V2253, reg5699, reg5700)
+				reg5701 := Call(__e, __defun__shen_4app, V2253, reg5699, reg5700)
 				reg5702 := PrimStringConcat(reg5694, reg5701)
 				reg5703 := PrimSimpleError(reg5702)
-				__ctx.Return(reg5703)
+				__e.Return(reg5703)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "nth", value: __defun__nth})
 
-	__defun__integer_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__integer_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2256 := __args[0]
 		_ = V2256
 		reg5704 := PrimIsNumber(V2256)
 		if reg5704 == True {
-			reg5705 := __e.Call(__defun__shen_4abs, V2256)
+			reg5705 := Call(__e, __defun__shen_4abs, V2256)
 			Abs := reg5705
 			_ = Abs
 			reg5706 := MakeNumber(1)
-			reg5707 := __e.Call(__defun__shen_4magless, Abs, reg5706)
-			reg5708 := __e.Call(__defun__shen_4integer_1test_2, Abs, reg5707)
+			reg5707 := Call(__e, __defun__shen_4magless, Abs, reg5706)
+			reg5708 := Call(__e, __defun__shen_4integer_1test_2, Abs, reg5707)
 			if reg5708 == True {
 				reg5709 := True
-				__ctx.Return(reg5709)
+				__e.Return(reg5709)
 				return
 			} else {
 				reg5710 := False
-				__ctx.Return(reg5710)
+				__e.Return(reg5710)
 				return
 			}
 		} else {
 			reg5711 := False
-			__ctx.Return(reg5711)
+			__e.Return(reg5711)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "integer?", value: __defun__integer_2})
 
-	__defun__shen_4abs = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4abs = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2258 := __args[0]
 		_ = V2258
 		reg5712 := MakeNumber(0)
 		reg5713 := PrimGreatThan(V2258, reg5712)
 		if reg5713 == True {
-			__ctx.Return(V2258)
+			__e.Return(V2258)
 			return
 		} else {
 			reg5714 := MakeNumber(0)
 			reg5715 := PrimNumberSubtract(reg5714, V2258)
-			__ctx.Return(reg5715)
+			__e.Return(reg5715)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.abs", value: __defun__shen_4abs})
 
-	__defun__shen_4magless = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4magless = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2261 := __args[0]
 		_ = V2261
 		V2262 := __args[1]
@@ -3231,16 +3231,16 @@ func init() {
 		_ = Nx2
 		reg5718 := PrimGreatThan(Nx2, V2261)
 		if reg5718 == True {
-			__ctx.Return(V2262)
+			__e.Return(V2262)
 			return
 		} else {
-			__ctx.TailApply(__defun__shen_4magless, V2261, Nx2)
+			__e.TailApply(__defun__shen_4magless, V2261, Nx2)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.magless", value: __defun__shen_4magless})
 
-	__defun__shen_4integer_1test_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4integer_1test_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2268 := __args[0]
 		_ = V2268
 		V2269 := __args[1]
@@ -3249,14 +3249,14 @@ func init() {
 		reg5721 := PrimEqual(reg5720, V2268)
 		if reg5721 == True {
 			reg5722 := True
-			__ctx.Return(reg5722)
+			__e.Return(reg5722)
 			return
 		} else {
 			reg5723 := MakeNumber(1)
 			reg5724 := PrimGreatThan(reg5723, V2268)
 			if reg5724 == True {
 				reg5725 := False
-				__ctx.Return(reg5725)
+				__e.Return(reg5725)
 				return
 			} else {
 				reg5726 := PrimNumberSubtract(V2268, V2269)
@@ -3266,10 +3266,10 @@ func init() {
 				reg5728 := PrimGreatThan(reg5727, Abs_1N)
 				if reg5728 == True {
 					reg5729 := PrimIsInteger(V2268)
-					__ctx.Return(reg5729)
+					__e.Return(reg5729)
 					return
 				} else {
-					__ctx.TailApply(__defun__shen_4integer_1test_2, Abs_1N, V2269)
+					__e.TailApply(__defun__shen_4integer_1test_2, Abs_1N, V2269)
 					return
 				}
 			}
@@ -3277,7 +3277,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.integer-test?", value: __defun__shen_4integer_1test_2})
 
-	__defun__mapcan = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__mapcan = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2274 := __args[0]
 		_ = V2274
 		V2275 := __args[1]
@@ -3286,27 +3286,27 @@ func init() {
 		reg5732 := PrimEqual(reg5731, V2275)
 		if reg5732 == True {
 			reg5733 := Nil
-			__ctx.Return(reg5733)
+			__e.Return(reg5733)
 			return
 		} else {
 			reg5734 := PrimIsPair(V2275)
 			if reg5734 == True {
 				reg5735 := PrimHead(V2275)
-				reg5736 := __e.Call(V2274, reg5735)
+				reg5736 := Call(__e, V2274, reg5735)
 				reg5737 := PrimTail(V2275)
-				reg5738 := __e.Call(__defun__mapcan, V2274, reg5737)
-				__ctx.TailApply(__defun__append, reg5736, reg5738)
+				reg5738 := Call(__e, __defun__mapcan, V2274, reg5737)
+				__e.TailApply(__defun__append, reg5736, reg5738)
 				return
 			} else {
 				reg5740 := MakeSymbol("mapcan")
-				__ctx.TailApply(__defun__shen_4f__error, reg5740)
+				__e.TailApply(__defun__shen_4f__error, reg5740)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "mapcan", value: __defun__mapcan})
 
-	__defun___a_a = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun___a_a = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2287 := __args[0]
 		_ = V2287
 		V2288 := __args[1]
@@ -3314,42 +3314,42 @@ func init() {
 		reg5742 := PrimEqual(V2288, V2287)
 		if reg5742 == True {
 			reg5743 := True
-			__ctx.Return(reg5743)
+			__e.Return(reg5743)
 			return
 		} else {
 			reg5744 := False
-			__ctx.Return(reg5744)
+			__e.Return(reg5744)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "==", value: __defun___a_a})
 
-	__defun__abort = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__abort = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5745 := MakeString("")
 		reg5746 := PrimSimpleError(reg5745)
-		__ctx.Return(reg5746)
+		__e.Return(reg5746)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "abort", value: __defun__abort})
 
-	__defun__bound_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__bound_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2290 := __args[0]
 		_ = V2290
 		reg5747 := PrimIsSymbol(V2290)
 		if reg5747 == True {
-			reg5748 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5748 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg5749 := PrimValue(V2290)
-				__ctx.Return(reg5749)
+				__e.Return(reg5749)
 				return
 			}, 0)
-			reg5750 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg5750 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg5751 := MakeSymbol("shen.this-symbol-is-unbound")
-				__ctx.Return(reg5751)
+				__e.Return(reg5751)
 				return
 			}, 1)
-			reg5752 := __e.Try(reg5748).Catch(reg5750)
+			reg5752 := Try(__e, reg5748).Catch(reg5750)
 			Val := reg5752
 			_ = Val
 			reg5753 := MakeSymbol("shen.this-symbol-is-unbound")
@@ -3364,86 +3364,86 @@ func init() {
 			}
 			if reg5757 == True {
 				reg5758 := True
-				__ctx.Return(reg5758)
+				__e.Return(reg5758)
 				return
 			} else {
 				reg5759 := False
-				__ctx.Return(reg5759)
+				__e.Return(reg5759)
 				return
 			}
 		} else {
 			reg5760 := False
-			__ctx.Return(reg5760)
+			__e.Return(reg5760)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "bound?", value: __defun__bound_2})
 
-	__defun__shen_4string_1_6bytes = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4string_1_6bytes = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2292 := __args[0]
 		_ = V2292
 		reg5761 := MakeString("")
 		reg5762 := PrimEqual(reg5761, V2292)
 		if reg5762 == True {
 			reg5763 := Nil
-			__ctx.Return(reg5763)
+			__e.Return(reg5763)
 			return
 		} else {
 			reg5764 := MakeNumber(0)
 			reg5765 := PrimPos(V2292, reg5764)
 			reg5766 := PrimStringToNumber(reg5765)
 			reg5767 := PrimTailString(V2292)
-			reg5768 := __e.Call(__defun__shen_4string_1_6bytes, reg5767)
+			reg5768 := Call(__e, __defun__shen_4string_1_6bytes, reg5767)
 			reg5769 := PrimCons(reg5766, reg5768)
-			__ctx.Return(reg5769)
+			__e.Return(reg5769)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.string->bytes", value: __defun__shen_4string_1_6bytes})
 
-	__defun__maxinferences = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__maxinferences = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2294 := __args[0]
 		_ = V2294
 		reg5770 := MakeSymbol("shen.*maxinferences*")
 		reg5771 := PrimSet(reg5770, V2294)
-		__ctx.Return(reg5771)
+		__e.Return(reg5771)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "maxinferences", value: __defun__maxinferences})
 
-	__defun__inferences = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__inferences = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5772 := MakeSymbol("shen.*infs*")
 		reg5773 := PrimValue(reg5772)
-		__ctx.Return(reg5773)
+		__e.Return(reg5773)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "inferences", value: __defun__inferences})
 
-	__defun__protect = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__protect = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2296 := __args[0]
 		_ = V2296
-		__ctx.Return(V2296)
+		__e.Return(V2296)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "protect", value: __defun__protect})
 
-	__defun__stoutput = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__stoutput = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5774 := MakeSymbol("*stoutput*")
 		reg5775 := PrimValue(reg5774)
-		__ctx.Return(reg5775)
+		__e.Return(reg5775)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "stoutput", value: __defun__stoutput})
 
-	__defun__sterror = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__sterror = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5776 := MakeSymbol("*sterror*")
 		reg5777 := PrimValue(reg5776)
-		__ctx.Return(reg5777)
+		__e.Return(reg5777)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "sterror", value: __defun__sterror})
 
-	__defun__string_1_6symbol = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__string_1_6symbol = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2298 := __args[0]
 		_ = V2298
 		reg5778 := PrimIntern(V2298)
@@ -3451,22 +3451,22 @@ func init() {
 		_ = Symbol
 		reg5779 := PrimIsSymbol(Symbol)
 		if reg5779 == True {
-			__ctx.Return(Symbol)
+			__e.Return(Symbol)
 			return
 		} else {
 			reg5780 := MakeString("cannot intern ")
 			reg5781 := MakeString(" to a symbol")
 			reg5782 := MakeSymbol("shen.s")
-			reg5783 := __e.Call(__defun__shen_4app, V2298, reg5781, reg5782)
+			reg5783 := Call(__e, __defun__shen_4app, V2298, reg5781, reg5782)
 			reg5784 := PrimStringConcat(reg5780, reg5783)
 			reg5785 := PrimSimpleError(reg5784)
-			__ctx.Return(reg5785)
+			__e.Return(reg5785)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "string->symbol", value: __defun__string_1_6symbol})
 
-	__defun__optimise = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__optimise = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2304 := __args[0]
 		_ = V2304
 		reg5786 := MakeSymbol("+")
@@ -3475,7 +3475,7 @@ func init() {
 			reg5788 := MakeSymbol("shen.*optimise*")
 			reg5789 := True
 			reg5790 := PrimSet(reg5788, reg5789)
-			__ctx.Return(reg5790)
+			__e.Return(reg5790)
 			return
 		} else {
 			reg5791 := MakeSymbol("-")
@@ -3484,127 +3484,127 @@ func init() {
 				reg5793 := MakeSymbol("shen.*optimise*")
 				reg5794 := False
 				reg5795 := PrimSet(reg5793, reg5794)
-				__ctx.Return(reg5795)
+				__e.Return(reg5795)
 				return
 			} else {
 				reg5796 := MakeString("optimise expects a + or a -.\n")
 				reg5797 := PrimSimpleError(reg5796)
-				__ctx.Return(reg5797)
+				__e.Return(reg5797)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "optimise", value: __defun__optimise})
 
-	__defun__os = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__os = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5798 := MakeSymbol("*os*")
 		reg5799 := PrimValue(reg5798)
-		__ctx.Return(reg5799)
+		__e.Return(reg5799)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "os", value: __defun__os})
 
-	__defun__language = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__language = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5800 := MakeSymbol("*language*")
 		reg5801 := PrimValue(reg5800)
-		__ctx.Return(reg5801)
+		__e.Return(reg5801)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "language", value: __defun__language})
 
-	__defun__version = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__version = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5802 := MakeSymbol("*version*")
 		reg5803 := PrimValue(reg5802)
-		__ctx.Return(reg5803)
+		__e.Return(reg5803)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "version", value: __defun__version})
 
-	__defun__port = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__port = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5804 := MakeSymbol("*port*")
 		reg5805 := PrimValue(reg5804)
-		__ctx.Return(reg5805)
+		__e.Return(reg5805)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "port", value: __defun__port})
 
-	__defun__porters = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__porters = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5806 := MakeSymbol("*porters*")
 		reg5807 := PrimValue(reg5806)
-		__ctx.Return(reg5807)
+		__e.Return(reg5807)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "porters", value: __defun__porters})
 
-	__defun__implementation = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__implementation = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5808 := MakeSymbol("*implementation*")
 		reg5809 := PrimValue(reg5808)
-		__ctx.Return(reg5809)
+		__e.Return(reg5809)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "implementation", value: __defun__implementation})
 
-	__defun__release = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__release = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg5810 := MakeSymbol("*release*")
 		reg5811 := PrimValue(reg5810)
-		__ctx.Return(reg5811)
+		__e.Return(reg5811)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "release", value: __defun__release})
 
-	__defun__package_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__package_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2306 := __args[0]
 		_ = V2306
-		reg5812 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			reg5813 := __e.Call(__defun__external, V2306)
+		reg5812 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			reg5813 := Call(__e, __defun__external, V2306)
 			_ = reg5813
 			reg5814 := True
-			__ctx.Return(reg5814)
+			__e.Return(reg5814)
 			return
 		}, 0)
-		reg5815 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5815 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg5816 := False
-			__ctx.Return(reg5816)
+			__e.Return(reg5816)
 			return
 		}, 1)
-		reg5817 := __e.Try(reg5812).Catch(reg5815)
-		__ctx.Return(reg5817)
+		reg5817 := Try(__e, reg5812).Catch(reg5815)
+		__e.Return(reg5817)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "package?", value: __defun__package_2})
 
-	__defun__function = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__function = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2308 := __args[0]
 		_ = V2308
-		__ctx.TailApply(__defun__shen_4lookup_1func, V2308)
+		__e.TailApply(__defun__shen_4lookup_1func, V2308)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "function", value: __defun__function})
 
-	__defun__shen_4lookup_1func = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4lookup_1func = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2310 := __args[0]
 		_ = V2310
-		reg5819 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5819 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg5820 := MakeSymbol("shen.lambda-form")
 			reg5821 := MakeSymbol("*property-vector*")
 			reg5822 := PrimValue(reg5821)
-			__ctx.TailApply(__defun__get, V2310, reg5820, reg5822)
+			__e.TailApply(__defun__get, V2310, reg5820, reg5822)
 			return
 		}, 0)
-		reg5824 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg5824 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg5825 := MakeString(" has no lambda expansion\n")
 			reg5826 := MakeSymbol("shen.a")
-			reg5827 := __e.Call(__defun__shen_4app, V2310, reg5825, reg5826)
+			reg5827 := Call(__e, __defun__shen_4app, V2310, reg5825, reg5826)
 			reg5828 := PrimSimpleError(reg5827)
-			__ctx.Return(reg5828)
+			__e.Return(reg5828)
 			return
 		}, 1)
-		reg5829 := __e.Try(reg5819).Catch(reg5824)
-		__ctx.Return(reg5829)
+		reg5829 := Try(__e, reg5819).Catch(reg5824)
+		__e.Return(reg5829)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.lookup-func", value: __defun__shen_4lookup_1func})

--- a/cmd/shen/t_star.go
+++ b/cmd/shen/t_star.go
@@ -49,30 +49,30 @@ var __defun__shen_4findallhelp Obj             // shen.findallhelp
 var __defun__shen_4remember Obj                // shen.remember
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg19190 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg19190)
+		__e.Return(reg19190)
 		return
 	}, 0))
-	__defun__shen_4typecheck = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4typecheck = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2701 := __args[0]
 		_ = V2701
 		V2702 := __args[1]
 		_ = V2702
-		reg19191 := __e.Call(__defun__shen_4curry, V2701)
+		reg19191 := Call(__e, __defun__shen_4curry, V2701)
 		Curry := reg19191
 		_ = Curry
-		reg19192 := __e.Call(__defun__shen_4start_1new_1prolog_1process)
+		reg19192 := Call(__e, __defun__shen_4start_1new_1prolog_1process)
 		ProcessN := reg19192
 		_ = ProcessN
-		reg19193 := __e.Call(__defun__shen_4curry_1type, V2702)
-		reg19194 := __e.Call(__defun__shen_4demodulate, reg19193)
-		reg19195 := __e.Call(__defun__shen_4insert_1prolog_1variables, reg19194, ProcessN)
+		reg19193 := Call(__e, __defun__shen_4curry_1type, V2702)
+		reg19194 := Call(__e, __defun__shen_4demodulate, reg19193)
+		reg19195 := Call(__e, __defun__shen_4insert_1prolog_1variables, reg19194, ProcessN)
 		Type := reg19195
 		_ = Type
-		reg19196 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg19196 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg19197 := MakeSymbol("shen.void")
-			__ctx.TailApply(__defun__return, Type, ProcessN, reg19197)
+			__e.TailApply(__defun__return, Type, ProcessN, reg19197)
 			return
 		}, 0)
 		Continuation := reg19196
@@ -83,19 +83,19 @@ func init() {
 		reg19202 := PrimCons(reg19199, reg19201)
 		reg19203 := PrimCons(Curry, reg19202)
 		reg19204 := Nil
-		__ctx.TailApply(__defun__shen_4t_d, reg19203, reg19204, ProcessN, Continuation)
+		__e.TailApply(__defun__shen_4t_d, reg19203, reg19204, ProcessN, Continuation)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.typecheck", value: __defun__shen_4typecheck})
 
-	__defun__shen_4curry = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4curry = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2704 := __args[0]
 		_ = V2704
 		reg19206 := PrimIsPair(V2704)
 		var reg19213 Obj
 		if reg19206 == True {
 			reg19207 := PrimHead(V2704)
-			reg19208 := __e.Call(__defun__shen_4special_2, reg19207)
+			reg19208 := Call(__e, __defun__shen_4special_2, reg19207)
 			var reg19211 Obj
 			if reg19208 == True {
 				reg19209 := True
@@ -111,16 +111,16 @@ func init() {
 		}
 		if reg19213 == True {
 			reg19214 := PrimHead(V2704)
-			reg19215 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg19215 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Y := __args[0]
 				_ = Y
-				__ctx.TailApply(__defun__shen_4curry, Y)
+				__e.TailApply(__defun__shen_4curry, Y)
 				return
 			}, 1)
 			reg19217 := PrimTail(V2704)
-			reg19218 := __e.Call(__defun__map, reg19215, reg19217)
+			reg19218 := Call(__e, __defun__map, reg19215, reg19217)
 			reg19219 := PrimCons(reg19214, reg19218)
-			__ctx.Return(reg19219)
+			__e.Return(reg19219)
 			return
 		} else {
 			reg19220 := PrimIsPair(V2704)
@@ -131,7 +131,7 @@ func init() {
 				var reg19229 Obj
 				if reg19222 == True {
 					reg19223 := PrimHead(V2704)
-					reg19224 := __e.Call(__defun__shen_4extraspecial_2, reg19223)
+					reg19224 := Call(__e, __defun__shen_4extraspecial_2, reg19223)
 					var reg19227 Obj
 					if reg19224 == True {
 						reg19225 := True
@@ -159,7 +159,7 @@ func init() {
 				reg19234 = reg19233
 			}
 			if reg19234 == True {
-				__ctx.Return(V2704)
+				__e.Return(V2704)
 				return
 			} else {
 				reg19235 := PrimIsPair(V2704)
@@ -240,12 +240,12 @@ func init() {
 					reg19269 := MakeSymbol("type")
 					reg19270 := PrimTail(V2704)
 					reg19271 := PrimHead(reg19270)
-					reg19272 := __e.Call(__defun__shen_4curry, reg19271)
+					reg19272 := Call(__e, __defun__shen_4curry, reg19271)
 					reg19273 := PrimTail(V2704)
 					reg19274 := PrimTail(reg19273)
 					reg19275 := PrimCons(reg19272, reg19274)
 					reg19276 := PrimCons(reg19269, reg19275)
-					__ctx.Return(reg19276)
+					__e.Return(reg19276)
 					return
 				} else {
 					reg19277 := PrimIsPair(V2704)
@@ -294,7 +294,7 @@ func init() {
 						reg19299 := PrimTail(V2704)
 						reg19300 := PrimTail(reg19299)
 						reg19301 := PrimCons(reg19298, reg19300)
-						__ctx.TailApply(__defun__shen_4curry, reg19301)
+						__e.TailApply(__defun__shen_4curry, reg19301)
 						return
 					} else {
 						reg19303 := PrimIsPair(V2704)
@@ -336,17 +336,17 @@ func init() {
 						}
 						if reg19319 == True {
 							reg19320 := PrimHead(V2704)
-							reg19321 := __e.Call(__defun__shen_4curry, reg19320)
+							reg19321 := Call(__e, __defun__shen_4curry, reg19320)
 							reg19322 := PrimTail(V2704)
 							reg19323 := PrimHead(reg19322)
-							reg19324 := __e.Call(__defun__shen_4curry, reg19323)
+							reg19324 := Call(__e, __defun__shen_4curry, reg19323)
 							reg19325 := Nil
 							reg19326 := PrimCons(reg19324, reg19325)
 							reg19327 := PrimCons(reg19321, reg19326)
-							__ctx.Return(reg19327)
+							__e.Return(reg19327)
 							return
 						} else {
-							__ctx.Return(V2704)
+							__e.Return(V2704)
 							return
 						}
 					}
@@ -356,27 +356,27 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.curry", value: __defun__shen_4curry})
 
-	__defun__shen_4special_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4special_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2706 := __args[0]
 		_ = V2706
 		reg19328 := MakeSymbol("shen.*special*")
 		reg19329 := PrimValue(reg19328)
-		__ctx.TailApply(__defun__element_2, V2706, reg19329)
+		__e.TailApply(__defun__element_2, V2706, reg19329)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.special?", value: __defun__shen_4special_2})
 
-	__defun__shen_4extraspecial_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4extraspecial_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2708 := __args[0]
 		_ = V2708
 		reg19331 := MakeSymbol("shen.*extraspecial*")
 		reg19332 := PrimValue(reg19331)
-		__ctx.TailApply(__defun__element_2, V2708, reg19332)
+		__e.TailApply(__defun__element_2, V2708, reg19332)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.extraspecial?", value: __defun__shen_4extraspecial_2})
 
-	__defun__shen_4t_d = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4t_d = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2713 := __args[0]
 		_ = V2713
 		V2714 := __args[1]
@@ -385,41 +385,41 @@ func init() {
 		_ = V2715
 		V2716 := __args[3]
 		_ = V2716
-		reg19334 := __e.Call(__defun__shen_4catchpoint)
+		reg19334 := Call(__e, __defun__shen_4catchpoint)
 		Throwcontrol := reg19334
 		_ = Throwcontrol
-		reg19335 := __e.Call(__defun__shen_4newpv, V2715)
+		reg19335 := Call(__e, __defun__shen_4newpv, V2715)
 		Error := reg19335
 		_ = Error
-		reg19336 := __e.Call(__defun__shen_4incinfs)
+		reg19336 := Call(__e, __defun__shen_4incinfs)
 		_ = reg19336
-		reg19337 := __e.Call(__defun__shen_4maxinfexceeded_2)
-		reg19338 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			reg19339 := __e.Call(__defun__shen_4errormaxinfs)
-			__ctx.TailApply(__defun__bind, Error, reg19339, V2715, V2716)
+		reg19337 := Call(__e, __defun__shen_4maxinfexceeded_2)
+		reg19338 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			reg19339 := Call(__e, __defun__shen_4errormaxinfs)
+			__e.TailApply(__defun__bind, Error, reg19339, V2715, V2716)
 			return
 		}, 0)
-		reg19341 := __e.Call(__defun__fwhen, reg19337, V2715, reg19338)
+		reg19341 := Call(__e, __defun__fwhen, reg19337, V2715, reg19338)
 		Case := reg19341
 		_ = Case
 		reg19342 := False
 		reg19343 := PrimEqual(Case, reg19342)
 		var reg19403 Obj
 		if reg19343 == True {
-			reg19344 := __e.Call(__defun__shen_4lazyderef, V2713, V2715)
+			reg19344 := Call(__e, __defun__shen_4lazyderef, V2713, V2715)
 			V2693 := reg19344
 			_ = V2693
 			reg19345 := MakeSymbol("fail")
 			reg19346 := PrimEqual(reg19345, V2693)
 			var reg19352 Obj
 			if reg19346 == True {
-				reg19347 := __e.Call(__defun__shen_4incinfs)
+				reg19347 := Call(__e, __defun__shen_4incinfs)
 				_ = reg19347
-				reg19348 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-					__ctx.TailApply(__defun__shen_4prolog_1failure, V2715, V2716)
+				reg19348 := MakeNative(func(__e Evaluator, __args ...Obj) {
+					__e.TailApply(__defun__shen_4prolog_1failure, V2715, V2716)
 					return
 				}, 0)
-				reg19350 := __e.Call(__defun__cut, Throwcontrol, V2715, reg19348)
+				reg19350 := Call(__e, __defun__cut, Throwcontrol, V2715, reg19348)
 				reg19352 = reg19350
 			} else {
 				reg19351 := False
@@ -431,7 +431,7 @@ func init() {
 			reg19354 := PrimEqual(Case, reg19353)
 			var reg19402 Obj
 			if reg19354 == True {
-				reg19355 := __e.Call(__defun__shen_4lazyderef, V2713, V2715)
+				reg19355 := Call(__e, __defun__shen_4lazyderef, V2713, V2715)
 				V2694 := reg19355
 				_ = V2694
 				reg19356 := PrimIsPair(V2694)
@@ -441,14 +441,14 @@ func init() {
 					X := reg19357
 					_ = X
 					reg19358 := PrimTail(V2694)
-					reg19359 := __e.Call(__defun__shen_4lazyderef, reg19358, V2715)
+					reg19359 := Call(__e, __defun__shen_4lazyderef, reg19358, V2715)
 					V2695 := reg19359
 					_ = V2695
 					reg19360 := PrimIsPair(V2695)
 					var reg19387 Obj
 					if reg19360 == True {
 						reg19361 := PrimHead(V2695)
-						reg19362 := __e.Call(__defun__shen_4lazyderef, reg19361, V2715)
+						reg19362 := Call(__e, __defun__shen_4lazyderef, reg19361, V2715)
 						V2696 := reg19362
 						_ = V2696
 						reg19363 := MakeSymbol(":")
@@ -456,7 +456,7 @@ func init() {
 						var reg19385 Obj
 						if reg19364 == True {
 							reg19365 := PrimTail(V2695)
-							reg19366 := __e.Call(__defun__shen_4lazyderef, reg19365, V2715)
+							reg19366 := Call(__e, __defun__shen_4lazyderef, reg19365, V2715)
 							V2697 := reg19366
 							_ = V2697
 							reg19367 := PrimIsPair(V2697)
@@ -466,25 +466,25 @@ func init() {
 								A := reg19368
 								_ = A
 								reg19369 := PrimTail(V2697)
-								reg19370 := __e.Call(__defun__shen_4lazyderef, reg19369, V2715)
+								reg19370 := Call(__e, __defun__shen_4lazyderef, reg19369, V2715)
 								V2698 := reg19370
 								_ = V2698
 								reg19371 := Nil
 								reg19372 := PrimEqual(reg19371, V2698)
 								var reg19381 Obj
 								if reg19372 == True {
-									reg19373 := __e.Call(__defun__shen_4incinfs)
+									reg19373 := Call(__e, __defun__shen_4incinfs)
 									_ = reg19373
-									reg19374 := __e.Call(__defun__shen_4type_1theory_1enabled_2)
-									reg19375 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-										reg19376 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-											__ctx.TailApply(__defun__shen_4th_d, X, A, V2714, V2715, V2716)
+									reg19374 := Call(__e, __defun__shen_4type_1theory_1enabled_2)
+									reg19375 := MakeNative(func(__e Evaluator, __args ...Obj) {
+										reg19376 := MakeNative(func(__e Evaluator, __args ...Obj) {
+											__e.TailApply(__defun__shen_4th_d, X, A, V2714, V2715, V2716)
 											return
 										}, 0)
-										__ctx.TailApply(__defun__cut, Throwcontrol, V2715, reg19376)
+										__e.TailApply(__defun__cut, Throwcontrol, V2715, reg19376)
 										return
 									}, 0)
-									reg19379 := __e.Call(__defun__fwhen, reg19374, V2715, reg19375)
+									reg19379 := Call(__e, __defun__fwhen, reg19374, V2715, reg19375)
 									reg19381 = reg19379
 								} else {
 									reg19380 := False
@@ -516,22 +516,22 @@ func init() {
 				reg19391 := PrimEqual(Case, reg19390)
 				var reg19401 Obj
 				if reg19391 == True {
-					reg19392 := __e.Call(__defun__shen_4newpv, V2715)
+					reg19392 := Call(__e, __defun__shen_4newpv, V2715)
 					Datatypes := reg19392
 					_ = Datatypes
-					reg19393 := __e.Call(__defun__shen_4incinfs)
+					reg19393 := Call(__e, __defun__shen_4incinfs)
 					_ = reg19393
-					reg19394 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg19394 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						reg19395 := MakeSymbol("shen.*datatypes*")
 						reg19396 := PrimValue(reg19395)
-						reg19397 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-							__ctx.TailApply(__defun__shen_4udefs_d, V2713, V2714, Datatypes, V2715, V2716)
+						reg19397 := MakeNative(func(__e Evaluator, __args ...Obj) {
+							__e.TailApply(__defun__shen_4udefs_d, V2713, V2714, Datatypes, V2715, V2716)
 							return
 						}, 0)
-						__ctx.TailApply(__defun__bind, Datatypes, reg19396, V2715, reg19397)
+						__e.TailApply(__defun__bind, Datatypes, reg19396, V2715, reg19397)
 						return
 					}, 0)
-					reg19400 := __e.Call(__defun__shen_4show, V2713, V2714, V2715, reg19394)
+					reg19400 := Call(__e, __defun__shen_4show, V2713, V2714, V2715, reg19394)
 					reg19401 = reg19400
 				} else {
 					reg19401 = Case
@@ -544,20 +544,20 @@ func init() {
 		} else {
 			reg19403 = Case
 		}
-		__ctx.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg19403)
+		__e.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg19403)
 		return
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.t*", value: __defun__shen_4t_d})
 
-	__defun__shen_4type_1theory_1enabled_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1theory_1enabled_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg19405 := MakeSymbol("shen.*shen-type-theory-enabled?*")
 		reg19406 := PrimValue(reg19405)
-		__ctx.Return(reg19406)
+		__e.Return(reg19406)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.type-theory-enabled?", value: __defun__shen_4type_1theory_1enabled_2})
 
-	__defun__enable_1type_1theory = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__enable_1type_1theory = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2722 := __args[0]
 		_ = V2722
 		reg19407 := MakeSymbol("+")
@@ -566,7 +566,7 @@ func init() {
 			reg19409 := MakeSymbol("shen.*shen-type-theory-enabled?*")
 			reg19410 := True
 			reg19411 := PrimSet(reg19409, reg19410)
-			__ctx.Return(reg19411)
+			__e.Return(reg19411)
 			return
 		} else {
 			reg19412 := MakeSymbol("-")
@@ -575,48 +575,48 @@ func init() {
 				reg19414 := MakeSymbol("shen.*shen-type-theory-enabled?*")
 				reg19415 := False
 				reg19416 := PrimSet(reg19414, reg19415)
-				__ctx.Return(reg19416)
+				__e.Return(reg19416)
 				return
 			} else {
 				reg19417 := MakeString("enable-type-theory expects a + or a -\n")
 				reg19418 := PrimSimpleError(reg19417)
-				__ctx.Return(reg19418)
+				__e.Return(reg19418)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "enable-type-theory", value: __defun__enable_1type_1theory})
 
-	__defun__shen_4prolog_1failure = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prolog_1failure = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2733 := __args[0]
 		_ = V2733
 		V2734 := __args[1]
 		_ = V2734
 		reg19419 := False
-		__ctx.Return(reg19419)
+		__e.Return(reg19419)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.prolog-failure", value: __defun__shen_4prolog_1failure})
 
-	__defun__shen_4maxinfexceeded_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-		reg19420 := __e.Call(__defun__inferences)
+	__defun__shen_4maxinfexceeded_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
+		reg19420 := Call(__e, __defun__inferences)
 		reg19421 := MakeSymbol("shen.*maxinferences*")
 		reg19422 := PrimValue(reg19421)
 		reg19423 := PrimGreatThan(reg19420, reg19422)
-		__ctx.Return(reg19423)
+		__e.Return(reg19423)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.maxinfexceeded?", value: __defun__shen_4maxinfexceeded_2})
 
-	__defun__shen_4errormaxinfs = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4errormaxinfs = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg19424 := MakeString("maximum inferences exceeded~%")
 		reg19425 := PrimSimpleError(reg19424)
-		__ctx.Return(reg19425)
+		__e.Return(reg19425)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.errormaxinfs", value: __defun__shen_4errormaxinfs})
 
-	__defun__shen_4udefs_d = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4udefs_d = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2740 := __args[0]
 		_ = V2740
 		V2741 := __args[1]
@@ -627,7 +627,7 @@ func init() {
 		_ = V2743
 		V2744 := __args[4]
 		_ = V2744
-		reg19426 := __e.Call(__defun__shen_4lazyderef, V2742, V2743)
+		reg19426 := Call(__e, __defun__shen_4lazyderef, V2742, V2743)
 		V2689 := reg19426
 		_ = V2689
 		reg19427 := PrimIsPair(V2689)
@@ -636,13 +636,13 @@ func init() {
 			reg19428 := PrimHead(V2689)
 			D := reg19428
 			_ = D
-			reg19429 := __e.Call(__defun__shen_4incinfs)
+			reg19429 := Call(__e, __defun__shen_4incinfs)
 			_ = reg19429
 			reg19430 := Nil
 			reg19431 := PrimCons(V2741, reg19430)
 			reg19432 := PrimCons(V2740, reg19431)
 			reg19433 := PrimCons(D, reg19432)
-			reg19434 := __e.Call(__defun__call, reg19433, V2743, V2744)
+			reg19434 := Call(__e, __defun__call, reg19433, V2743, V2744)
 			reg19436 = reg19434
 		} else {
 			reg19435 := False
@@ -653,7 +653,7 @@ func init() {
 		reg19437 := False
 		reg19438 := PrimEqual(Case, reg19437)
 		if reg19438 == True {
-			reg19439 := __e.Call(__defun__shen_4lazyderef, V2742, V2743)
+			reg19439 := Call(__e, __defun__shen_4lazyderef, V2742, V2743)
 			V2690 := reg19439
 			_ = V2690
 			reg19440 := PrimIsPair(V2690)
@@ -661,23 +661,23 @@ func init() {
 				reg19441 := PrimTail(V2690)
 				Ds := reg19441
 				_ = Ds
-				reg19442 := __e.Call(__defun__shen_4incinfs)
+				reg19442 := Call(__e, __defun__shen_4incinfs)
 				_ = reg19442
-				__ctx.TailApply(__defun__shen_4udefs_d, V2740, V2741, Ds, V2743, V2744)
+				__e.TailApply(__defun__shen_4udefs_d, V2740, V2741, Ds, V2743, V2744)
 				return
 			} else {
 				reg19444 := False
-				__ctx.Return(reg19444)
+				__e.Return(reg19444)
 				return
 			}
 		} else {
-			__ctx.Return(Case)
+			__e.Return(Case)
 			return
 		}
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.udefs*", value: __defun__shen_4udefs_d})
 
-	__defun__shen_4th_d = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4th_d = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2750 := __args[0]
 		_ = V2750
 		V2751 := __args[1]
@@ -688,74 +688,74 @@ func init() {
 		_ = V2753
 		V2754 := __args[4]
 		_ = V2754
-		reg19445 := __e.Call(__defun__shen_4catchpoint)
+		reg19445 := Call(__e, __defun__shen_4catchpoint)
 		Throwcontrol := reg19445
 		_ = Throwcontrol
-		reg19446 := __e.Call(__defun__shen_4incinfs)
+		reg19446 := Call(__e, __defun__shen_4incinfs)
 		_ = reg19446
 		reg19447 := MakeSymbol(":")
 		reg19448 := Nil
 		reg19449 := PrimCons(V2751, reg19448)
 		reg19450 := PrimCons(reg19447, reg19449)
 		reg19451 := PrimCons(V2750, reg19450)
-		reg19452 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg19452 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg19453 := False
-			__ctx.TailApply(__defun__fwhen, reg19453, V2753, V2754)
+			__e.TailApply(__defun__fwhen, reg19453, V2753, V2754)
 			return
 		}, 0)
-		reg19455 := __e.Call(__defun__shen_4show, reg19451, V2752, V2753, reg19452)
+		reg19455 := Call(__e, __defun__shen_4show, reg19451, V2752, V2753, reg19452)
 		Case := reg19455
 		_ = Case
 		reg19456 := False
 		reg19457 := PrimEqual(Case, reg19456)
 		var reg20876 Obj
 		if reg19457 == True {
-			reg19458 := __e.Call(__defun__shen_4newpv, V2753)
+			reg19458 := Call(__e, __defun__shen_4newpv, V2753)
 			F := reg19458
 			_ = F
-			reg19459 := __e.Call(__defun__shen_4incinfs)
+			reg19459 := Call(__e, __defun__shen_4incinfs)
 			_ = reg19459
-			reg19460 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
-			reg19461 := __e.Call(__defun__shen_4typedf_2, reg19460)
-			reg19462 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-				reg19463 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
-				reg19464 := __e.Call(__defun__shen_4sigf, reg19463)
-				reg19465 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg19460 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
+			reg19461 := Call(__e, __defun__shen_4typedf_2, reg19460)
+			reg19462 := MakeNative(func(__e Evaluator, __args ...Obj) {
+				reg19463 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
+				reg19464 := Call(__e, __defun__shen_4sigf, reg19463)
+				reg19465 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					reg19466 := Nil
 					reg19467 := PrimCons(V2751, reg19466)
 					reg19468 := PrimCons(F, reg19467)
-					__ctx.TailApply(__defun__call, reg19468, V2753, V2754)
+					__e.TailApply(__defun__call, reg19468, V2753, V2754)
 					return
 				}, 0)
-				__ctx.TailApply(__defun__bind, F, reg19464, V2753, reg19465)
+				__e.TailApply(__defun__bind, F, reg19464, V2753, reg19465)
 				return
 			}, 0)
-			reg19471 := __e.Call(__defun__fwhen, reg19461, V2753, reg19462)
+			reg19471 := Call(__e, __defun__fwhen, reg19461, V2753, reg19462)
 			Case := reg19471
 			_ = Case
 			reg19472 := False
 			reg19473 := PrimEqual(Case, reg19472)
 			var reg20875 Obj
 			if reg19473 == True {
-				reg19474 := __e.Call(__defun__shen_4incinfs)
+				reg19474 := Call(__e, __defun__shen_4incinfs)
 				_ = reg19474
-				reg19475 := __e.Call(__defun__shen_4base, V2750, V2751, V2753, V2754)
+				reg19475 := Call(__e, __defun__shen_4base, V2750, V2751, V2753, V2754)
 				Case := reg19475
 				_ = Case
 				reg19476 := False
 				reg19477 := PrimEqual(Case, reg19476)
 				var reg20874 Obj
 				if reg19477 == True {
-					reg19478 := __e.Call(__defun__shen_4incinfs)
+					reg19478 := Call(__e, __defun__shen_4incinfs)
 					_ = reg19478
-					reg19479 := __e.Call(__defun__shen_4by__hypothesis, V2750, V2751, V2752, V2753, V2754)
+					reg19479 := Call(__e, __defun__shen_4by__hypothesis, V2750, V2751, V2752, V2753, V2754)
 					Case := reg19479
 					_ = Case
 					reg19480 := False
 					reg19481 := PrimEqual(Case, reg19480)
 					var reg20873 Obj
 					if reg19481 == True {
-						reg19482 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+						reg19482 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 						V2585 := reg19482
 						_ = V2585
 						reg19483 := PrimIsPair(V2585)
@@ -765,20 +765,20 @@ func init() {
 							F := reg19484
 							_ = F
 							reg19485 := PrimTail(V2585)
-							reg19486 := __e.Call(__defun__shen_4lazyderef, reg19485, V2753)
+							reg19486 := Call(__e, __defun__shen_4lazyderef, reg19485, V2753)
 							V2586 := reg19486
 							_ = V2586
 							reg19487 := Nil
 							reg19488 := PrimEqual(reg19487, V2586)
 							var reg19496 Obj
 							if reg19488 == True {
-								reg19489 := __e.Call(__defun__shen_4incinfs)
+								reg19489 := Call(__e, __defun__shen_4incinfs)
 								_ = reg19489
 								reg19490 := MakeSymbol("-->")
 								reg19491 := Nil
 								reg19492 := PrimCons(V2751, reg19491)
 								reg19493 := PrimCons(reg19490, reg19492)
-								reg19494 := __e.Call(__defun__shen_4th_d, F, reg19493, V2752, V2753, V2754)
+								reg19494 := Call(__e, __defun__shen_4th_d, F, reg19493, V2752, V2753, V2754)
 								reg19496 = reg19494
 							} else {
 								reg19495 := False
@@ -795,7 +795,7 @@ func init() {
 						reg19500 := PrimEqual(Case, reg19499)
 						var reg20872 Obj
 						if reg19500 == True {
-							reg19501 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+							reg19501 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 							V2587 := reg19501
 							_ = V2587
 							reg19502 := PrimIsPair(V2587)
@@ -805,7 +805,7 @@ func init() {
 								F := reg19503
 								_ = F
 								reg19504 := PrimTail(V2587)
-								reg19505 := __e.Call(__defun__shen_4lazyderef, reg19504, V2753)
+								reg19505 := Call(__e, __defun__shen_4lazyderef, reg19504, V2753)
 								V2588 := reg19505
 								_ = V2588
 								reg19506 := PrimIsPair(V2588)
@@ -815,28 +815,28 @@ func init() {
 									X := reg19507
 									_ = X
 									reg19508 := PrimTail(V2588)
-									reg19509 := __e.Call(__defun__shen_4lazyderef, reg19508, V2753)
+									reg19509 := Call(__e, __defun__shen_4lazyderef, reg19508, V2753)
 									V2589 := reg19509
 									_ = V2589
 									reg19510 := Nil
 									reg19511 := PrimEqual(reg19510, V2589)
 									var reg19523 Obj
 									if reg19511 == True {
-										reg19512 := __e.Call(__defun__shen_4newpv, V2753)
+										reg19512 := Call(__e, __defun__shen_4newpv, V2753)
 										B := reg19512
 										_ = B
-										reg19513 := __e.Call(__defun__shen_4incinfs)
+										reg19513 := Call(__e, __defun__shen_4incinfs)
 										_ = reg19513
 										reg19514 := MakeSymbol("-->")
 										reg19515 := Nil
 										reg19516 := PrimCons(V2751, reg19515)
 										reg19517 := PrimCons(reg19514, reg19516)
 										reg19518 := PrimCons(B, reg19517)
-										reg19519 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-											__ctx.TailApply(__defun__shen_4th_d, X, B, V2752, V2753, V2754)
+										reg19519 := MakeNative(func(__e Evaluator, __args ...Obj) {
+											__e.TailApply(__defun__shen_4th_d, X, B, V2752, V2753, V2754)
 											return
 										}, 0)
-										reg19521 := __e.Call(__defun__shen_4th_d, F, reg19518, V2752, V2753, reg19519)
+										reg19521 := Call(__e, __defun__shen_4th_d, F, reg19518, V2752, V2753, reg19519)
 										reg19523 = reg19521
 									} else {
 										reg19522 := False
@@ -858,14 +858,14 @@ func init() {
 							reg19529 := PrimEqual(Case, reg19528)
 							var reg20871 Obj
 							if reg19529 == True {
-								reg19530 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+								reg19530 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 								V2590 := reg19530
 								_ = V2590
 								reg19531 := PrimIsPair(V2590)
 								var reg19685 Obj
 								if reg19531 == True {
 									reg19532 := PrimHead(V2590)
-									reg19533 := __e.Call(__defun__shen_4lazyderef, reg19532, V2753)
+									reg19533 := Call(__e, __defun__shen_4lazyderef, reg19532, V2753)
 									V2591 := reg19533
 									_ = V2591
 									reg19534 := MakeSymbol("cons")
@@ -873,7 +873,7 @@ func init() {
 									var reg19683 Obj
 									if reg19535 == True {
 										reg19536 := PrimTail(V2590)
-										reg19537 := __e.Call(__defun__shen_4lazyderef, reg19536, V2753)
+										reg19537 := Call(__e, __defun__shen_4lazyderef, reg19536, V2753)
 										V2592 := reg19537
 										_ = V2592
 										reg19538 := PrimIsPair(V2592)
@@ -883,7 +883,7 @@ func init() {
 											X := reg19539
 											_ = X
 											reg19540 := PrimTail(V2592)
-											reg19541 := __e.Call(__defun__shen_4lazyderef, reg19540, V2753)
+											reg19541 := Call(__e, __defun__shen_4lazyderef, reg19540, V2753)
 											V2593 := reg19541
 											_ = V2593
 											reg19542 := PrimIsPair(V2593)
@@ -893,21 +893,21 @@ func init() {
 												Y := reg19543
 												_ = Y
 												reg19544 := PrimTail(V2593)
-												reg19545 := __e.Call(__defun__shen_4lazyderef, reg19544, V2753)
+												reg19545 := Call(__e, __defun__shen_4lazyderef, reg19544, V2753)
 												V2594 := reg19545
 												_ = V2594
 												reg19546 := Nil
 												reg19547 := PrimEqual(reg19546, V2594)
 												var reg19677 Obj
 												if reg19547 == True {
-													reg19548 := __e.Call(__defun__shen_4lazyderef, V2751, V2753)
+													reg19548 := Call(__e, __defun__shen_4lazyderef, V2751, V2753)
 													V2595 := reg19548
 													_ = V2595
 													reg19549 := PrimIsPair(V2595)
 													var reg19675 Obj
 													if reg19549 == True {
 														reg19550 := PrimHead(V2595)
-														reg19551 := __e.Call(__defun__shen_4lazyderef, reg19550, V2753)
+														reg19551 := Call(__e, __defun__shen_4lazyderef, reg19550, V2753)
 														V2596 := reg19551
 														_ = V2596
 														reg19552 := MakeSymbol("list")
@@ -915,7 +915,7 @@ func init() {
 														var reg19656 Obj
 														if reg19553 == True {
 															reg19554 := PrimTail(V2595)
-															reg19555 := __e.Call(__defun__shen_4lazyderef, reg19554, V2753)
+															reg19555 := Call(__e, __defun__shen_4lazyderef, reg19554, V2753)
 															V2597 := reg19555
 															_ = V2597
 															reg19556 := PrimIsPair(V2597)
@@ -925,46 +925,46 @@ func init() {
 																A := reg19557
 																_ = A
 																reg19558 := PrimTail(V2597)
-																reg19559 := __e.Call(__defun__shen_4lazyderef, reg19558, V2753)
+																reg19559 := Call(__e, __defun__shen_4lazyderef, reg19558, V2753)
 																V2598 := reg19559
 																_ = V2598
 																reg19560 := Nil
 																reg19561 := PrimEqual(reg19560, V2598)
 																var reg19584 Obj
 																if reg19561 == True {
-																	reg19562 := __e.Call(__defun__shen_4incinfs)
+																	reg19562 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg19562
-																	reg19563 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																	reg19563 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																		reg19564 := MakeSymbol("list")
 																		reg19565 := Nil
 																		reg19566 := PrimCons(A, reg19565)
 																		reg19567 := PrimCons(reg19564, reg19566)
-																		__ctx.TailApply(__defun__shen_4th_d, Y, reg19567, V2752, V2753, V2754)
+																		__e.TailApply(__defun__shen_4th_d, Y, reg19567, V2752, V2753, V2754)
 																		return
 																	}, 0)
-																	reg19569 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19563)
+																	reg19569 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19563)
 																	reg19584 = reg19569
 																} else {
-																	reg19570 := __e.Call(__defun__shen_4pvar_2, V2598)
+																	reg19570 := Call(__e, __defun__shen_4pvar_2, V2598)
 																	var reg19583 Obj
 																	if reg19570 == True {
 																		reg19571 := Nil
-																		reg19572 := __e.Call(__defun__shen_4bindv, V2598, reg19571, V2753)
+																		reg19572 := Call(__e, __defun__shen_4bindv, V2598, reg19571, V2753)
 																		_ = reg19572
-																		reg19573 := __e.Call(__defun__shen_4incinfs)
+																		reg19573 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg19573
-																		reg19574 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																		reg19574 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																			reg19575 := MakeSymbol("list")
 																			reg19576 := Nil
 																			reg19577 := PrimCons(A, reg19576)
 																			reg19578 := PrimCons(reg19575, reg19577)
-																			__ctx.TailApply(__defun__shen_4th_d, Y, reg19578, V2752, V2753, V2754)
+																			__e.TailApply(__defun__shen_4th_d, Y, reg19578, V2752, V2753, V2754)
 																			return
 																		}, 0)
-																		reg19580 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19574)
+																		reg19580 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19574)
 																		Result := reg19580
 																		_ = Result
-																		reg19581 := __e.Call(__defun__shen_4unbindv, V2598, V2753)
+																		reg19581 := Call(__e, __defun__shen_4unbindv, V2598, V2753)
 																		_ = reg19581
 																		reg19583 = Result
 																	} else {
@@ -975,30 +975,30 @@ func init() {
 																}
 																reg19601 = reg19584
 															} else {
-																reg19585 := __e.Call(__defun__shen_4pvar_2, V2597)
+																reg19585 := Call(__e, __defun__shen_4pvar_2, V2597)
 																var reg19600 Obj
 																if reg19585 == True {
-																	reg19586 := __e.Call(__defun__shen_4newpv, V2753)
+																	reg19586 := Call(__e, __defun__shen_4newpv, V2753)
 																	A := reg19586
 																	_ = A
 																	reg19587 := Nil
 																	reg19588 := PrimCons(A, reg19587)
-																	reg19589 := __e.Call(__defun__shen_4bindv, V2597, reg19588, V2753)
+																	reg19589 := Call(__e, __defun__shen_4bindv, V2597, reg19588, V2753)
 																	_ = reg19589
-																	reg19590 := __e.Call(__defun__shen_4incinfs)
+																	reg19590 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg19590
-																	reg19591 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																	reg19591 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																		reg19592 := MakeSymbol("list")
 																		reg19593 := Nil
 																		reg19594 := PrimCons(A, reg19593)
 																		reg19595 := PrimCons(reg19592, reg19594)
-																		__ctx.TailApply(__defun__shen_4th_d, Y, reg19595, V2752, V2753, V2754)
+																		__e.TailApply(__defun__shen_4th_d, Y, reg19595, V2752, V2753, V2754)
 																		return
 																	}, 0)
-																	reg19597 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19591)
+																	reg19597 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19591)
 																	Result := reg19597
 																	_ = Result
-																	reg19598 := __e.Call(__defun__shen_4unbindv, V2597, V2753)
+																	reg19598 := Call(__e, __defun__shen_4unbindv, V2597, V2753)
 																	_ = reg19598
 																	reg19600 = Result
 																} else {
@@ -1009,14 +1009,14 @@ func init() {
 															}
 															reg19656 = reg19601
 														} else {
-															reg19602 := __e.Call(__defun__shen_4pvar_2, V2596)
+															reg19602 := Call(__e, __defun__shen_4pvar_2, V2596)
 															var reg19655 Obj
 															if reg19602 == True {
 																reg19603 := MakeSymbol("list")
-																reg19604 := __e.Call(__defun__shen_4bindv, V2596, reg19603, V2753)
+																reg19604 := Call(__e, __defun__shen_4bindv, V2596, reg19603, V2753)
 																_ = reg19604
 																reg19605 := PrimTail(V2595)
-																reg19606 := __e.Call(__defun__shen_4lazyderef, reg19605, V2753)
+																reg19606 := Call(__e, __defun__shen_4lazyderef, reg19605, V2753)
 																V2599 := reg19606
 																_ = V2599
 																reg19607 := PrimIsPair(V2599)
@@ -1026,46 +1026,46 @@ func init() {
 																	A := reg19608
 																	_ = A
 																	reg19609 := PrimTail(V2599)
-																	reg19610 := __e.Call(__defun__shen_4lazyderef, reg19609, V2753)
+																	reg19610 := Call(__e, __defun__shen_4lazyderef, reg19609, V2753)
 																	V2600 := reg19610
 																	_ = V2600
 																	reg19611 := Nil
 																	reg19612 := PrimEqual(reg19611, V2600)
 																	var reg19635 Obj
 																	if reg19612 == True {
-																		reg19613 := __e.Call(__defun__shen_4incinfs)
+																		reg19613 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg19613
-																		reg19614 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																		reg19614 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																			reg19615 := MakeSymbol("list")
 																			reg19616 := Nil
 																			reg19617 := PrimCons(A, reg19616)
 																			reg19618 := PrimCons(reg19615, reg19617)
-																			__ctx.TailApply(__defun__shen_4th_d, Y, reg19618, V2752, V2753, V2754)
+																			__e.TailApply(__defun__shen_4th_d, Y, reg19618, V2752, V2753, V2754)
 																			return
 																		}, 0)
-																		reg19620 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19614)
+																		reg19620 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19614)
 																		reg19635 = reg19620
 																	} else {
-																		reg19621 := __e.Call(__defun__shen_4pvar_2, V2600)
+																		reg19621 := Call(__e, __defun__shen_4pvar_2, V2600)
 																		var reg19634 Obj
 																		if reg19621 == True {
 																			reg19622 := Nil
-																			reg19623 := __e.Call(__defun__shen_4bindv, V2600, reg19622, V2753)
+																			reg19623 := Call(__e, __defun__shen_4bindv, V2600, reg19622, V2753)
 																			_ = reg19623
-																			reg19624 := __e.Call(__defun__shen_4incinfs)
+																			reg19624 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg19624
-																			reg19625 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																			reg19625 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																				reg19626 := MakeSymbol("list")
 																				reg19627 := Nil
 																				reg19628 := PrimCons(A, reg19627)
 																				reg19629 := PrimCons(reg19626, reg19628)
-																				__ctx.TailApply(__defun__shen_4th_d, Y, reg19629, V2752, V2753, V2754)
+																				__e.TailApply(__defun__shen_4th_d, Y, reg19629, V2752, V2753, V2754)
 																				return
 																			}, 0)
-																			reg19631 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19625)
+																			reg19631 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19625)
 																			Result := reg19631
 																			_ = Result
-																			reg19632 := __e.Call(__defun__shen_4unbindv, V2600, V2753)
+																			reg19632 := Call(__e, __defun__shen_4unbindv, V2600, V2753)
 																			_ = reg19632
 																			reg19634 = Result
 																		} else {
@@ -1076,30 +1076,30 @@ func init() {
 																	}
 																	reg19652 = reg19635
 																} else {
-																	reg19636 := __e.Call(__defun__shen_4pvar_2, V2599)
+																	reg19636 := Call(__e, __defun__shen_4pvar_2, V2599)
 																	var reg19651 Obj
 																	if reg19636 == True {
-																		reg19637 := __e.Call(__defun__shen_4newpv, V2753)
+																		reg19637 := Call(__e, __defun__shen_4newpv, V2753)
 																		A := reg19637
 																		_ = A
 																		reg19638 := Nil
 																		reg19639 := PrimCons(A, reg19638)
-																		reg19640 := __e.Call(__defun__shen_4bindv, V2599, reg19639, V2753)
+																		reg19640 := Call(__e, __defun__shen_4bindv, V2599, reg19639, V2753)
 																		_ = reg19640
-																		reg19641 := __e.Call(__defun__shen_4incinfs)
+																		reg19641 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg19641
-																		reg19642 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																		reg19642 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																			reg19643 := MakeSymbol("list")
 																			reg19644 := Nil
 																			reg19645 := PrimCons(A, reg19644)
 																			reg19646 := PrimCons(reg19643, reg19645)
-																			__ctx.TailApply(__defun__shen_4th_d, Y, reg19646, V2752, V2753, V2754)
+																			__e.TailApply(__defun__shen_4th_d, Y, reg19646, V2752, V2753, V2754)
 																			return
 																		}, 0)
-																		reg19648 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19642)
+																		reg19648 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19642)
 																		Result := reg19648
 																		_ = Result
-																		reg19649 := __e.Call(__defun__shen_4unbindv, V2599, V2753)
+																		reg19649 := Call(__e, __defun__shen_4unbindv, V2599, V2753)
 																		_ = reg19649
 																		reg19651 = Result
 																	} else {
@@ -1110,7 +1110,7 @@ func init() {
 																}
 																Result := reg19652
 																_ = Result
-																reg19653 := __e.Call(__defun__shen_4unbindv, V2596, V2753)
+																reg19653 := Call(__e, __defun__shen_4unbindv, V2596, V2753)
 																_ = reg19653
 																reg19655 = Result
 															} else {
@@ -1121,32 +1121,32 @@ func init() {
 														}
 														reg19675 = reg19656
 													} else {
-														reg19657 := __e.Call(__defun__shen_4pvar_2, V2595)
+														reg19657 := Call(__e, __defun__shen_4pvar_2, V2595)
 														var reg19674 Obj
 														if reg19657 == True {
-															reg19658 := __e.Call(__defun__shen_4newpv, V2753)
+															reg19658 := Call(__e, __defun__shen_4newpv, V2753)
 															A := reg19658
 															_ = A
 															reg19659 := MakeSymbol("list")
 															reg19660 := Nil
 															reg19661 := PrimCons(A, reg19660)
 															reg19662 := PrimCons(reg19659, reg19661)
-															reg19663 := __e.Call(__defun__shen_4bindv, V2595, reg19662, V2753)
+															reg19663 := Call(__e, __defun__shen_4bindv, V2595, reg19662, V2753)
 															_ = reg19663
-															reg19664 := __e.Call(__defun__shen_4incinfs)
+															reg19664 := Call(__e, __defun__shen_4incinfs)
 															_ = reg19664
-															reg19665 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+															reg19665 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																reg19666 := MakeSymbol("list")
 																reg19667 := Nil
 																reg19668 := PrimCons(A, reg19667)
 																reg19669 := PrimCons(reg19666, reg19668)
-																__ctx.TailApply(__defun__shen_4th_d, Y, reg19669, V2752, V2753, V2754)
+																__e.TailApply(__defun__shen_4th_d, Y, reg19669, V2752, V2753, V2754)
 																return
 															}, 0)
-															reg19671 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19665)
+															reg19671 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19665)
 															Result := reg19671
 															_ = Result
-															reg19672 := __e.Call(__defun__shen_4unbindv, V2595, V2753)
+															reg19672 := Call(__e, __defun__shen_4unbindv, V2595, V2753)
 															_ = reg19672
 															reg19674 = Result
 														} else {
@@ -1186,14 +1186,14 @@ func init() {
 								reg19687 := PrimEqual(Case, reg19686)
 								var reg20870 Obj
 								if reg19687 == True {
-									reg19688 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+									reg19688 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 									V2601 := reg19688
 									_ = V2601
 									reg19689 := PrimIsPair(V2601)
 									var reg19836 Obj
 									if reg19689 == True {
 										reg19690 := PrimHead(V2601)
-										reg19691 := __e.Call(__defun__shen_4lazyderef, reg19690, V2753)
+										reg19691 := Call(__e, __defun__shen_4lazyderef, reg19690, V2753)
 										V2602 := reg19691
 										_ = V2602
 										reg19692 := MakeSymbol("@p")
@@ -1201,7 +1201,7 @@ func init() {
 										var reg19834 Obj
 										if reg19693 == True {
 											reg19694 := PrimTail(V2601)
-											reg19695 := __e.Call(__defun__shen_4lazyderef, reg19694, V2753)
+											reg19695 := Call(__e, __defun__shen_4lazyderef, reg19694, V2753)
 											V2603 := reg19695
 											_ = V2603
 											reg19696 := PrimIsPair(V2603)
@@ -1211,7 +1211,7 @@ func init() {
 												X := reg19697
 												_ = X
 												reg19698 := PrimTail(V2603)
-												reg19699 := __e.Call(__defun__shen_4lazyderef, reg19698, V2753)
+												reg19699 := Call(__e, __defun__shen_4lazyderef, reg19698, V2753)
 												V2604 := reg19699
 												_ = V2604
 												reg19700 := PrimIsPair(V2604)
@@ -1221,14 +1221,14 @@ func init() {
 													Y := reg19701
 													_ = Y
 													reg19702 := PrimTail(V2604)
-													reg19703 := __e.Call(__defun__shen_4lazyderef, reg19702, V2753)
+													reg19703 := Call(__e, __defun__shen_4lazyderef, reg19702, V2753)
 													V2605 := reg19703
 													_ = V2605
 													reg19704 := Nil
 													reg19705 := PrimEqual(reg19704, V2605)
 													var reg19828 Obj
 													if reg19705 == True {
-														reg19706 := __e.Call(__defun__shen_4lazyderef, V2751, V2753)
+														reg19706 := Call(__e, __defun__shen_4lazyderef, V2751, V2753)
 														V2606 := reg19706
 														_ = V2606
 														reg19707 := PrimIsPair(V2606)
@@ -1238,14 +1238,14 @@ func init() {
 															A := reg19708
 															_ = A
 															reg19709 := PrimTail(V2606)
-															reg19710 := __e.Call(__defun__shen_4lazyderef, reg19709, V2753)
+															reg19710 := Call(__e, __defun__shen_4lazyderef, reg19709, V2753)
 															V2607 := reg19710
 															_ = V2607
 															reg19711 := PrimIsPair(V2607)
 															var reg19809 Obj
 															if reg19711 == True {
 																reg19712 := PrimHead(V2607)
-																reg19713 := __e.Call(__defun__shen_4lazyderef, reg19712, V2753)
+																reg19713 := Call(__e, __defun__shen_4lazyderef, reg19712, V2753)
 																V2608 := reg19713
 																_ = V2608
 																reg19714 := MakeSymbol("*")
@@ -1253,7 +1253,7 @@ func init() {
 																var reg19794 Obj
 																if reg19715 == True {
 																	reg19716 := PrimTail(V2607)
-																	reg19717 := __e.Call(__defun__shen_4lazyderef, reg19716, V2753)
+																	reg19717 := Call(__e, __defun__shen_4lazyderef, reg19716, V2753)
 																	V2609 := reg19717
 																	_ = V2609
 																	reg19718 := PrimIsPair(V2609)
@@ -1263,38 +1263,38 @@ func init() {
 																		B := reg19719
 																		_ = B
 																		reg19720 := PrimTail(V2609)
-																		reg19721 := __e.Call(__defun__shen_4lazyderef, reg19720, V2753)
+																		reg19721 := Call(__e, __defun__shen_4lazyderef, reg19720, V2753)
 																		V2610 := reg19721
 																		_ = V2610
 																		reg19722 := Nil
 																		reg19723 := PrimEqual(reg19722, V2610)
 																		var reg19738 Obj
 																		if reg19723 == True {
-																			reg19724 := __e.Call(__defun__shen_4incinfs)
+																			reg19724 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg19724
-																			reg19725 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																				__ctx.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
+																			reg19725 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																				__e.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
 																				return
 																			}, 0)
-																			reg19727 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19725)
+																			reg19727 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19725)
 																			reg19738 = reg19727
 																		} else {
-																			reg19728 := __e.Call(__defun__shen_4pvar_2, V2610)
+																			reg19728 := Call(__e, __defun__shen_4pvar_2, V2610)
 																			var reg19737 Obj
 																			if reg19728 == True {
 																				reg19729 := Nil
-																				reg19730 := __e.Call(__defun__shen_4bindv, V2610, reg19729, V2753)
+																				reg19730 := Call(__e, __defun__shen_4bindv, V2610, reg19729, V2753)
 																				_ = reg19730
-																				reg19731 := __e.Call(__defun__shen_4incinfs)
+																				reg19731 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg19731
-																				reg19732 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																					__ctx.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
+																				reg19732 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																					__e.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
 																					return
 																				}, 0)
-																				reg19734 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19732)
+																				reg19734 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19732)
 																				Result := reg19734
 																				_ = Result
-																				reg19735 := __e.Call(__defun__shen_4unbindv, V2610, V2753)
+																				reg19735 := Call(__e, __defun__shen_4unbindv, V2610, V2753)
 																				_ = reg19735
 																				reg19737 = Result
 																			} else {
@@ -1305,26 +1305,26 @@ func init() {
 																		}
 																		reg19751 = reg19738
 																	} else {
-																		reg19739 := __e.Call(__defun__shen_4pvar_2, V2609)
+																		reg19739 := Call(__e, __defun__shen_4pvar_2, V2609)
 																		var reg19750 Obj
 																		if reg19739 == True {
-																			reg19740 := __e.Call(__defun__shen_4newpv, V2753)
+																			reg19740 := Call(__e, __defun__shen_4newpv, V2753)
 																			B := reg19740
 																			_ = B
 																			reg19741 := Nil
 																			reg19742 := PrimCons(B, reg19741)
-																			reg19743 := __e.Call(__defun__shen_4bindv, V2609, reg19742, V2753)
+																			reg19743 := Call(__e, __defun__shen_4bindv, V2609, reg19742, V2753)
 																			_ = reg19743
-																			reg19744 := __e.Call(__defun__shen_4incinfs)
+																			reg19744 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg19744
-																			reg19745 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																				__ctx.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
+																			reg19745 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																				__e.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
 																				return
 																			}, 0)
-																			reg19747 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19745)
+																			reg19747 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19745)
 																			Result := reg19747
 																			_ = Result
-																			reg19748 := __e.Call(__defun__shen_4unbindv, V2609, V2753)
+																			reg19748 := Call(__e, __defun__shen_4unbindv, V2609, V2753)
 																			_ = reg19748
 																			reg19750 = Result
 																		} else {
@@ -1335,14 +1335,14 @@ func init() {
 																	}
 																	reg19794 = reg19751
 																} else {
-																	reg19752 := __e.Call(__defun__shen_4pvar_2, V2608)
+																	reg19752 := Call(__e, __defun__shen_4pvar_2, V2608)
 																	var reg19793 Obj
 																	if reg19752 == True {
 																		reg19753 := MakeSymbol("*")
-																		reg19754 := __e.Call(__defun__shen_4bindv, V2608, reg19753, V2753)
+																		reg19754 := Call(__e, __defun__shen_4bindv, V2608, reg19753, V2753)
 																		_ = reg19754
 																		reg19755 := PrimTail(V2607)
-																		reg19756 := __e.Call(__defun__shen_4lazyderef, reg19755, V2753)
+																		reg19756 := Call(__e, __defun__shen_4lazyderef, reg19755, V2753)
 																		V2611 := reg19756
 																		_ = V2611
 																		reg19757 := PrimIsPair(V2611)
@@ -1352,38 +1352,38 @@ func init() {
 																			B := reg19758
 																			_ = B
 																			reg19759 := PrimTail(V2611)
-																			reg19760 := __e.Call(__defun__shen_4lazyderef, reg19759, V2753)
+																			reg19760 := Call(__e, __defun__shen_4lazyderef, reg19759, V2753)
 																			V2612 := reg19760
 																			_ = V2612
 																			reg19761 := Nil
 																			reg19762 := PrimEqual(reg19761, V2612)
 																			var reg19777 Obj
 																			if reg19762 == True {
-																				reg19763 := __e.Call(__defun__shen_4incinfs)
+																				reg19763 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg19763
-																				reg19764 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																					__ctx.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
+																				reg19764 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																					__e.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
 																					return
 																				}, 0)
-																				reg19766 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19764)
+																				reg19766 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19764)
 																				reg19777 = reg19766
 																			} else {
-																				reg19767 := __e.Call(__defun__shen_4pvar_2, V2612)
+																				reg19767 := Call(__e, __defun__shen_4pvar_2, V2612)
 																				var reg19776 Obj
 																				if reg19767 == True {
 																					reg19768 := Nil
-																					reg19769 := __e.Call(__defun__shen_4bindv, V2612, reg19768, V2753)
+																					reg19769 := Call(__e, __defun__shen_4bindv, V2612, reg19768, V2753)
 																					_ = reg19769
-																					reg19770 := __e.Call(__defun__shen_4incinfs)
+																					reg19770 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg19770
-																					reg19771 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																						__ctx.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
+																					reg19771 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																						__e.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
 																						return
 																					}, 0)
-																					reg19773 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19771)
+																					reg19773 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19771)
 																					Result := reg19773
 																					_ = Result
-																					reg19774 := __e.Call(__defun__shen_4unbindv, V2612, V2753)
+																					reg19774 := Call(__e, __defun__shen_4unbindv, V2612, V2753)
 																					_ = reg19774
 																					reg19776 = Result
 																				} else {
@@ -1394,26 +1394,26 @@ func init() {
 																			}
 																			reg19790 = reg19777
 																		} else {
-																			reg19778 := __e.Call(__defun__shen_4pvar_2, V2611)
+																			reg19778 := Call(__e, __defun__shen_4pvar_2, V2611)
 																			var reg19789 Obj
 																			if reg19778 == True {
-																				reg19779 := __e.Call(__defun__shen_4newpv, V2753)
+																				reg19779 := Call(__e, __defun__shen_4newpv, V2753)
 																				B := reg19779
 																				_ = B
 																				reg19780 := Nil
 																				reg19781 := PrimCons(B, reg19780)
-																				reg19782 := __e.Call(__defun__shen_4bindv, V2611, reg19781, V2753)
+																				reg19782 := Call(__e, __defun__shen_4bindv, V2611, reg19781, V2753)
 																				_ = reg19782
-																				reg19783 := __e.Call(__defun__shen_4incinfs)
+																				reg19783 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg19783
-																				reg19784 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																					__ctx.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
+																				reg19784 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																					__e.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
 																					return
 																				}, 0)
-																				reg19786 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19784)
+																				reg19786 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19784)
 																				Result := reg19786
 																				_ = Result
-																				reg19787 := __e.Call(__defun__shen_4unbindv, V2611, V2753)
+																				reg19787 := Call(__e, __defun__shen_4unbindv, V2611, V2753)
 																				_ = reg19787
 																				reg19789 = Result
 																			} else {
@@ -1424,7 +1424,7 @@ func init() {
 																		}
 																		Result := reg19790
 																		_ = Result
-																		reg19791 := __e.Call(__defun__shen_4unbindv, V2608, V2753)
+																		reg19791 := Call(__e, __defun__shen_4unbindv, V2608, V2753)
 																		_ = reg19791
 																		reg19793 = Result
 																	} else {
@@ -1435,28 +1435,28 @@ func init() {
 																}
 																reg19809 = reg19794
 															} else {
-																reg19795 := __e.Call(__defun__shen_4pvar_2, V2607)
+																reg19795 := Call(__e, __defun__shen_4pvar_2, V2607)
 																var reg19808 Obj
 																if reg19795 == True {
-																	reg19796 := __e.Call(__defun__shen_4newpv, V2753)
+																	reg19796 := Call(__e, __defun__shen_4newpv, V2753)
 																	B := reg19796
 																	_ = B
 																	reg19797 := MakeSymbol("*")
 																	reg19798 := Nil
 																	reg19799 := PrimCons(B, reg19798)
 																	reg19800 := PrimCons(reg19797, reg19799)
-																	reg19801 := __e.Call(__defun__shen_4bindv, V2607, reg19800, V2753)
+																	reg19801 := Call(__e, __defun__shen_4bindv, V2607, reg19800, V2753)
 																	_ = reg19801
-																	reg19802 := __e.Call(__defun__shen_4incinfs)
+																	reg19802 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg19802
-																	reg19803 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																		__ctx.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
+																	reg19803 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																		__e.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
 																		return
 																	}, 0)
-																	reg19805 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19803)
+																	reg19805 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19803)
 																	Result := reg19805
 																	_ = Result
-																	reg19806 := __e.Call(__defun__shen_4unbindv, V2607, V2753)
+																	reg19806 := Call(__e, __defun__shen_4unbindv, V2607, V2753)
 																	_ = reg19806
 																	reg19808 = Result
 																} else {
@@ -1467,13 +1467,13 @@ func init() {
 															}
 															reg19826 = reg19809
 														} else {
-															reg19810 := __e.Call(__defun__shen_4pvar_2, V2606)
+															reg19810 := Call(__e, __defun__shen_4pvar_2, V2606)
 															var reg19825 Obj
 															if reg19810 == True {
-																reg19811 := __e.Call(__defun__shen_4newpv, V2753)
+																reg19811 := Call(__e, __defun__shen_4newpv, V2753)
 																A := reg19811
 																_ = A
-																reg19812 := __e.Call(__defun__shen_4newpv, V2753)
+																reg19812 := Call(__e, __defun__shen_4newpv, V2753)
 																B := reg19812
 																_ = B
 																reg19813 := MakeSymbol("*")
@@ -1481,18 +1481,18 @@ func init() {
 																reg19815 := PrimCons(B, reg19814)
 																reg19816 := PrimCons(reg19813, reg19815)
 																reg19817 := PrimCons(A, reg19816)
-																reg19818 := __e.Call(__defun__shen_4bindv, V2606, reg19817, V2753)
+																reg19818 := Call(__e, __defun__shen_4bindv, V2606, reg19817, V2753)
 																_ = reg19818
-																reg19819 := __e.Call(__defun__shen_4incinfs)
+																reg19819 := Call(__e, __defun__shen_4incinfs)
 																_ = reg19819
-																reg19820 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																	__ctx.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
+																reg19820 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																	__e.TailApply(__defun__shen_4th_d, Y, B, V2752, V2753, V2754)
 																	return
 																}, 0)
-																reg19822 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19820)
+																reg19822 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19820)
 																Result := reg19822
 																_ = Result
-																reg19823 := __e.Call(__defun__shen_4unbindv, V2606, V2753)
+																reg19823 := Call(__e, __defun__shen_4unbindv, V2606, V2753)
 																_ = reg19823
 																reg19825 = Result
 															} else {
@@ -1532,14 +1532,14 @@ func init() {
 									reg19838 := PrimEqual(Case, reg19837)
 									var reg20869 Obj
 									if reg19838 == True {
-										reg19839 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+										reg19839 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 										V2613 := reg19839
 										_ = V2613
 										reg19840 := PrimIsPair(V2613)
 										var reg19994 Obj
 										if reg19840 == True {
 											reg19841 := PrimHead(V2613)
-											reg19842 := __e.Call(__defun__shen_4lazyderef, reg19841, V2753)
+											reg19842 := Call(__e, __defun__shen_4lazyderef, reg19841, V2753)
 											V2614 := reg19842
 											_ = V2614
 											reg19843 := MakeSymbol("@v")
@@ -1547,7 +1547,7 @@ func init() {
 											var reg19992 Obj
 											if reg19844 == True {
 												reg19845 := PrimTail(V2613)
-												reg19846 := __e.Call(__defun__shen_4lazyderef, reg19845, V2753)
+												reg19846 := Call(__e, __defun__shen_4lazyderef, reg19845, V2753)
 												V2615 := reg19846
 												_ = V2615
 												reg19847 := PrimIsPair(V2615)
@@ -1557,7 +1557,7 @@ func init() {
 													X := reg19848
 													_ = X
 													reg19849 := PrimTail(V2615)
-													reg19850 := __e.Call(__defun__shen_4lazyderef, reg19849, V2753)
+													reg19850 := Call(__e, __defun__shen_4lazyderef, reg19849, V2753)
 													V2616 := reg19850
 													_ = V2616
 													reg19851 := PrimIsPair(V2616)
@@ -1567,21 +1567,21 @@ func init() {
 														Y := reg19852
 														_ = Y
 														reg19853 := PrimTail(V2616)
-														reg19854 := __e.Call(__defun__shen_4lazyderef, reg19853, V2753)
+														reg19854 := Call(__e, __defun__shen_4lazyderef, reg19853, V2753)
 														V2617 := reg19854
 														_ = V2617
 														reg19855 := Nil
 														reg19856 := PrimEqual(reg19855, V2617)
 														var reg19986 Obj
 														if reg19856 == True {
-															reg19857 := __e.Call(__defun__shen_4lazyderef, V2751, V2753)
+															reg19857 := Call(__e, __defun__shen_4lazyderef, V2751, V2753)
 															V2618 := reg19857
 															_ = V2618
 															reg19858 := PrimIsPair(V2618)
 															var reg19984 Obj
 															if reg19858 == True {
 																reg19859 := PrimHead(V2618)
-																reg19860 := __e.Call(__defun__shen_4lazyderef, reg19859, V2753)
+																reg19860 := Call(__e, __defun__shen_4lazyderef, reg19859, V2753)
 																V2619 := reg19860
 																_ = V2619
 																reg19861 := MakeSymbol("vector")
@@ -1589,7 +1589,7 @@ func init() {
 																var reg19965 Obj
 																if reg19862 == True {
 																	reg19863 := PrimTail(V2618)
-																	reg19864 := __e.Call(__defun__shen_4lazyderef, reg19863, V2753)
+																	reg19864 := Call(__e, __defun__shen_4lazyderef, reg19863, V2753)
 																	V2620 := reg19864
 																	_ = V2620
 																	reg19865 := PrimIsPair(V2620)
@@ -1599,46 +1599,46 @@ func init() {
 																		A := reg19866
 																		_ = A
 																		reg19867 := PrimTail(V2620)
-																		reg19868 := __e.Call(__defun__shen_4lazyderef, reg19867, V2753)
+																		reg19868 := Call(__e, __defun__shen_4lazyderef, reg19867, V2753)
 																		V2621 := reg19868
 																		_ = V2621
 																		reg19869 := Nil
 																		reg19870 := PrimEqual(reg19869, V2621)
 																		var reg19893 Obj
 																		if reg19870 == True {
-																			reg19871 := __e.Call(__defun__shen_4incinfs)
+																			reg19871 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg19871
-																			reg19872 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																			reg19872 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																				reg19873 := MakeSymbol("vector")
 																				reg19874 := Nil
 																				reg19875 := PrimCons(A, reg19874)
 																				reg19876 := PrimCons(reg19873, reg19875)
-																				__ctx.TailApply(__defun__shen_4th_d, Y, reg19876, V2752, V2753, V2754)
+																				__e.TailApply(__defun__shen_4th_d, Y, reg19876, V2752, V2753, V2754)
 																				return
 																			}, 0)
-																			reg19878 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19872)
+																			reg19878 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19872)
 																			reg19893 = reg19878
 																		} else {
-																			reg19879 := __e.Call(__defun__shen_4pvar_2, V2621)
+																			reg19879 := Call(__e, __defun__shen_4pvar_2, V2621)
 																			var reg19892 Obj
 																			if reg19879 == True {
 																				reg19880 := Nil
-																				reg19881 := __e.Call(__defun__shen_4bindv, V2621, reg19880, V2753)
+																				reg19881 := Call(__e, __defun__shen_4bindv, V2621, reg19880, V2753)
 																				_ = reg19881
-																				reg19882 := __e.Call(__defun__shen_4incinfs)
+																				reg19882 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg19882
-																				reg19883 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																				reg19883 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																					reg19884 := MakeSymbol("vector")
 																					reg19885 := Nil
 																					reg19886 := PrimCons(A, reg19885)
 																					reg19887 := PrimCons(reg19884, reg19886)
-																					__ctx.TailApply(__defun__shen_4th_d, Y, reg19887, V2752, V2753, V2754)
+																					__e.TailApply(__defun__shen_4th_d, Y, reg19887, V2752, V2753, V2754)
 																					return
 																				}, 0)
-																				reg19889 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19883)
+																				reg19889 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19883)
 																				Result := reg19889
 																				_ = Result
-																				reg19890 := __e.Call(__defun__shen_4unbindv, V2621, V2753)
+																				reg19890 := Call(__e, __defun__shen_4unbindv, V2621, V2753)
 																				_ = reg19890
 																				reg19892 = Result
 																			} else {
@@ -1649,30 +1649,30 @@ func init() {
 																		}
 																		reg19910 = reg19893
 																	} else {
-																		reg19894 := __e.Call(__defun__shen_4pvar_2, V2620)
+																		reg19894 := Call(__e, __defun__shen_4pvar_2, V2620)
 																		var reg19909 Obj
 																		if reg19894 == True {
-																			reg19895 := __e.Call(__defun__shen_4newpv, V2753)
+																			reg19895 := Call(__e, __defun__shen_4newpv, V2753)
 																			A := reg19895
 																			_ = A
 																			reg19896 := Nil
 																			reg19897 := PrimCons(A, reg19896)
-																			reg19898 := __e.Call(__defun__shen_4bindv, V2620, reg19897, V2753)
+																			reg19898 := Call(__e, __defun__shen_4bindv, V2620, reg19897, V2753)
 																			_ = reg19898
-																			reg19899 := __e.Call(__defun__shen_4incinfs)
+																			reg19899 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg19899
-																			reg19900 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																			reg19900 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																				reg19901 := MakeSymbol("vector")
 																				reg19902 := Nil
 																				reg19903 := PrimCons(A, reg19902)
 																				reg19904 := PrimCons(reg19901, reg19903)
-																				__ctx.TailApply(__defun__shen_4th_d, Y, reg19904, V2752, V2753, V2754)
+																				__e.TailApply(__defun__shen_4th_d, Y, reg19904, V2752, V2753, V2754)
 																				return
 																			}, 0)
-																			reg19906 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19900)
+																			reg19906 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19900)
 																			Result := reg19906
 																			_ = Result
-																			reg19907 := __e.Call(__defun__shen_4unbindv, V2620, V2753)
+																			reg19907 := Call(__e, __defun__shen_4unbindv, V2620, V2753)
 																			_ = reg19907
 																			reg19909 = Result
 																		} else {
@@ -1683,14 +1683,14 @@ func init() {
 																	}
 																	reg19965 = reg19910
 																} else {
-																	reg19911 := __e.Call(__defun__shen_4pvar_2, V2619)
+																	reg19911 := Call(__e, __defun__shen_4pvar_2, V2619)
 																	var reg19964 Obj
 																	if reg19911 == True {
 																		reg19912 := MakeSymbol("vector")
-																		reg19913 := __e.Call(__defun__shen_4bindv, V2619, reg19912, V2753)
+																		reg19913 := Call(__e, __defun__shen_4bindv, V2619, reg19912, V2753)
 																		_ = reg19913
 																		reg19914 := PrimTail(V2618)
-																		reg19915 := __e.Call(__defun__shen_4lazyderef, reg19914, V2753)
+																		reg19915 := Call(__e, __defun__shen_4lazyderef, reg19914, V2753)
 																		V2622 := reg19915
 																		_ = V2622
 																		reg19916 := PrimIsPair(V2622)
@@ -1700,46 +1700,46 @@ func init() {
 																			A := reg19917
 																			_ = A
 																			reg19918 := PrimTail(V2622)
-																			reg19919 := __e.Call(__defun__shen_4lazyderef, reg19918, V2753)
+																			reg19919 := Call(__e, __defun__shen_4lazyderef, reg19918, V2753)
 																			V2623 := reg19919
 																			_ = V2623
 																			reg19920 := Nil
 																			reg19921 := PrimEqual(reg19920, V2623)
 																			var reg19944 Obj
 																			if reg19921 == True {
-																				reg19922 := __e.Call(__defun__shen_4incinfs)
+																				reg19922 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg19922
-																				reg19923 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																				reg19923 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																					reg19924 := MakeSymbol("vector")
 																					reg19925 := Nil
 																					reg19926 := PrimCons(A, reg19925)
 																					reg19927 := PrimCons(reg19924, reg19926)
-																					__ctx.TailApply(__defun__shen_4th_d, Y, reg19927, V2752, V2753, V2754)
+																					__e.TailApply(__defun__shen_4th_d, Y, reg19927, V2752, V2753, V2754)
 																					return
 																				}, 0)
-																				reg19929 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19923)
+																				reg19929 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19923)
 																				reg19944 = reg19929
 																			} else {
-																				reg19930 := __e.Call(__defun__shen_4pvar_2, V2623)
+																				reg19930 := Call(__e, __defun__shen_4pvar_2, V2623)
 																				var reg19943 Obj
 																				if reg19930 == True {
 																					reg19931 := Nil
-																					reg19932 := __e.Call(__defun__shen_4bindv, V2623, reg19931, V2753)
+																					reg19932 := Call(__e, __defun__shen_4bindv, V2623, reg19931, V2753)
 																					_ = reg19932
-																					reg19933 := __e.Call(__defun__shen_4incinfs)
+																					reg19933 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg19933
-																					reg19934 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																					reg19934 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																						reg19935 := MakeSymbol("vector")
 																						reg19936 := Nil
 																						reg19937 := PrimCons(A, reg19936)
 																						reg19938 := PrimCons(reg19935, reg19937)
-																						__ctx.TailApply(__defun__shen_4th_d, Y, reg19938, V2752, V2753, V2754)
+																						__e.TailApply(__defun__shen_4th_d, Y, reg19938, V2752, V2753, V2754)
 																						return
 																					}, 0)
-																					reg19940 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19934)
+																					reg19940 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19934)
 																					Result := reg19940
 																					_ = Result
-																					reg19941 := __e.Call(__defun__shen_4unbindv, V2623, V2753)
+																					reg19941 := Call(__e, __defun__shen_4unbindv, V2623, V2753)
 																					_ = reg19941
 																					reg19943 = Result
 																				} else {
@@ -1750,30 +1750,30 @@ func init() {
 																			}
 																			reg19961 = reg19944
 																		} else {
-																			reg19945 := __e.Call(__defun__shen_4pvar_2, V2622)
+																			reg19945 := Call(__e, __defun__shen_4pvar_2, V2622)
 																			var reg19960 Obj
 																			if reg19945 == True {
-																				reg19946 := __e.Call(__defun__shen_4newpv, V2753)
+																				reg19946 := Call(__e, __defun__shen_4newpv, V2753)
 																				A := reg19946
 																				_ = A
 																				reg19947 := Nil
 																				reg19948 := PrimCons(A, reg19947)
-																				reg19949 := __e.Call(__defun__shen_4bindv, V2622, reg19948, V2753)
+																				reg19949 := Call(__e, __defun__shen_4bindv, V2622, reg19948, V2753)
 																				_ = reg19949
-																				reg19950 := __e.Call(__defun__shen_4incinfs)
+																				reg19950 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg19950
-																				reg19951 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																				reg19951 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																					reg19952 := MakeSymbol("vector")
 																					reg19953 := Nil
 																					reg19954 := PrimCons(A, reg19953)
 																					reg19955 := PrimCons(reg19952, reg19954)
-																					__ctx.TailApply(__defun__shen_4th_d, Y, reg19955, V2752, V2753, V2754)
+																					__e.TailApply(__defun__shen_4th_d, Y, reg19955, V2752, V2753, V2754)
 																					return
 																				}, 0)
-																				reg19957 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19951)
+																				reg19957 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19951)
 																				Result := reg19957
 																				_ = Result
-																				reg19958 := __e.Call(__defun__shen_4unbindv, V2622, V2753)
+																				reg19958 := Call(__e, __defun__shen_4unbindv, V2622, V2753)
 																				_ = reg19958
 																				reg19960 = Result
 																			} else {
@@ -1784,7 +1784,7 @@ func init() {
 																		}
 																		Result := reg19961
 																		_ = Result
-																		reg19962 := __e.Call(__defun__shen_4unbindv, V2619, V2753)
+																		reg19962 := Call(__e, __defun__shen_4unbindv, V2619, V2753)
 																		_ = reg19962
 																		reg19964 = Result
 																	} else {
@@ -1795,32 +1795,32 @@ func init() {
 																}
 																reg19984 = reg19965
 															} else {
-																reg19966 := __e.Call(__defun__shen_4pvar_2, V2618)
+																reg19966 := Call(__e, __defun__shen_4pvar_2, V2618)
 																var reg19983 Obj
 																if reg19966 == True {
-																	reg19967 := __e.Call(__defun__shen_4newpv, V2753)
+																	reg19967 := Call(__e, __defun__shen_4newpv, V2753)
 																	A := reg19967
 																	_ = A
 																	reg19968 := MakeSymbol("vector")
 																	reg19969 := Nil
 																	reg19970 := PrimCons(A, reg19969)
 																	reg19971 := PrimCons(reg19968, reg19970)
-																	reg19972 := __e.Call(__defun__shen_4bindv, V2618, reg19971, V2753)
+																	reg19972 := Call(__e, __defun__shen_4bindv, V2618, reg19971, V2753)
 																	_ = reg19972
-																	reg19973 := __e.Call(__defun__shen_4incinfs)
+																	reg19973 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg19973
-																	reg19974 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																	reg19974 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																		reg19975 := MakeSymbol("vector")
 																		reg19976 := Nil
 																		reg19977 := PrimCons(A, reg19976)
 																		reg19978 := PrimCons(reg19975, reg19977)
-																		__ctx.TailApply(__defun__shen_4th_d, Y, reg19978, V2752, V2753, V2754)
+																		__e.TailApply(__defun__shen_4th_d, Y, reg19978, V2752, V2753, V2754)
 																		return
 																	}, 0)
-																	reg19980 := __e.Call(__defun__shen_4th_d, X, A, V2752, V2753, reg19974)
+																	reg19980 := Call(__e, __defun__shen_4th_d, X, A, V2752, V2753, reg19974)
 																	Result := reg19980
 																	_ = Result
-																	reg19981 := __e.Call(__defun__shen_4unbindv, V2618, V2753)
+																	reg19981 := Call(__e, __defun__shen_4unbindv, V2618, V2753)
 																	_ = reg19981
 																	reg19983 = Result
 																} else {
@@ -1860,14 +1860,14 @@ func init() {
 										reg19996 := PrimEqual(Case, reg19995)
 										var reg20868 Obj
 										if reg19996 == True {
-											reg19997 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+											reg19997 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 											V2624 := reg19997
 											_ = V2624
 											reg19998 := PrimIsPair(V2624)
 											var reg20046 Obj
 											if reg19998 == True {
 												reg19999 := PrimHead(V2624)
-												reg20000 := __e.Call(__defun__shen_4lazyderef, reg19999, V2753)
+												reg20000 := Call(__e, __defun__shen_4lazyderef, reg19999, V2753)
 												V2625 := reg20000
 												_ = V2625
 												reg20001 := MakeSymbol("@s")
@@ -1875,7 +1875,7 @@ func init() {
 												var reg20044 Obj
 												if reg20002 == True {
 													reg20003 := PrimTail(V2624)
-													reg20004 := __e.Call(__defun__shen_4lazyderef, reg20003, V2753)
+													reg20004 := Call(__e, __defun__shen_4lazyderef, reg20003, V2753)
 													V2626 := reg20004
 													_ = V2626
 													reg20005 := PrimIsPair(V2626)
@@ -1885,7 +1885,7 @@ func init() {
 														X := reg20006
 														_ = X
 														reg20007 := PrimTail(V2626)
-														reg20008 := __e.Call(__defun__shen_4lazyderef, reg20007, V2753)
+														reg20008 := Call(__e, __defun__shen_4lazyderef, reg20007, V2753)
 														V2627 := reg20008
 														_ = V2627
 														reg20009 := PrimIsPair(V2627)
@@ -1895,49 +1895,49 @@ func init() {
 															Y := reg20010
 															_ = Y
 															reg20011 := PrimTail(V2627)
-															reg20012 := __e.Call(__defun__shen_4lazyderef, reg20011, V2753)
+															reg20012 := Call(__e, __defun__shen_4lazyderef, reg20011, V2753)
 															V2628 := reg20012
 															_ = V2628
 															reg20013 := Nil
 															reg20014 := PrimEqual(reg20013, V2628)
 															var reg20038 Obj
 															if reg20014 == True {
-																reg20015 := __e.Call(__defun__shen_4lazyderef, V2751, V2753)
+																reg20015 := Call(__e, __defun__shen_4lazyderef, V2751, V2753)
 																V2629 := reg20015
 																_ = V2629
 																reg20016 := MakeSymbol("string")
 																reg20017 := PrimEqual(reg20016, V2629)
 																var reg20036 Obj
 																if reg20017 == True {
-																	reg20018 := __e.Call(__defun__shen_4incinfs)
+																	reg20018 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg20018
 																	reg20019 := MakeSymbol("string")
-																	reg20020 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																	reg20020 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																		reg20021 := MakeSymbol("string")
-																		__ctx.TailApply(__defun__shen_4th_d, Y, reg20021, V2752, V2753, V2754)
+																		__e.TailApply(__defun__shen_4th_d, Y, reg20021, V2752, V2753, V2754)
 																		return
 																	}, 0)
-																	reg20023 := __e.Call(__defun__shen_4th_d, X, reg20019, V2752, V2753, reg20020)
+																	reg20023 := Call(__e, __defun__shen_4th_d, X, reg20019, V2752, V2753, reg20020)
 																	reg20036 = reg20023
 																} else {
-																	reg20024 := __e.Call(__defun__shen_4pvar_2, V2629)
+																	reg20024 := Call(__e, __defun__shen_4pvar_2, V2629)
 																	var reg20035 Obj
 																	if reg20024 == True {
 																		reg20025 := MakeSymbol("string")
-																		reg20026 := __e.Call(__defun__shen_4bindv, V2629, reg20025, V2753)
+																		reg20026 := Call(__e, __defun__shen_4bindv, V2629, reg20025, V2753)
 																		_ = reg20026
-																		reg20027 := __e.Call(__defun__shen_4incinfs)
+																		reg20027 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg20027
 																		reg20028 := MakeSymbol("string")
-																		reg20029 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																		reg20029 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																			reg20030 := MakeSymbol("string")
-																			__ctx.TailApply(__defun__shen_4th_d, Y, reg20030, V2752, V2753, V2754)
+																			__e.TailApply(__defun__shen_4th_d, Y, reg20030, V2752, V2753, V2754)
 																			return
 																		}, 0)
-																		reg20032 := __e.Call(__defun__shen_4th_d, X, reg20028, V2752, V2753, reg20029)
+																		reg20032 := Call(__e, __defun__shen_4th_d, X, reg20028, V2752, V2753, reg20029)
 																		Result := reg20032
 																		_ = Result
-																		reg20033 := __e.Call(__defun__shen_4unbindv, V2629, V2753)
+																		reg20033 := Call(__e, __defun__shen_4unbindv, V2629, V2753)
 																		_ = reg20033
 																		reg20035 = Result
 																	} else {
@@ -1977,14 +1977,14 @@ func init() {
 											reg20048 := PrimEqual(Case, reg20047)
 											var reg20867 Obj
 											if reg20048 == True {
-												reg20049 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+												reg20049 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 												V2630 := reg20049
 												_ = V2630
 												reg20050 := PrimIsPair(V2630)
 												var reg20333 Obj
 												if reg20050 == True {
 													reg20051 := PrimHead(V2630)
-													reg20052 := __e.Call(__defun__shen_4lazyderef, reg20051, V2753)
+													reg20052 := Call(__e, __defun__shen_4lazyderef, reg20051, V2753)
 													V2631 := reg20052
 													_ = V2631
 													reg20053 := MakeSymbol("lambda")
@@ -1992,7 +1992,7 @@ func init() {
 													var reg20331 Obj
 													if reg20054 == True {
 														reg20055 := PrimTail(V2630)
-														reg20056 := __e.Call(__defun__shen_4lazyderef, reg20055, V2753)
+														reg20056 := Call(__e, __defun__shen_4lazyderef, reg20055, V2753)
 														V2632 := reg20056
 														_ = V2632
 														reg20057 := PrimIsPair(V2632)
@@ -2002,7 +2002,7 @@ func init() {
 															X := reg20058
 															_ = X
 															reg20059 := PrimTail(V2632)
-															reg20060 := __e.Call(__defun__shen_4lazyderef, reg20059, V2753)
+															reg20060 := Call(__e, __defun__shen_4lazyderef, reg20059, V2753)
 															V2633 := reg20060
 															_ = V2633
 															reg20061 := PrimIsPair(V2633)
@@ -2012,14 +2012,14 @@ func init() {
 																Y := reg20062
 																_ = Y
 																reg20063 := PrimTail(V2633)
-																reg20064 := __e.Call(__defun__shen_4lazyderef, reg20063, V2753)
+																reg20064 := Call(__e, __defun__shen_4lazyderef, reg20063, V2753)
 																V2634 := reg20064
 																_ = V2634
 																reg20065 := Nil
 																reg20066 := PrimEqual(reg20065, V2634)
 																var reg20325 Obj
 																if reg20066 == True {
-																	reg20067 := __e.Call(__defun__shen_4lazyderef, V2751, V2753)
+																	reg20067 := Call(__e, __defun__shen_4lazyderef, V2751, V2753)
 																	V2635 := reg20067
 																	_ = V2635
 																	reg20068 := PrimIsPair(V2635)
@@ -2029,14 +2029,14 @@ func init() {
 																		A := reg20069
 																		_ = A
 																		reg20070 := PrimTail(V2635)
-																		reg20071 := __e.Call(__defun__shen_4lazyderef, reg20070, V2753)
+																		reg20071 := Call(__e, __defun__shen_4lazyderef, reg20070, V2753)
 																		V2636 := reg20071
 																		_ = V2636
 																		reg20072 := PrimIsPair(V2636)
 																		var reg20289 Obj
 																		if reg20072 == True {
 																			reg20073 := PrimHead(V2636)
-																			reg20074 := __e.Call(__defun__shen_4lazyderef, reg20073, V2753)
+																			reg20074 := Call(__e, __defun__shen_4lazyderef, reg20073, V2753)
 																			V2637 := reg20074
 																			_ = V2637
 																			reg20075 := MakeSymbol("-->")
@@ -2044,7 +2044,7 @@ func init() {
 																			var reg20257 Obj
 																			if reg20076 == True {
 																				reg20077 := PrimTail(V2636)
-																				reg20078 := __e.Call(__defun__shen_4lazyderef, reg20077, V2753)
+																				reg20078 := Call(__e, __defun__shen_4lazyderef, reg20077, V2753)
 																				V2638 := reg20078
 																				_ = V2638
 																				reg20079 := PrimIsPair(V2638)
@@ -2054,88 +2054,88 @@ func init() {
 																					B := reg20080
 																					_ = B
 																					reg20081 := PrimTail(V2638)
-																					reg20082 := __e.Call(__defun__shen_4lazyderef, reg20081, V2753)
+																					reg20082 := Call(__e, __defun__shen_4lazyderef, reg20081, V2753)
 																					V2639 := reg20082
 																					_ = V2639
 																					reg20083 := Nil
 																					reg20084 := PrimEqual(reg20083, V2639)
 																					var reg20133 Obj
 																					if reg20084 == True {
-																						reg20085 := __e.Call(__defun__shen_4newpv, V2753)
+																						reg20085 := Call(__e, __defun__shen_4newpv, V2753)
 																						Z := reg20085
 																						_ = Z
-																						reg20086 := __e.Call(__defun__shen_4newpv, V2753)
+																						reg20086 := Call(__e, __defun__shen_4newpv, V2753)
 																						X_e_e := reg20086
 																						_ = X_e_e
-																						reg20087 := __e.Call(__defun__shen_4incinfs)
+																						reg20087 := Call(__e, __defun__shen_4incinfs)
 																						_ = reg20087
-																						reg20088 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																							reg20089 := __e.Call(__defun__shen_4placeholder)
-																							reg20090 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																								reg20091 := __e.Call(__defun__shen_4lazyderef, X_e_e, V2753)
-																								reg20092 := __e.Call(__defun__shen_4lazyderef, X, V2753)
-																								reg20093 := __e.Call(__defun__shen_4lazyderef, Y, V2753)
-																								reg20094 := __e.Call(__defun__shen_4ebr, reg20091, reg20092, reg20093)
-																								reg20095 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																						reg20088 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																							reg20089 := Call(__e, __defun__shen_4placeholder)
+																							reg20090 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																								reg20091 := Call(__e, __defun__shen_4lazyderef, X_e_e, V2753)
+																								reg20092 := Call(__e, __defun__shen_4lazyderef, X, V2753)
+																								reg20093 := Call(__e, __defun__shen_4lazyderef, Y, V2753)
+																								reg20094 := Call(__e, __defun__shen_4ebr, reg20091, reg20092, reg20093)
+																								reg20095 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																									reg20096 := MakeSymbol(":")
 																									reg20097 := Nil
 																									reg20098 := PrimCons(A, reg20097)
 																									reg20099 := PrimCons(reg20096, reg20098)
 																									reg20100 := PrimCons(X_e_e, reg20099)
 																									reg20101 := PrimCons(reg20100, V2752)
-																									__ctx.TailApply(__defun__shen_4th_d, Z, B, reg20101, V2753, V2754)
+																									__e.TailApply(__defun__shen_4th_d, Z, B, reg20101, V2753, V2754)
 																									return
 																								}, 0)
-																								__ctx.TailApply(__defun__bind, Z, reg20094, V2753, reg20095)
+																								__e.TailApply(__defun__bind, Z, reg20094, V2753, reg20095)
 																								return
 																							}, 0)
-																							__ctx.TailApply(__defun__bind, X_e_e, reg20089, V2753, reg20090)
+																							__e.TailApply(__defun__bind, X_e_e, reg20089, V2753, reg20090)
 																							return
 																						}, 0)
-																						reg20105 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20088)
+																						reg20105 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20088)
 																						reg20133 = reg20105
 																					} else {
-																						reg20106 := __e.Call(__defun__shen_4pvar_2, V2639)
+																						reg20106 := Call(__e, __defun__shen_4pvar_2, V2639)
 																						var reg20132 Obj
 																						if reg20106 == True {
 																							reg20107 := Nil
-																							reg20108 := __e.Call(__defun__shen_4bindv, V2639, reg20107, V2753)
+																							reg20108 := Call(__e, __defun__shen_4bindv, V2639, reg20107, V2753)
 																							_ = reg20108
-																							reg20109 := __e.Call(__defun__shen_4newpv, V2753)
+																							reg20109 := Call(__e, __defun__shen_4newpv, V2753)
 																							Z := reg20109
 																							_ = Z
-																							reg20110 := __e.Call(__defun__shen_4newpv, V2753)
+																							reg20110 := Call(__e, __defun__shen_4newpv, V2753)
 																							X_e_e := reg20110
 																							_ = X_e_e
-																							reg20111 := __e.Call(__defun__shen_4incinfs)
+																							reg20111 := Call(__e, __defun__shen_4incinfs)
 																							_ = reg20111
-																							reg20112 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																								reg20113 := __e.Call(__defun__shen_4placeholder)
-																								reg20114 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																									reg20115 := __e.Call(__defun__shen_4lazyderef, X_e_e, V2753)
-																									reg20116 := __e.Call(__defun__shen_4lazyderef, X, V2753)
-																									reg20117 := __e.Call(__defun__shen_4lazyderef, Y, V2753)
-																									reg20118 := __e.Call(__defun__shen_4ebr, reg20115, reg20116, reg20117)
-																									reg20119 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																							reg20112 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																								reg20113 := Call(__e, __defun__shen_4placeholder)
+																								reg20114 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																									reg20115 := Call(__e, __defun__shen_4lazyderef, X_e_e, V2753)
+																									reg20116 := Call(__e, __defun__shen_4lazyderef, X, V2753)
+																									reg20117 := Call(__e, __defun__shen_4lazyderef, Y, V2753)
+																									reg20118 := Call(__e, __defun__shen_4ebr, reg20115, reg20116, reg20117)
+																									reg20119 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																										reg20120 := MakeSymbol(":")
 																										reg20121 := Nil
 																										reg20122 := PrimCons(A, reg20121)
 																										reg20123 := PrimCons(reg20120, reg20122)
 																										reg20124 := PrimCons(X_e_e, reg20123)
 																										reg20125 := PrimCons(reg20124, V2752)
-																										__ctx.TailApply(__defun__shen_4th_d, Z, B, reg20125, V2753, V2754)
+																										__e.TailApply(__defun__shen_4th_d, Z, B, reg20125, V2753, V2754)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__bind, Z, reg20118, V2753, reg20119)
+																									__e.TailApply(__defun__bind, Z, reg20118, V2753, reg20119)
 																									return
 																								}, 0)
-																								__ctx.TailApply(__defun__bind, X_e_e, reg20113, V2753, reg20114)
+																								__e.TailApply(__defun__bind, X_e_e, reg20113, V2753, reg20114)
 																								return
 																							}, 0)
-																							reg20129 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20112)
+																							reg20129 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20112)
 																							Result := reg20129
 																							_ = Result
-																							reg20130 := __e.Call(__defun__shen_4unbindv, V2639, V2753)
+																							reg20130 := Call(__e, __defun__shen_4unbindv, V2639, V2753)
 																							_ = reg20130
 																							reg20132 = Result
 																						} else {
@@ -2146,51 +2146,51 @@ func init() {
 																					}
 																					reg20163 = reg20133
 																				} else {
-																					reg20134 := __e.Call(__defun__shen_4pvar_2, V2638)
+																					reg20134 := Call(__e, __defun__shen_4pvar_2, V2638)
 																					var reg20162 Obj
 																					if reg20134 == True {
-																						reg20135 := __e.Call(__defun__shen_4newpv, V2753)
+																						reg20135 := Call(__e, __defun__shen_4newpv, V2753)
 																						B := reg20135
 																						_ = B
 																						reg20136 := Nil
 																						reg20137 := PrimCons(B, reg20136)
-																						reg20138 := __e.Call(__defun__shen_4bindv, V2638, reg20137, V2753)
+																						reg20138 := Call(__e, __defun__shen_4bindv, V2638, reg20137, V2753)
 																						_ = reg20138
-																						reg20139 := __e.Call(__defun__shen_4newpv, V2753)
+																						reg20139 := Call(__e, __defun__shen_4newpv, V2753)
 																						Z := reg20139
 																						_ = Z
-																						reg20140 := __e.Call(__defun__shen_4newpv, V2753)
+																						reg20140 := Call(__e, __defun__shen_4newpv, V2753)
 																						X_e_e := reg20140
 																						_ = X_e_e
-																						reg20141 := __e.Call(__defun__shen_4incinfs)
+																						reg20141 := Call(__e, __defun__shen_4incinfs)
 																						_ = reg20141
-																						reg20142 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																							reg20143 := __e.Call(__defun__shen_4placeholder)
-																							reg20144 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																								reg20145 := __e.Call(__defun__shen_4lazyderef, X_e_e, V2753)
-																								reg20146 := __e.Call(__defun__shen_4lazyderef, X, V2753)
-																								reg20147 := __e.Call(__defun__shen_4lazyderef, Y, V2753)
-																								reg20148 := __e.Call(__defun__shen_4ebr, reg20145, reg20146, reg20147)
-																								reg20149 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																						reg20142 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																							reg20143 := Call(__e, __defun__shen_4placeholder)
+																							reg20144 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																								reg20145 := Call(__e, __defun__shen_4lazyderef, X_e_e, V2753)
+																								reg20146 := Call(__e, __defun__shen_4lazyderef, X, V2753)
+																								reg20147 := Call(__e, __defun__shen_4lazyderef, Y, V2753)
+																								reg20148 := Call(__e, __defun__shen_4ebr, reg20145, reg20146, reg20147)
+																								reg20149 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																									reg20150 := MakeSymbol(":")
 																									reg20151 := Nil
 																									reg20152 := PrimCons(A, reg20151)
 																									reg20153 := PrimCons(reg20150, reg20152)
 																									reg20154 := PrimCons(X_e_e, reg20153)
 																									reg20155 := PrimCons(reg20154, V2752)
-																									__ctx.TailApply(__defun__shen_4th_d, Z, B, reg20155, V2753, V2754)
+																									__e.TailApply(__defun__shen_4th_d, Z, B, reg20155, V2753, V2754)
 																									return
 																								}, 0)
-																								__ctx.TailApply(__defun__bind, Z, reg20148, V2753, reg20149)
+																								__e.TailApply(__defun__bind, Z, reg20148, V2753, reg20149)
 																								return
 																							}, 0)
-																							__ctx.TailApply(__defun__bind, X_e_e, reg20143, V2753, reg20144)
+																							__e.TailApply(__defun__bind, X_e_e, reg20143, V2753, reg20144)
 																							return
 																						}, 0)
-																						reg20159 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20142)
+																						reg20159 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20142)
 																						Result := reg20159
 																						_ = Result
-																						reg20160 := __e.Call(__defun__shen_4unbindv, V2638, V2753)
+																						reg20160 := Call(__e, __defun__shen_4unbindv, V2638, V2753)
 																						_ = reg20160
 																						reg20162 = Result
 																					} else {
@@ -2201,14 +2201,14 @@ func init() {
 																				}
 																				reg20257 = reg20163
 																			} else {
-																				reg20164 := __e.Call(__defun__shen_4pvar_2, V2637)
+																				reg20164 := Call(__e, __defun__shen_4pvar_2, V2637)
 																				var reg20256 Obj
 																				if reg20164 == True {
 																					reg20165 := MakeSymbol("-->")
-																					reg20166 := __e.Call(__defun__shen_4bindv, V2637, reg20165, V2753)
+																					reg20166 := Call(__e, __defun__shen_4bindv, V2637, reg20165, V2753)
 																					_ = reg20166
 																					reg20167 := PrimTail(V2636)
-																					reg20168 := __e.Call(__defun__shen_4lazyderef, reg20167, V2753)
+																					reg20168 := Call(__e, __defun__shen_4lazyderef, reg20167, V2753)
 																					V2640 := reg20168
 																					_ = V2640
 																					reg20169 := PrimIsPair(V2640)
@@ -2218,88 +2218,88 @@ func init() {
 																						B := reg20170
 																						_ = B
 																						reg20171 := PrimTail(V2640)
-																						reg20172 := __e.Call(__defun__shen_4lazyderef, reg20171, V2753)
+																						reg20172 := Call(__e, __defun__shen_4lazyderef, reg20171, V2753)
 																						V2641 := reg20172
 																						_ = V2641
 																						reg20173 := Nil
 																						reg20174 := PrimEqual(reg20173, V2641)
 																						var reg20223 Obj
 																						if reg20174 == True {
-																							reg20175 := __e.Call(__defun__shen_4newpv, V2753)
+																							reg20175 := Call(__e, __defun__shen_4newpv, V2753)
 																							Z := reg20175
 																							_ = Z
-																							reg20176 := __e.Call(__defun__shen_4newpv, V2753)
+																							reg20176 := Call(__e, __defun__shen_4newpv, V2753)
 																							X_e_e := reg20176
 																							_ = X_e_e
-																							reg20177 := __e.Call(__defun__shen_4incinfs)
+																							reg20177 := Call(__e, __defun__shen_4incinfs)
 																							_ = reg20177
-																							reg20178 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																								reg20179 := __e.Call(__defun__shen_4placeholder)
-																								reg20180 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																									reg20181 := __e.Call(__defun__shen_4lazyderef, X_e_e, V2753)
-																									reg20182 := __e.Call(__defun__shen_4lazyderef, X, V2753)
-																									reg20183 := __e.Call(__defun__shen_4lazyderef, Y, V2753)
-																									reg20184 := __e.Call(__defun__shen_4ebr, reg20181, reg20182, reg20183)
-																									reg20185 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																							reg20178 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																								reg20179 := Call(__e, __defun__shen_4placeholder)
+																								reg20180 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																									reg20181 := Call(__e, __defun__shen_4lazyderef, X_e_e, V2753)
+																									reg20182 := Call(__e, __defun__shen_4lazyderef, X, V2753)
+																									reg20183 := Call(__e, __defun__shen_4lazyderef, Y, V2753)
+																									reg20184 := Call(__e, __defun__shen_4ebr, reg20181, reg20182, reg20183)
+																									reg20185 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																										reg20186 := MakeSymbol(":")
 																										reg20187 := Nil
 																										reg20188 := PrimCons(A, reg20187)
 																										reg20189 := PrimCons(reg20186, reg20188)
 																										reg20190 := PrimCons(X_e_e, reg20189)
 																										reg20191 := PrimCons(reg20190, V2752)
-																										__ctx.TailApply(__defun__shen_4th_d, Z, B, reg20191, V2753, V2754)
+																										__e.TailApply(__defun__shen_4th_d, Z, B, reg20191, V2753, V2754)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__bind, Z, reg20184, V2753, reg20185)
+																									__e.TailApply(__defun__bind, Z, reg20184, V2753, reg20185)
 																									return
 																								}, 0)
-																								__ctx.TailApply(__defun__bind, X_e_e, reg20179, V2753, reg20180)
+																								__e.TailApply(__defun__bind, X_e_e, reg20179, V2753, reg20180)
 																								return
 																							}, 0)
-																							reg20195 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20178)
+																							reg20195 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20178)
 																							reg20223 = reg20195
 																						} else {
-																							reg20196 := __e.Call(__defun__shen_4pvar_2, V2641)
+																							reg20196 := Call(__e, __defun__shen_4pvar_2, V2641)
 																							var reg20222 Obj
 																							if reg20196 == True {
 																								reg20197 := Nil
-																								reg20198 := __e.Call(__defun__shen_4bindv, V2641, reg20197, V2753)
+																								reg20198 := Call(__e, __defun__shen_4bindv, V2641, reg20197, V2753)
 																								_ = reg20198
-																								reg20199 := __e.Call(__defun__shen_4newpv, V2753)
+																								reg20199 := Call(__e, __defun__shen_4newpv, V2753)
 																								Z := reg20199
 																								_ = Z
-																								reg20200 := __e.Call(__defun__shen_4newpv, V2753)
+																								reg20200 := Call(__e, __defun__shen_4newpv, V2753)
 																								X_e_e := reg20200
 																								_ = X_e_e
-																								reg20201 := __e.Call(__defun__shen_4incinfs)
+																								reg20201 := Call(__e, __defun__shen_4incinfs)
 																								_ = reg20201
-																								reg20202 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																									reg20203 := __e.Call(__defun__shen_4placeholder)
-																									reg20204 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																										reg20205 := __e.Call(__defun__shen_4lazyderef, X_e_e, V2753)
-																										reg20206 := __e.Call(__defun__shen_4lazyderef, X, V2753)
-																										reg20207 := __e.Call(__defun__shen_4lazyderef, Y, V2753)
-																										reg20208 := __e.Call(__defun__shen_4ebr, reg20205, reg20206, reg20207)
-																										reg20209 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																								reg20202 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																									reg20203 := Call(__e, __defun__shen_4placeholder)
+																									reg20204 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																										reg20205 := Call(__e, __defun__shen_4lazyderef, X_e_e, V2753)
+																										reg20206 := Call(__e, __defun__shen_4lazyderef, X, V2753)
+																										reg20207 := Call(__e, __defun__shen_4lazyderef, Y, V2753)
+																										reg20208 := Call(__e, __defun__shen_4ebr, reg20205, reg20206, reg20207)
+																										reg20209 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																											reg20210 := MakeSymbol(":")
 																											reg20211 := Nil
 																											reg20212 := PrimCons(A, reg20211)
 																											reg20213 := PrimCons(reg20210, reg20212)
 																											reg20214 := PrimCons(X_e_e, reg20213)
 																											reg20215 := PrimCons(reg20214, V2752)
-																											__ctx.TailApply(__defun__shen_4th_d, Z, B, reg20215, V2753, V2754)
+																											__e.TailApply(__defun__shen_4th_d, Z, B, reg20215, V2753, V2754)
 																											return
 																										}, 0)
-																										__ctx.TailApply(__defun__bind, Z, reg20208, V2753, reg20209)
+																										__e.TailApply(__defun__bind, Z, reg20208, V2753, reg20209)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__bind, X_e_e, reg20203, V2753, reg20204)
+																									__e.TailApply(__defun__bind, X_e_e, reg20203, V2753, reg20204)
 																									return
 																								}, 0)
-																								reg20219 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20202)
+																								reg20219 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20202)
 																								Result := reg20219
 																								_ = Result
-																								reg20220 := __e.Call(__defun__shen_4unbindv, V2641, V2753)
+																								reg20220 := Call(__e, __defun__shen_4unbindv, V2641, V2753)
 																								_ = reg20220
 																								reg20222 = Result
 																							} else {
@@ -2310,51 +2310,51 @@ func init() {
 																						}
 																						reg20253 = reg20223
 																					} else {
-																						reg20224 := __e.Call(__defun__shen_4pvar_2, V2640)
+																						reg20224 := Call(__e, __defun__shen_4pvar_2, V2640)
 																						var reg20252 Obj
 																						if reg20224 == True {
-																							reg20225 := __e.Call(__defun__shen_4newpv, V2753)
+																							reg20225 := Call(__e, __defun__shen_4newpv, V2753)
 																							B := reg20225
 																							_ = B
 																							reg20226 := Nil
 																							reg20227 := PrimCons(B, reg20226)
-																							reg20228 := __e.Call(__defun__shen_4bindv, V2640, reg20227, V2753)
+																							reg20228 := Call(__e, __defun__shen_4bindv, V2640, reg20227, V2753)
 																							_ = reg20228
-																							reg20229 := __e.Call(__defun__shen_4newpv, V2753)
+																							reg20229 := Call(__e, __defun__shen_4newpv, V2753)
 																							Z := reg20229
 																							_ = Z
-																							reg20230 := __e.Call(__defun__shen_4newpv, V2753)
+																							reg20230 := Call(__e, __defun__shen_4newpv, V2753)
 																							X_e_e := reg20230
 																							_ = X_e_e
-																							reg20231 := __e.Call(__defun__shen_4incinfs)
+																							reg20231 := Call(__e, __defun__shen_4incinfs)
 																							_ = reg20231
-																							reg20232 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																								reg20233 := __e.Call(__defun__shen_4placeholder)
-																								reg20234 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																									reg20235 := __e.Call(__defun__shen_4lazyderef, X_e_e, V2753)
-																									reg20236 := __e.Call(__defun__shen_4lazyderef, X, V2753)
-																									reg20237 := __e.Call(__defun__shen_4lazyderef, Y, V2753)
-																									reg20238 := __e.Call(__defun__shen_4ebr, reg20235, reg20236, reg20237)
-																									reg20239 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																							reg20232 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																								reg20233 := Call(__e, __defun__shen_4placeholder)
+																								reg20234 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																									reg20235 := Call(__e, __defun__shen_4lazyderef, X_e_e, V2753)
+																									reg20236 := Call(__e, __defun__shen_4lazyderef, X, V2753)
+																									reg20237 := Call(__e, __defun__shen_4lazyderef, Y, V2753)
+																									reg20238 := Call(__e, __defun__shen_4ebr, reg20235, reg20236, reg20237)
+																									reg20239 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																										reg20240 := MakeSymbol(":")
 																										reg20241 := Nil
 																										reg20242 := PrimCons(A, reg20241)
 																										reg20243 := PrimCons(reg20240, reg20242)
 																										reg20244 := PrimCons(X_e_e, reg20243)
 																										reg20245 := PrimCons(reg20244, V2752)
-																										__ctx.TailApply(__defun__shen_4th_d, Z, B, reg20245, V2753, V2754)
+																										__e.TailApply(__defun__shen_4th_d, Z, B, reg20245, V2753, V2754)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__bind, Z, reg20238, V2753, reg20239)
+																									__e.TailApply(__defun__bind, Z, reg20238, V2753, reg20239)
 																									return
 																								}, 0)
-																								__ctx.TailApply(__defun__bind, X_e_e, reg20233, V2753, reg20234)
+																								__e.TailApply(__defun__bind, X_e_e, reg20233, V2753, reg20234)
 																								return
 																							}, 0)
-																							reg20249 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20232)
+																							reg20249 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20232)
 																							Result := reg20249
 																							_ = Result
-																							reg20250 := __e.Call(__defun__shen_4unbindv, V2640, V2753)
+																							reg20250 := Call(__e, __defun__shen_4unbindv, V2640, V2753)
 																							_ = reg20250
 																							reg20252 = Result
 																						} else {
@@ -2365,7 +2365,7 @@ func init() {
 																					}
 																					Result := reg20253
 																					_ = Result
-																					reg20254 := __e.Call(__defun__shen_4unbindv, V2637, V2753)
+																					reg20254 := Call(__e, __defun__shen_4unbindv, V2637, V2753)
 																					_ = reg20254
 																					reg20256 = Result
 																				} else {
@@ -2376,53 +2376,53 @@ func init() {
 																			}
 																			reg20289 = reg20257
 																		} else {
-																			reg20258 := __e.Call(__defun__shen_4pvar_2, V2636)
+																			reg20258 := Call(__e, __defun__shen_4pvar_2, V2636)
 																			var reg20288 Obj
 																			if reg20258 == True {
-																				reg20259 := __e.Call(__defun__shen_4newpv, V2753)
+																				reg20259 := Call(__e, __defun__shen_4newpv, V2753)
 																				B := reg20259
 																				_ = B
 																				reg20260 := MakeSymbol("-->")
 																				reg20261 := Nil
 																				reg20262 := PrimCons(B, reg20261)
 																				reg20263 := PrimCons(reg20260, reg20262)
-																				reg20264 := __e.Call(__defun__shen_4bindv, V2636, reg20263, V2753)
+																				reg20264 := Call(__e, __defun__shen_4bindv, V2636, reg20263, V2753)
 																				_ = reg20264
-																				reg20265 := __e.Call(__defun__shen_4newpv, V2753)
+																				reg20265 := Call(__e, __defun__shen_4newpv, V2753)
 																				Z := reg20265
 																				_ = Z
-																				reg20266 := __e.Call(__defun__shen_4newpv, V2753)
+																				reg20266 := Call(__e, __defun__shen_4newpv, V2753)
 																				X_e_e := reg20266
 																				_ = X_e_e
-																				reg20267 := __e.Call(__defun__shen_4incinfs)
+																				reg20267 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg20267
-																				reg20268 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																					reg20269 := __e.Call(__defun__shen_4placeholder)
-																					reg20270 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																						reg20271 := __e.Call(__defun__shen_4lazyderef, X_e_e, V2753)
-																						reg20272 := __e.Call(__defun__shen_4lazyderef, X, V2753)
-																						reg20273 := __e.Call(__defun__shen_4lazyderef, Y, V2753)
-																						reg20274 := __e.Call(__defun__shen_4ebr, reg20271, reg20272, reg20273)
-																						reg20275 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																				reg20268 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																					reg20269 := Call(__e, __defun__shen_4placeholder)
+																					reg20270 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																						reg20271 := Call(__e, __defun__shen_4lazyderef, X_e_e, V2753)
+																						reg20272 := Call(__e, __defun__shen_4lazyderef, X, V2753)
+																						reg20273 := Call(__e, __defun__shen_4lazyderef, Y, V2753)
+																						reg20274 := Call(__e, __defun__shen_4ebr, reg20271, reg20272, reg20273)
+																						reg20275 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																							reg20276 := MakeSymbol(":")
 																							reg20277 := Nil
 																							reg20278 := PrimCons(A, reg20277)
 																							reg20279 := PrimCons(reg20276, reg20278)
 																							reg20280 := PrimCons(X_e_e, reg20279)
 																							reg20281 := PrimCons(reg20280, V2752)
-																							__ctx.TailApply(__defun__shen_4th_d, Z, B, reg20281, V2753, V2754)
+																							__e.TailApply(__defun__shen_4th_d, Z, B, reg20281, V2753, V2754)
 																							return
 																						}, 0)
-																						__ctx.TailApply(__defun__bind, Z, reg20274, V2753, reg20275)
+																						__e.TailApply(__defun__bind, Z, reg20274, V2753, reg20275)
 																						return
 																					}, 0)
-																					__ctx.TailApply(__defun__bind, X_e_e, reg20269, V2753, reg20270)
+																					__e.TailApply(__defun__bind, X_e_e, reg20269, V2753, reg20270)
 																					return
 																				}, 0)
-																				reg20285 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20268)
+																				reg20285 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20268)
 																				Result := reg20285
 																				_ = Result
-																				reg20286 := __e.Call(__defun__shen_4unbindv, V2636, V2753)
+																				reg20286 := Call(__e, __defun__shen_4unbindv, V2636, V2753)
 																				_ = reg20286
 																				reg20288 = Result
 																			} else {
@@ -2433,13 +2433,13 @@ func init() {
 																		}
 																		reg20323 = reg20289
 																	} else {
-																		reg20290 := __e.Call(__defun__shen_4pvar_2, V2635)
+																		reg20290 := Call(__e, __defun__shen_4pvar_2, V2635)
 																		var reg20322 Obj
 																		if reg20290 == True {
-																			reg20291 := __e.Call(__defun__shen_4newpv, V2753)
+																			reg20291 := Call(__e, __defun__shen_4newpv, V2753)
 																			A := reg20291
 																			_ = A
-																			reg20292 := __e.Call(__defun__shen_4newpv, V2753)
+																			reg20292 := Call(__e, __defun__shen_4newpv, V2753)
 																			B := reg20292
 																			_ = B
 																			reg20293 := MakeSymbol("-->")
@@ -2447,43 +2447,43 @@ func init() {
 																			reg20295 := PrimCons(B, reg20294)
 																			reg20296 := PrimCons(reg20293, reg20295)
 																			reg20297 := PrimCons(A, reg20296)
-																			reg20298 := __e.Call(__defun__shen_4bindv, V2635, reg20297, V2753)
+																			reg20298 := Call(__e, __defun__shen_4bindv, V2635, reg20297, V2753)
 																			_ = reg20298
-																			reg20299 := __e.Call(__defun__shen_4newpv, V2753)
+																			reg20299 := Call(__e, __defun__shen_4newpv, V2753)
 																			Z := reg20299
 																			_ = Z
-																			reg20300 := __e.Call(__defun__shen_4newpv, V2753)
+																			reg20300 := Call(__e, __defun__shen_4newpv, V2753)
 																			X_e_e := reg20300
 																			_ = X_e_e
-																			reg20301 := __e.Call(__defun__shen_4incinfs)
+																			reg20301 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg20301
-																			reg20302 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																				reg20303 := __e.Call(__defun__shen_4placeholder)
-																				reg20304 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																					reg20305 := __e.Call(__defun__shen_4lazyderef, X_e_e, V2753)
-																					reg20306 := __e.Call(__defun__shen_4lazyderef, X, V2753)
-																					reg20307 := __e.Call(__defun__shen_4lazyderef, Y, V2753)
-																					reg20308 := __e.Call(__defun__shen_4ebr, reg20305, reg20306, reg20307)
-																					reg20309 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																			reg20302 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																				reg20303 := Call(__e, __defun__shen_4placeholder)
+																				reg20304 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																					reg20305 := Call(__e, __defun__shen_4lazyderef, X_e_e, V2753)
+																					reg20306 := Call(__e, __defun__shen_4lazyderef, X, V2753)
+																					reg20307 := Call(__e, __defun__shen_4lazyderef, Y, V2753)
+																					reg20308 := Call(__e, __defun__shen_4ebr, reg20305, reg20306, reg20307)
+																					reg20309 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																						reg20310 := MakeSymbol(":")
 																						reg20311 := Nil
 																						reg20312 := PrimCons(A, reg20311)
 																						reg20313 := PrimCons(reg20310, reg20312)
 																						reg20314 := PrimCons(X_e_e, reg20313)
 																						reg20315 := PrimCons(reg20314, V2752)
-																						__ctx.TailApply(__defun__shen_4th_d, Z, B, reg20315, V2753, V2754)
+																						__e.TailApply(__defun__shen_4th_d, Z, B, reg20315, V2753, V2754)
 																						return
 																					}, 0)
-																					__ctx.TailApply(__defun__bind, Z, reg20308, V2753, reg20309)
+																					__e.TailApply(__defun__bind, Z, reg20308, V2753, reg20309)
 																					return
 																				}, 0)
-																				__ctx.TailApply(__defun__bind, X_e_e, reg20303, V2753, reg20304)
+																				__e.TailApply(__defun__bind, X_e_e, reg20303, V2753, reg20304)
 																				return
 																			}, 0)
-																			reg20319 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20302)
+																			reg20319 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20302)
 																			Result := reg20319
 																			_ = Result
-																			reg20320 := __e.Call(__defun__shen_4unbindv, V2635, V2753)
+																			reg20320 := Call(__e, __defun__shen_4unbindv, V2635, V2753)
 																			_ = reg20320
 																			reg20322 = Result
 																		} else {
@@ -2523,14 +2523,14 @@ func init() {
 												reg20335 := PrimEqual(Case, reg20334)
 												var reg20866 Obj
 												if reg20335 == True {
-													reg20336 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+													reg20336 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 													V2642 := reg20336
 													_ = V2642
 													reg20337 := PrimIsPair(V2642)
 													var reg20391 Obj
 													if reg20337 == True {
 														reg20338 := PrimHead(V2642)
-														reg20339 := __e.Call(__defun__shen_4lazyderef, reg20338, V2753)
+														reg20339 := Call(__e, __defun__shen_4lazyderef, reg20338, V2753)
 														V2643 := reg20339
 														_ = V2643
 														reg20340 := MakeSymbol("let")
@@ -2538,7 +2538,7 @@ func init() {
 														var reg20389 Obj
 														if reg20341 == True {
 															reg20342 := PrimTail(V2642)
-															reg20343 := __e.Call(__defun__shen_4lazyderef, reg20342, V2753)
+															reg20343 := Call(__e, __defun__shen_4lazyderef, reg20342, V2753)
 															V2644 := reg20343
 															_ = V2644
 															reg20344 := PrimIsPair(V2644)
@@ -2548,7 +2548,7 @@ func init() {
 																X := reg20345
 																_ = X
 																reg20346 := PrimTail(V2644)
-																reg20347 := __e.Call(__defun__shen_4lazyderef, reg20346, V2753)
+																reg20347 := Call(__e, __defun__shen_4lazyderef, reg20346, V2753)
 																V2645 := reg20347
 																_ = V2645
 																reg20348 := PrimIsPair(V2645)
@@ -2558,7 +2558,7 @@ func init() {
 																	Y := reg20349
 																	_ = Y
 																	reg20350 := PrimTail(V2645)
-																	reg20351 := __e.Call(__defun__shen_4lazyderef, reg20350, V2753)
+																	reg20351 := Call(__e, __defun__shen_4lazyderef, reg20350, V2753)
 																	V2646 := reg20351
 																	_ = V2646
 																	reg20352 := PrimIsPair(V2646)
@@ -2568,48 +2568,48 @@ func init() {
 																		Z := reg20353
 																		_ = Z
 																		reg20354 := PrimTail(V2646)
-																		reg20355 := __e.Call(__defun__shen_4lazyderef, reg20354, V2753)
+																		reg20355 := Call(__e, __defun__shen_4lazyderef, reg20354, V2753)
 																		V2647 := reg20355
 																		_ = V2647
 																		reg20356 := Nil
 																		reg20357 := PrimEqual(reg20356, V2647)
 																		var reg20381 Obj
 																		if reg20357 == True {
-																			reg20358 := __e.Call(__defun__shen_4newpv, V2753)
+																			reg20358 := Call(__e, __defun__shen_4newpv, V2753)
 																			W := reg20358
 																			_ = W
-																			reg20359 := __e.Call(__defun__shen_4newpv, V2753)
+																			reg20359 := Call(__e, __defun__shen_4newpv, V2753)
 																			X_e_e := reg20359
 																			_ = X_e_e
-																			reg20360 := __e.Call(__defun__shen_4newpv, V2753)
+																			reg20360 := Call(__e, __defun__shen_4newpv, V2753)
 																			B := reg20360
 																			_ = B
-																			reg20361 := __e.Call(__defun__shen_4incinfs)
+																			reg20361 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg20361
-																			reg20362 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																				reg20363 := __e.Call(__defun__shen_4placeholder)
-																				reg20364 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																					reg20365 := __e.Call(__defun__shen_4lazyderef, X_e_e, V2753)
-																					reg20366 := __e.Call(__defun__shen_4lazyderef, X, V2753)
-																					reg20367 := __e.Call(__defun__shen_4lazyderef, Z, V2753)
-																					reg20368 := __e.Call(__defun__shen_4ebr, reg20365, reg20366, reg20367)
-																					reg20369 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																			reg20362 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																				reg20363 := Call(__e, __defun__shen_4placeholder)
+																				reg20364 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																					reg20365 := Call(__e, __defun__shen_4lazyderef, X_e_e, V2753)
+																					reg20366 := Call(__e, __defun__shen_4lazyderef, X, V2753)
+																					reg20367 := Call(__e, __defun__shen_4lazyderef, Z, V2753)
+																					reg20368 := Call(__e, __defun__shen_4ebr, reg20365, reg20366, reg20367)
+																					reg20369 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																						reg20370 := MakeSymbol(":")
 																						reg20371 := Nil
 																						reg20372 := PrimCons(B, reg20371)
 																						reg20373 := PrimCons(reg20370, reg20372)
 																						reg20374 := PrimCons(X_e_e, reg20373)
 																						reg20375 := PrimCons(reg20374, V2752)
-																						__ctx.TailApply(__defun__shen_4th_d, W, V2751, reg20375, V2753, V2754)
+																						__e.TailApply(__defun__shen_4th_d, W, V2751, reg20375, V2753, V2754)
 																						return
 																					}, 0)
-																					__ctx.TailApply(__defun__bind, W, reg20368, V2753, reg20369)
+																					__e.TailApply(__defun__bind, W, reg20368, V2753, reg20369)
 																					return
 																				}, 0)
-																				__ctx.TailApply(__defun__bind, X_e_e, reg20363, V2753, reg20364)
+																				__e.TailApply(__defun__bind, X_e_e, reg20363, V2753, reg20364)
 																				return
 																			}, 0)
-																			reg20379 := __e.Call(__defun__shen_4th_d, Y, B, V2752, V2753, reg20362)
+																			reg20379 := Call(__e, __defun__shen_4th_d, Y, B, V2752, V2753, reg20362)
 																			reg20381 = reg20379
 																		} else {
 																			reg20380 := False
@@ -2646,14 +2646,14 @@ func init() {
 													reg20393 := PrimEqual(Case, reg20392)
 													var reg20865 Obj
 													if reg20393 == True {
-														reg20394 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+														reg20394 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 														V2648 := reg20394
 														_ = V2648
 														reg20395 := PrimIsPair(V2648)
 														var reg20605 Obj
 														if reg20395 == True {
 															reg20396 := PrimHead(V2648)
-															reg20397 := __e.Call(__defun__shen_4lazyderef, reg20396, V2753)
+															reg20397 := Call(__e, __defun__shen_4lazyderef, reg20396, V2753)
 															V2649 := reg20397
 															_ = V2649
 															reg20398 := MakeSymbol("open")
@@ -2661,7 +2661,7 @@ func init() {
 															var reg20603 Obj
 															if reg20399 == True {
 																reg20400 := PrimTail(V2648)
-																reg20401 := __e.Call(__defun__shen_4lazyderef, reg20400, V2753)
+																reg20401 := Call(__e, __defun__shen_4lazyderef, reg20400, V2753)
 																V2650 := reg20401
 																_ = V2650
 																reg20402 := PrimIsPair(V2650)
@@ -2671,7 +2671,7 @@ func init() {
 																	FileName := reg20403
 																	_ = FileName
 																	reg20404 := PrimTail(V2650)
-																	reg20405 := __e.Call(__defun__shen_4lazyderef, reg20404, V2753)
+																	reg20405 := Call(__e, __defun__shen_4lazyderef, reg20404, V2753)
 																	V2651 := reg20405
 																	_ = V2651
 																	reg20406 := PrimIsPair(V2651)
@@ -2681,21 +2681,21 @@ func init() {
 																		Direction2581 := reg20407
 																		_ = Direction2581
 																		reg20408 := PrimTail(V2651)
-																		reg20409 := __e.Call(__defun__shen_4lazyderef, reg20408, V2753)
+																		reg20409 := Call(__e, __defun__shen_4lazyderef, reg20408, V2753)
 																		V2652 := reg20409
 																		_ = V2652
 																		reg20410 := Nil
 																		reg20411 := PrimEqual(reg20410, V2652)
 																		var reg20597 Obj
 																		if reg20411 == True {
-																			reg20412 := __e.Call(__defun__shen_4lazyderef, V2751, V2753)
+																			reg20412 := Call(__e, __defun__shen_4lazyderef, V2751, V2753)
 																			V2653 := reg20412
 																			_ = V2653
 																			reg20413 := PrimIsPair(V2653)
 																			var reg20595 Obj
 																			if reg20413 == True {
 																				reg20414 := PrimHead(V2653)
-																				reg20415 := __e.Call(__defun__shen_4lazyderef, reg20414, V2753)
+																				reg20415 := Call(__e, __defun__shen_4lazyderef, reg20414, V2753)
 																				V2654 := reg20415
 																				_ = V2654
 																				reg20416 := MakeSymbol("stream")
@@ -2703,7 +2703,7 @@ func init() {
 																				var reg20568 Obj
 																				if reg20417 == True {
 																					reg20418 := PrimTail(V2653)
-																					reg20419 := __e.Call(__defun__shen_4lazyderef, reg20418, V2753)
+																					reg20419 := Call(__e, __defun__shen_4lazyderef, reg20418, V2753)
 																					V2655 := reg20419
 																					_ = V2655
 																					reg20420 := PrimIsPair(V2655)
@@ -2713,70 +2713,70 @@ func init() {
 																						Direction := reg20421
 																						_ = Direction
 																						reg20422 := PrimTail(V2655)
-																						reg20423 := __e.Call(__defun__shen_4lazyderef, reg20422, V2753)
+																						reg20423 := Call(__e, __defun__shen_4lazyderef, reg20422, V2753)
 																						V2656 := reg20423
 																						_ = V2656
 																						reg20424 := Nil
 																						reg20425 := PrimEqual(reg20424, V2656)
 																						var reg20464 Obj
 																						if reg20425 == True {
-																							reg20426 := __e.Call(__defun__shen_4incinfs)
+																							reg20426 := Call(__e, __defun__shen_4incinfs)
 																							_ = reg20426
-																							reg20427 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																								reg20428 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																									reg20429 := __e.Call(__defun__shen_4lazyderef, Direction, V2753)
+																							reg20427 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																								reg20428 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																									reg20429 := Call(__e, __defun__shen_4lazyderef, Direction, V2753)
 																									reg20430 := MakeSymbol("in")
 																									reg20431 := MakeSymbol("out")
 																									reg20432 := Nil
 																									reg20433 := PrimCons(reg20431, reg20432)
 																									reg20434 := PrimCons(reg20430, reg20433)
-																									reg20435 := __e.Call(__defun__element_2, reg20429, reg20434)
-																									reg20436 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																									reg20435 := Call(__e, __defun__element_2, reg20429, reg20434)
+																									reg20436 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																										reg20437 := MakeSymbol("string")
-																										__ctx.TailApply(__defun__shen_4th_d, FileName, reg20437, V2752, V2753, V2754)
+																										__e.TailApply(__defun__shen_4th_d, FileName, reg20437, V2752, V2753, V2754)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__fwhen, reg20435, V2753, reg20436)
+																									__e.TailApply(__defun__fwhen, reg20435, V2753, reg20436)
 																									return
 																								}, 0)
-																								__ctx.TailApply(__defun__cut, Throwcontrol, V2753, reg20428)
+																								__e.TailApply(__defun__cut, Throwcontrol, V2753, reg20428)
 																								return
 																							}, 0)
-																							reg20441 := __e.Call(__defun__unify_b, Direction, Direction2581, V2753, reg20427)
+																							reg20441 := Call(__e, __defun__unify_b, Direction, Direction2581, V2753, reg20427)
 																							reg20464 = reg20441
 																						} else {
-																							reg20442 := __e.Call(__defun__shen_4pvar_2, V2656)
+																							reg20442 := Call(__e, __defun__shen_4pvar_2, V2656)
 																							var reg20463 Obj
 																							if reg20442 == True {
 																								reg20443 := Nil
-																								reg20444 := __e.Call(__defun__shen_4bindv, V2656, reg20443, V2753)
+																								reg20444 := Call(__e, __defun__shen_4bindv, V2656, reg20443, V2753)
 																								_ = reg20444
-																								reg20445 := __e.Call(__defun__shen_4incinfs)
+																								reg20445 := Call(__e, __defun__shen_4incinfs)
 																								_ = reg20445
-																								reg20446 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																									reg20447 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																										reg20448 := __e.Call(__defun__shen_4lazyderef, Direction, V2753)
+																								reg20446 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																									reg20447 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																										reg20448 := Call(__e, __defun__shen_4lazyderef, Direction, V2753)
 																										reg20449 := MakeSymbol("in")
 																										reg20450 := MakeSymbol("out")
 																										reg20451 := Nil
 																										reg20452 := PrimCons(reg20450, reg20451)
 																										reg20453 := PrimCons(reg20449, reg20452)
-																										reg20454 := __e.Call(__defun__element_2, reg20448, reg20453)
-																										reg20455 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																										reg20454 := Call(__e, __defun__element_2, reg20448, reg20453)
+																										reg20455 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																											reg20456 := MakeSymbol("string")
-																											__ctx.TailApply(__defun__shen_4th_d, FileName, reg20456, V2752, V2753, V2754)
+																											__e.TailApply(__defun__shen_4th_d, FileName, reg20456, V2752, V2753, V2754)
 																											return
 																										}, 0)
-																										__ctx.TailApply(__defun__fwhen, reg20454, V2753, reg20455)
+																										__e.TailApply(__defun__fwhen, reg20454, V2753, reg20455)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__cut, Throwcontrol, V2753, reg20447)
+																									__e.TailApply(__defun__cut, Throwcontrol, V2753, reg20447)
 																									return
 																								}, 0)
-																								reg20460 := __e.Call(__defun__unify_b, Direction, Direction2581, V2753, reg20446)
+																								reg20460 := Call(__e, __defun__unify_b, Direction, Direction2581, V2753, reg20446)
 																								Result := reg20460
 																								_ = Result
-																								reg20461 := __e.Call(__defun__shen_4unbindv, V2656, V2753)
+																								reg20461 := Call(__e, __defun__shen_4unbindv, V2656, V2753)
 																								_ = reg20461
 																								reg20463 = Result
 																							} else {
@@ -2787,42 +2787,42 @@ func init() {
 																						}
 																						reg20489 = reg20464
 																					} else {
-																						reg20465 := __e.Call(__defun__shen_4pvar_2, V2655)
+																						reg20465 := Call(__e, __defun__shen_4pvar_2, V2655)
 																						var reg20488 Obj
 																						if reg20465 == True {
-																							reg20466 := __e.Call(__defun__shen_4newpv, V2753)
+																							reg20466 := Call(__e, __defun__shen_4newpv, V2753)
 																							Direction := reg20466
 																							_ = Direction
 																							reg20467 := Nil
 																							reg20468 := PrimCons(Direction, reg20467)
-																							reg20469 := __e.Call(__defun__shen_4bindv, V2655, reg20468, V2753)
+																							reg20469 := Call(__e, __defun__shen_4bindv, V2655, reg20468, V2753)
 																							_ = reg20469
-																							reg20470 := __e.Call(__defun__shen_4incinfs)
+																							reg20470 := Call(__e, __defun__shen_4incinfs)
 																							_ = reg20470
-																							reg20471 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																								reg20472 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																									reg20473 := __e.Call(__defun__shen_4lazyderef, Direction, V2753)
+																							reg20471 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																								reg20472 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																									reg20473 := Call(__e, __defun__shen_4lazyderef, Direction, V2753)
 																									reg20474 := MakeSymbol("in")
 																									reg20475 := MakeSymbol("out")
 																									reg20476 := Nil
 																									reg20477 := PrimCons(reg20475, reg20476)
 																									reg20478 := PrimCons(reg20474, reg20477)
-																									reg20479 := __e.Call(__defun__element_2, reg20473, reg20478)
-																									reg20480 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																									reg20479 := Call(__e, __defun__element_2, reg20473, reg20478)
+																									reg20480 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																										reg20481 := MakeSymbol("string")
-																										__ctx.TailApply(__defun__shen_4th_d, FileName, reg20481, V2752, V2753, V2754)
+																										__e.TailApply(__defun__shen_4th_d, FileName, reg20481, V2752, V2753, V2754)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__fwhen, reg20479, V2753, reg20480)
+																									__e.TailApply(__defun__fwhen, reg20479, V2753, reg20480)
 																									return
 																								}, 0)
-																								__ctx.TailApply(__defun__cut, Throwcontrol, V2753, reg20472)
+																								__e.TailApply(__defun__cut, Throwcontrol, V2753, reg20472)
 																								return
 																							}, 0)
-																							reg20485 := __e.Call(__defun__unify_b, Direction, Direction2581, V2753, reg20471)
+																							reg20485 := Call(__e, __defun__unify_b, Direction, Direction2581, V2753, reg20471)
 																							Result := reg20485
 																							_ = Result
-																							reg20486 := __e.Call(__defun__shen_4unbindv, V2655, V2753)
+																							reg20486 := Call(__e, __defun__shen_4unbindv, V2655, V2753)
 																							_ = reg20486
 																							reg20488 = Result
 																						} else {
@@ -2833,14 +2833,14 @@ func init() {
 																					}
 																					reg20568 = reg20489
 																				} else {
-																					reg20490 := __e.Call(__defun__shen_4pvar_2, V2654)
+																					reg20490 := Call(__e, __defun__shen_4pvar_2, V2654)
 																					var reg20567 Obj
 																					if reg20490 == True {
 																						reg20491 := MakeSymbol("stream")
-																						reg20492 := __e.Call(__defun__shen_4bindv, V2654, reg20491, V2753)
+																						reg20492 := Call(__e, __defun__shen_4bindv, V2654, reg20491, V2753)
 																						_ = reg20492
 																						reg20493 := PrimTail(V2653)
-																						reg20494 := __e.Call(__defun__shen_4lazyderef, reg20493, V2753)
+																						reg20494 := Call(__e, __defun__shen_4lazyderef, reg20493, V2753)
 																						V2657 := reg20494
 																						_ = V2657
 																						reg20495 := PrimIsPair(V2657)
@@ -2850,70 +2850,70 @@ func init() {
 																							Direction := reg20496
 																							_ = Direction
 																							reg20497 := PrimTail(V2657)
-																							reg20498 := __e.Call(__defun__shen_4lazyderef, reg20497, V2753)
+																							reg20498 := Call(__e, __defun__shen_4lazyderef, reg20497, V2753)
 																							V2658 := reg20498
 																							_ = V2658
 																							reg20499 := Nil
 																							reg20500 := PrimEqual(reg20499, V2658)
 																							var reg20539 Obj
 																							if reg20500 == True {
-																								reg20501 := __e.Call(__defun__shen_4incinfs)
+																								reg20501 := Call(__e, __defun__shen_4incinfs)
 																								_ = reg20501
-																								reg20502 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																									reg20503 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																										reg20504 := __e.Call(__defun__shen_4lazyderef, Direction, V2753)
+																								reg20502 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																									reg20503 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																										reg20504 := Call(__e, __defun__shen_4lazyderef, Direction, V2753)
 																										reg20505 := MakeSymbol("in")
 																										reg20506 := MakeSymbol("out")
 																										reg20507 := Nil
 																										reg20508 := PrimCons(reg20506, reg20507)
 																										reg20509 := PrimCons(reg20505, reg20508)
-																										reg20510 := __e.Call(__defun__element_2, reg20504, reg20509)
-																										reg20511 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																										reg20510 := Call(__e, __defun__element_2, reg20504, reg20509)
+																										reg20511 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																											reg20512 := MakeSymbol("string")
-																											__ctx.TailApply(__defun__shen_4th_d, FileName, reg20512, V2752, V2753, V2754)
+																											__e.TailApply(__defun__shen_4th_d, FileName, reg20512, V2752, V2753, V2754)
 																											return
 																										}, 0)
-																										__ctx.TailApply(__defun__fwhen, reg20510, V2753, reg20511)
+																										__e.TailApply(__defun__fwhen, reg20510, V2753, reg20511)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__cut, Throwcontrol, V2753, reg20503)
+																									__e.TailApply(__defun__cut, Throwcontrol, V2753, reg20503)
 																									return
 																								}, 0)
-																								reg20516 := __e.Call(__defun__unify_b, Direction, Direction2581, V2753, reg20502)
+																								reg20516 := Call(__e, __defun__unify_b, Direction, Direction2581, V2753, reg20502)
 																								reg20539 = reg20516
 																							} else {
-																								reg20517 := __e.Call(__defun__shen_4pvar_2, V2658)
+																								reg20517 := Call(__e, __defun__shen_4pvar_2, V2658)
 																								var reg20538 Obj
 																								if reg20517 == True {
 																									reg20518 := Nil
-																									reg20519 := __e.Call(__defun__shen_4bindv, V2658, reg20518, V2753)
+																									reg20519 := Call(__e, __defun__shen_4bindv, V2658, reg20518, V2753)
 																									_ = reg20519
-																									reg20520 := __e.Call(__defun__shen_4incinfs)
+																									reg20520 := Call(__e, __defun__shen_4incinfs)
 																									_ = reg20520
-																									reg20521 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																										reg20522 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																											reg20523 := __e.Call(__defun__shen_4lazyderef, Direction, V2753)
+																									reg20521 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																										reg20522 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																											reg20523 := Call(__e, __defun__shen_4lazyderef, Direction, V2753)
 																											reg20524 := MakeSymbol("in")
 																											reg20525 := MakeSymbol("out")
 																											reg20526 := Nil
 																											reg20527 := PrimCons(reg20525, reg20526)
 																											reg20528 := PrimCons(reg20524, reg20527)
-																											reg20529 := __e.Call(__defun__element_2, reg20523, reg20528)
-																											reg20530 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																											reg20529 := Call(__e, __defun__element_2, reg20523, reg20528)
+																											reg20530 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																												reg20531 := MakeSymbol("string")
-																												__ctx.TailApply(__defun__shen_4th_d, FileName, reg20531, V2752, V2753, V2754)
+																												__e.TailApply(__defun__shen_4th_d, FileName, reg20531, V2752, V2753, V2754)
 																												return
 																											}, 0)
-																											__ctx.TailApply(__defun__fwhen, reg20529, V2753, reg20530)
+																											__e.TailApply(__defun__fwhen, reg20529, V2753, reg20530)
 																											return
 																										}, 0)
-																										__ctx.TailApply(__defun__cut, Throwcontrol, V2753, reg20522)
+																										__e.TailApply(__defun__cut, Throwcontrol, V2753, reg20522)
 																										return
 																									}, 0)
-																									reg20535 := __e.Call(__defun__unify_b, Direction, Direction2581, V2753, reg20521)
+																									reg20535 := Call(__e, __defun__unify_b, Direction, Direction2581, V2753, reg20521)
 																									Result := reg20535
 																									_ = Result
-																									reg20536 := __e.Call(__defun__shen_4unbindv, V2658, V2753)
+																									reg20536 := Call(__e, __defun__shen_4unbindv, V2658, V2753)
 																									_ = reg20536
 																									reg20538 = Result
 																								} else {
@@ -2924,42 +2924,42 @@ func init() {
 																							}
 																							reg20564 = reg20539
 																						} else {
-																							reg20540 := __e.Call(__defun__shen_4pvar_2, V2657)
+																							reg20540 := Call(__e, __defun__shen_4pvar_2, V2657)
 																							var reg20563 Obj
 																							if reg20540 == True {
-																								reg20541 := __e.Call(__defun__shen_4newpv, V2753)
+																								reg20541 := Call(__e, __defun__shen_4newpv, V2753)
 																								Direction := reg20541
 																								_ = Direction
 																								reg20542 := Nil
 																								reg20543 := PrimCons(Direction, reg20542)
-																								reg20544 := __e.Call(__defun__shen_4bindv, V2657, reg20543, V2753)
+																								reg20544 := Call(__e, __defun__shen_4bindv, V2657, reg20543, V2753)
 																								_ = reg20544
-																								reg20545 := __e.Call(__defun__shen_4incinfs)
+																								reg20545 := Call(__e, __defun__shen_4incinfs)
 																								_ = reg20545
-																								reg20546 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																									reg20547 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																										reg20548 := __e.Call(__defun__shen_4lazyderef, Direction, V2753)
+																								reg20546 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																									reg20547 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																										reg20548 := Call(__e, __defun__shen_4lazyderef, Direction, V2753)
 																										reg20549 := MakeSymbol("in")
 																										reg20550 := MakeSymbol("out")
 																										reg20551 := Nil
 																										reg20552 := PrimCons(reg20550, reg20551)
 																										reg20553 := PrimCons(reg20549, reg20552)
-																										reg20554 := __e.Call(__defun__element_2, reg20548, reg20553)
-																										reg20555 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																										reg20554 := Call(__e, __defun__element_2, reg20548, reg20553)
+																										reg20555 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																											reg20556 := MakeSymbol("string")
-																											__ctx.TailApply(__defun__shen_4th_d, FileName, reg20556, V2752, V2753, V2754)
+																											__e.TailApply(__defun__shen_4th_d, FileName, reg20556, V2752, V2753, V2754)
 																											return
 																										}, 0)
-																										__ctx.TailApply(__defun__fwhen, reg20554, V2753, reg20555)
+																										__e.TailApply(__defun__fwhen, reg20554, V2753, reg20555)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__cut, Throwcontrol, V2753, reg20547)
+																									__e.TailApply(__defun__cut, Throwcontrol, V2753, reg20547)
 																									return
 																								}, 0)
-																								reg20560 := __e.Call(__defun__unify_b, Direction, Direction2581, V2753, reg20546)
+																								reg20560 := Call(__e, __defun__unify_b, Direction, Direction2581, V2753, reg20546)
 																								Result := reg20560
 																								_ = Result
-																								reg20561 := __e.Call(__defun__shen_4unbindv, V2657, V2753)
+																								reg20561 := Call(__e, __defun__shen_4unbindv, V2657, V2753)
 																								_ = reg20561
 																								reg20563 = Result
 																							} else {
@@ -2970,7 +2970,7 @@ func init() {
 																						}
 																						Result := reg20564
 																						_ = Result
-																						reg20565 := __e.Call(__defun__shen_4unbindv, V2654, V2753)
+																						reg20565 := Call(__e, __defun__shen_4unbindv, V2654, V2753)
 																						_ = reg20565
 																						reg20567 = Result
 																					} else {
@@ -2981,44 +2981,44 @@ func init() {
 																				}
 																				reg20595 = reg20568
 																			} else {
-																				reg20569 := __e.Call(__defun__shen_4pvar_2, V2653)
+																				reg20569 := Call(__e, __defun__shen_4pvar_2, V2653)
 																				var reg20594 Obj
 																				if reg20569 == True {
-																					reg20570 := __e.Call(__defun__shen_4newpv, V2753)
+																					reg20570 := Call(__e, __defun__shen_4newpv, V2753)
 																					Direction := reg20570
 																					_ = Direction
 																					reg20571 := MakeSymbol("stream")
 																					reg20572 := Nil
 																					reg20573 := PrimCons(Direction, reg20572)
 																					reg20574 := PrimCons(reg20571, reg20573)
-																					reg20575 := __e.Call(__defun__shen_4bindv, V2653, reg20574, V2753)
+																					reg20575 := Call(__e, __defun__shen_4bindv, V2653, reg20574, V2753)
 																					_ = reg20575
-																					reg20576 := __e.Call(__defun__shen_4incinfs)
+																					reg20576 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg20576
-																					reg20577 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																						reg20578 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																							reg20579 := __e.Call(__defun__shen_4lazyderef, Direction, V2753)
+																					reg20577 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																						reg20578 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																							reg20579 := Call(__e, __defun__shen_4lazyderef, Direction, V2753)
 																							reg20580 := MakeSymbol("in")
 																							reg20581 := MakeSymbol("out")
 																							reg20582 := Nil
 																							reg20583 := PrimCons(reg20581, reg20582)
 																							reg20584 := PrimCons(reg20580, reg20583)
-																							reg20585 := __e.Call(__defun__element_2, reg20579, reg20584)
-																							reg20586 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																							reg20585 := Call(__e, __defun__element_2, reg20579, reg20584)
+																							reg20586 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																								reg20587 := MakeSymbol("string")
-																								__ctx.TailApply(__defun__shen_4th_d, FileName, reg20587, V2752, V2753, V2754)
+																								__e.TailApply(__defun__shen_4th_d, FileName, reg20587, V2752, V2753, V2754)
 																								return
 																							}, 0)
-																							__ctx.TailApply(__defun__fwhen, reg20585, V2753, reg20586)
+																							__e.TailApply(__defun__fwhen, reg20585, V2753, reg20586)
 																							return
 																						}, 0)
-																						__ctx.TailApply(__defun__cut, Throwcontrol, V2753, reg20578)
+																						__e.TailApply(__defun__cut, Throwcontrol, V2753, reg20578)
 																						return
 																					}, 0)
-																					reg20591 := __e.Call(__defun__unify_b, Direction, Direction2581, V2753, reg20577)
+																					reg20591 := Call(__e, __defun__unify_b, Direction, Direction2581, V2753, reg20577)
 																					Result := reg20591
 																					_ = Result
-																					reg20592 := __e.Call(__defun__shen_4unbindv, V2653, V2753)
+																					reg20592 := Call(__e, __defun__shen_4unbindv, V2653, V2753)
 																					_ = reg20592
 																					reg20594 = Result
 																				} else {
@@ -3058,14 +3058,14 @@ func init() {
 														reg20607 := PrimEqual(Case, reg20606)
 														var reg20864 Obj
 														if reg20607 == True {
-															reg20608 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+															reg20608 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 															V2659 := reg20608
 															_ = V2659
 															reg20609 := PrimIsPair(V2659)
 															var reg20641 Obj
 															if reg20609 == True {
 																reg20610 := PrimHead(V2659)
-																reg20611 := __e.Call(__defun__shen_4lazyderef, reg20610, V2753)
+																reg20611 := Call(__e, __defun__shen_4lazyderef, reg20610, V2753)
 																V2660 := reg20611
 																_ = V2660
 																reg20612 := MakeSymbol("type")
@@ -3073,7 +3073,7 @@ func init() {
 																var reg20639 Obj
 																if reg20613 == True {
 																	reg20614 := PrimTail(V2659)
-																	reg20615 := __e.Call(__defun__shen_4lazyderef, reg20614, V2753)
+																	reg20615 := Call(__e, __defun__shen_4lazyderef, reg20614, V2753)
 																	V2661 := reg20615
 																	_ = V2661
 																	reg20616 := PrimIsPair(V2661)
@@ -3083,7 +3083,7 @@ func init() {
 																		X := reg20617
 																		_ = X
 																		reg20618 := PrimTail(V2661)
-																		reg20619 := __e.Call(__defun__shen_4lazyderef, reg20618, V2753)
+																		reg20619 := Call(__e, __defun__shen_4lazyderef, reg20618, V2753)
 																		V2662 := reg20619
 																		_ = V2662
 																		reg20620 := PrimIsPair(V2662)
@@ -3093,24 +3093,24 @@ func init() {
 																			A := reg20621
 																			_ = A
 																			reg20622 := PrimTail(V2662)
-																			reg20623 := __e.Call(__defun__shen_4lazyderef, reg20622, V2753)
+																			reg20623 := Call(__e, __defun__shen_4lazyderef, reg20622, V2753)
 																			V2663 := reg20623
 																			_ = V2663
 																			reg20624 := Nil
 																			reg20625 := PrimEqual(reg20624, V2663)
 																			var reg20633 Obj
 																			if reg20625 == True {
-																				reg20626 := __e.Call(__defun__shen_4incinfs)
+																				reg20626 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg20626
-																				reg20627 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																					reg20628 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																						__ctx.TailApply(__defun__shen_4th_d, X, A, V2752, V2753, V2754)
+																				reg20627 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																					reg20628 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																						__e.TailApply(__defun__shen_4th_d, X, A, V2752, V2753, V2754)
 																						return
 																					}, 0)
-																					__ctx.TailApply(__defun__unify, A, V2751, V2753, reg20628)
+																					__e.TailApply(__defun__unify, A, V2751, V2753, reg20628)
 																					return
 																				}, 0)
-																				reg20631 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20627)
+																				reg20631 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20627)
 																				reg20633 = reg20631
 																			} else {
 																				reg20632 := False
@@ -3142,14 +3142,14 @@ func init() {
 															reg20643 := PrimEqual(Case, reg20642)
 															var reg20863 Obj
 															if reg20643 == True {
-																reg20644 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+																reg20644 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 																V2664 := reg20644
 																_ = V2664
 																reg20645 := PrimIsPair(V2664)
 																var reg20685 Obj
 																if reg20645 == True {
 																	reg20646 := PrimHead(V2664)
-																	reg20647 := __e.Call(__defun__shen_4lazyderef, reg20646, V2753)
+																	reg20647 := Call(__e, __defun__shen_4lazyderef, reg20646, V2753)
 																	V2665 := reg20647
 																	_ = V2665
 																	reg20648 := MakeSymbol("input+")
@@ -3157,7 +3157,7 @@ func init() {
 																	var reg20683 Obj
 																	if reg20649 == True {
 																		reg20650 := PrimTail(V2664)
-																		reg20651 := __e.Call(__defun__shen_4lazyderef, reg20650, V2753)
+																		reg20651 := Call(__e, __defun__shen_4lazyderef, reg20650, V2753)
 																		V2666 := reg20651
 																		_ = V2666
 																		reg20652 := PrimIsPair(V2666)
@@ -3167,7 +3167,7 @@ func init() {
 																			A := reg20653
 																			_ = A
 																			reg20654 := PrimTail(V2666)
-																			reg20655 := __e.Call(__defun__shen_4lazyderef, reg20654, V2753)
+																			reg20655 := Call(__e, __defun__shen_4lazyderef, reg20654, V2753)
 																			V2667 := reg20655
 																			_ = V2667
 																			reg20656 := PrimIsPair(V2667)
@@ -3177,34 +3177,34 @@ func init() {
 																				Stream := reg20657
 																				_ = Stream
 																				reg20658 := PrimTail(V2667)
-																				reg20659 := __e.Call(__defun__shen_4lazyderef, reg20658, V2753)
+																				reg20659 := Call(__e, __defun__shen_4lazyderef, reg20658, V2753)
 																				V2668 := reg20659
 																				_ = V2668
 																				reg20660 := Nil
 																				reg20661 := PrimEqual(reg20660, V2668)
 																				var reg20677 Obj
 																				if reg20661 == True {
-																					reg20662 := __e.Call(__defun__shen_4newpv, V2753)
+																					reg20662 := Call(__e, __defun__shen_4newpv, V2753)
 																					C := reg20662
 																					_ = C
-																					reg20663 := __e.Call(__defun__shen_4incinfs)
+																					reg20663 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg20663
-																					reg20664 := __e.Call(__defun__shen_4lazyderef, A, V2753)
-																					reg20665 := __e.Call(__defun__shen_4demodulate, reg20664)
-																					reg20666 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																						reg20667 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																					reg20664 := Call(__e, __defun__shen_4lazyderef, A, V2753)
+																					reg20665 := Call(__e, __defun__shen_4demodulate, reg20664)
+																					reg20666 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																						reg20667 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																							reg20668 := MakeSymbol("stream")
 																							reg20669 := MakeSymbol("in")
 																							reg20670 := Nil
 																							reg20671 := PrimCons(reg20669, reg20670)
 																							reg20672 := PrimCons(reg20668, reg20671)
-																							__ctx.TailApply(__defun__shen_4th_d, Stream, reg20672, V2752, V2753, V2754)
+																							__e.TailApply(__defun__shen_4th_d, Stream, reg20672, V2752, V2753, V2754)
 																							return
 																						}, 0)
-																						__ctx.TailApply(__defun__unify, V2751, C, V2753, reg20667)
+																						__e.TailApply(__defun__unify, V2751, C, V2753, reg20667)
 																						return
 																					}, 0)
-																					reg20675 := __e.Call(__defun__bind, C, reg20665, V2753, reg20666)
+																					reg20675 := Call(__e, __defun__bind, C, reg20665, V2753, reg20666)
 																					reg20677 = reg20675
 																				} else {
 																					reg20676 := False
@@ -3236,14 +3236,14 @@ func init() {
 																reg20687 := PrimEqual(Case, reg20686)
 																var reg20862 Obj
 																if reg20687 == True {
-																	reg20688 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+																	reg20688 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 																	V2669 := reg20688
 																	_ = V2669
 																	reg20689 := PrimIsPair(V2669)
 																	var reg20730 Obj
 																	if reg20689 == True {
 																		reg20690 := PrimHead(V2669)
-																		reg20691 := __e.Call(__defun__shen_4lazyderef, reg20690, V2753)
+																		reg20691 := Call(__e, __defun__shen_4lazyderef, reg20690, V2753)
 																		V2670 := reg20691
 																		_ = V2670
 																		reg20692 := MakeSymbol("set")
@@ -3251,7 +3251,7 @@ func init() {
 																		var reg20728 Obj
 																		if reg20693 == True {
 																			reg20694 := PrimTail(V2669)
-																			reg20695 := __e.Call(__defun__shen_4lazyderef, reg20694, V2753)
+																			reg20695 := Call(__e, __defun__shen_4lazyderef, reg20694, V2753)
 																			V2671 := reg20695
 																			_ = V2671
 																			reg20696 := PrimIsPair(V2671)
@@ -3261,7 +3261,7 @@ func init() {
 																				Var := reg20697
 																				_ = Var
 																				reg20698 := PrimTail(V2671)
-																				reg20699 := __e.Call(__defun__shen_4lazyderef, reg20698, V2753)
+																				reg20699 := Call(__e, __defun__shen_4lazyderef, reg20698, V2753)
 																				V2672 := reg20699
 																				_ = V2672
 																				reg20700 := PrimIsPair(V2672)
@@ -3271,37 +3271,37 @@ func init() {
 																					Val := reg20701
 																					_ = Val
 																					reg20702 := PrimTail(V2672)
-																					reg20703 := __e.Call(__defun__shen_4lazyderef, reg20702, V2753)
+																					reg20703 := Call(__e, __defun__shen_4lazyderef, reg20702, V2753)
 																					V2673 := reg20703
 																					_ = V2673
 																					reg20704 := Nil
 																					reg20705 := PrimEqual(reg20704, V2673)
 																					var reg20722 Obj
 																					if reg20705 == True {
-																						reg20706 := __e.Call(__defun__shen_4incinfs)
+																						reg20706 := Call(__e, __defun__shen_4incinfs)
 																						_ = reg20706
-																						reg20707 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																						reg20707 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																							reg20708 := MakeSymbol("symbol")
-																							reg20709 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																								reg20710 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																							reg20709 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																								reg20710 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																									reg20711 := MakeSymbol("value")
 																									reg20712 := Nil
 																									reg20713 := PrimCons(Var, reg20712)
 																									reg20714 := PrimCons(reg20711, reg20713)
-																									reg20715 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																										__ctx.TailApply(__defun__shen_4th_d, Val, V2751, V2752, V2753, V2754)
+																									reg20715 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																										__e.TailApply(__defun__shen_4th_d, Val, V2751, V2752, V2753, V2754)
 																										return
 																									}, 0)
-																									__ctx.TailApply(__defun__shen_4th_d, reg20714, V2751, V2752, V2753, reg20715)
+																									__e.TailApply(__defun__shen_4th_d, reg20714, V2751, V2752, V2753, reg20715)
 																									return
 																								}, 0)
-																								__ctx.TailApply(__defun__cut, Throwcontrol, V2753, reg20710)
+																								__e.TailApply(__defun__cut, Throwcontrol, V2753, reg20710)
 																								return
 																							}, 0)
-																							__ctx.TailApply(__defun__shen_4th_d, Var, reg20708, V2752, V2753, reg20709)
+																							__e.TailApply(__defun__shen_4th_d, Var, reg20708, V2752, V2753, reg20709)
 																							return
 																						}, 0)
-																						reg20720 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20707)
+																						reg20720 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20707)
 																						reg20722 = reg20720
 																					} else {
 																						reg20721 := False
@@ -3333,30 +3333,30 @@ func init() {
 																	reg20732 := PrimEqual(Case, reg20731)
 																	var reg20861 Obj
 																	if reg20732 == True {
-																		reg20733 := __e.Call(__defun__shen_4newpv, V2753)
+																		reg20733 := Call(__e, __defun__shen_4newpv, V2753)
 																		NewHyp := reg20733
 																		_ = NewHyp
-																		reg20734 := __e.Call(__defun__shen_4incinfs)
+																		reg20734 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg20734
-																		reg20735 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-																			__ctx.TailApply(__defun__shen_4th_d, V2750, V2751, NewHyp, V2753, V2754)
+																		reg20735 := MakeNative(func(__e Evaluator, __args ...Obj) {
+																			__e.TailApply(__defun__shen_4th_d, V2750, V2751, NewHyp, V2753, V2754)
 																			return
 																		}, 0)
-																		reg20737 := __e.Call(__defun__shen_4t_d_1hyps, V2752, NewHyp, V2753, reg20735)
+																		reg20737 := Call(__e, __defun__shen_4t_d_1hyps, V2752, NewHyp, V2753, reg20735)
 																		Case := reg20737
 																		_ = Case
 																		reg20738 := False
 																		reg20739 := PrimEqual(Case, reg20738)
 																		var reg20860 Obj
 																		if reg20739 == True {
-																			reg20740 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+																			reg20740 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 																			V2674 := reg20740
 																			_ = V2674
 																			reg20741 := PrimIsPair(V2674)
 																			var reg20763 Obj
 																			if reg20741 == True {
 																				reg20742 := PrimHead(V2674)
-																				reg20743 := __e.Call(__defun__shen_4lazyderef, reg20742, V2753)
+																				reg20743 := Call(__e, __defun__shen_4lazyderef, reg20742, V2753)
 																				V2675 := reg20743
 																				_ = V2675
 																				reg20744 := MakeSymbol("define")
@@ -3364,7 +3364,7 @@ func init() {
 																				var reg20761 Obj
 																				if reg20745 == True {
 																					reg20746 := PrimTail(V2674)
-																					reg20747 := __e.Call(__defun__shen_4lazyderef, reg20746, V2753)
+																					reg20747 := Call(__e, __defun__shen_4lazyderef, reg20746, V2753)
 																					V2676 := reg20747
 																					_ = V2676
 																					reg20748 := PrimIsPair(V2676)
@@ -3376,16 +3376,16 @@ func init() {
 																						reg20750 := PrimTail(V2676)
 																						X := reg20750
 																						_ = X
-																						reg20751 := __e.Call(__defun__shen_4incinfs)
+																						reg20751 := Call(__e, __defun__shen_4incinfs)
 																						_ = reg20751
-																						reg20752 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																						reg20752 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																							reg20753 := MakeSymbol("define")
 																							reg20754 := PrimCons(F, X)
 																							reg20755 := PrimCons(reg20753, reg20754)
-																							__ctx.TailApply(__defun__shen_4t_d_1def, reg20755, V2751, V2752, V2753, V2754)
+																							__e.TailApply(__defun__shen_4t_d_1def, reg20755, V2751, V2752, V2753, V2754)
 																							return
 																						}, 0)
-																						reg20757 := __e.Call(__defun__cut, Throwcontrol, V2753, reg20752)
+																						reg20757 := Call(__e, __defun__cut, Throwcontrol, V2753, reg20752)
 																						reg20759 = reg20757
 																					} else {
 																						reg20758 := False
@@ -3407,44 +3407,44 @@ func init() {
 																			reg20765 := PrimEqual(Case, reg20764)
 																			var reg20859 Obj
 																			if reg20765 == True {
-																				reg20766 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+																				reg20766 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 																				V2677 := reg20766
 																				_ = V2677
 																				reg20767 := PrimIsPair(V2677)
 																				var reg20789 Obj
 																				if reg20767 == True {
 																					reg20768 := PrimHead(V2677)
-																					reg20769 := __e.Call(__defun__shen_4lazyderef, reg20768, V2753)
+																					reg20769 := Call(__e, __defun__shen_4lazyderef, reg20768, V2753)
 																					V2678 := reg20769
 																					_ = V2678
 																					reg20770 := MakeSymbol("defmacro")
 																					reg20771 := PrimEqual(reg20770, V2678)
 																					var reg20787 Obj
 																					if reg20771 == True {
-																						reg20772 := __e.Call(__defun__shen_4lazyderef, V2751, V2753)
+																						reg20772 := Call(__e, __defun__shen_4lazyderef, V2751, V2753)
 																						V2679 := reg20772
 																						_ = V2679
 																						reg20773 := MakeSymbol("unit")
 																						reg20774 := PrimEqual(reg20773, V2679)
 																						var reg20785 Obj
 																						if reg20774 == True {
-																							reg20775 := __e.Call(__defun__shen_4incinfs)
+																							reg20775 := Call(__e, __defun__shen_4incinfs)
 																							_ = reg20775
-																							reg20776 := __e.Call(__defun__cut, Throwcontrol, V2753, V2754)
+																							reg20776 := Call(__e, __defun__cut, Throwcontrol, V2753, V2754)
 																							reg20785 = reg20776
 																						} else {
-																							reg20777 := __e.Call(__defun__shen_4pvar_2, V2679)
+																							reg20777 := Call(__e, __defun__shen_4pvar_2, V2679)
 																							var reg20784 Obj
 																							if reg20777 == True {
 																								reg20778 := MakeSymbol("unit")
-																								reg20779 := __e.Call(__defun__shen_4bindv, V2679, reg20778, V2753)
+																								reg20779 := Call(__e, __defun__shen_4bindv, V2679, reg20778, V2753)
 																								_ = reg20779
-																								reg20780 := __e.Call(__defun__shen_4incinfs)
+																								reg20780 := Call(__e, __defun__shen_4incinfs)
 																								_ = reg20780
-																								reg20781 := __e.Call(__defun__cut, Throwcontrol, V2753, V2754)
+																								reg20781 := Call(__e, __defun__cut, Throwcontrol, V2753, V2754)
 																								Result := reg20781
 																								_ = Result
-																								reg20782 := __e.Call(__defun__shen_4unbindv, V2679, V2753)
+																								reg20782 := Call(__e, __defun__shen_4unbindv, V2679, V2753)
 																								_ = reg20782
 																								reg20784 = Result
 																							} else {
@@ -3469,44 +3469,44 @@ func init() {
 																				reg20791 := PrimEqual(Case, reg20790)
 																				var reg20858 Obj
 																				if reg20791 == True {
-																					reg20792 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+																					reg20792 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 																					V2680 := reg20792
 																					_ = V2680
 																					reg20793 := PrimIsPair(V2680)
 																					var reg20815 Obj
 																					if reg20793 == True {
 																						reg20794 := PrimHead(V2680)
-																						reg20795 := __e.Call(__defun__shen_4lazyderef, reg20794, V2753)
+																						reg20795 := Call(__e, __defun__shen_4lazyderef, reg20794, V2753)
 																						V2681 := reg20795
 																						_ = V2681
 																						reg20796 := MakeSymbol("shen.process-datatype")
 																						reg20797 := PrimEqual(reg20796, V2681)
 																						var reg20813 Obj
 																						if reg20797 == True {
-																							reg20798 := __e.Call(__defun__shen_4lazyderef, V2751, V2753)
+																							reg20798 := Call(__e, __defun__shen_4lazyderef, V2751, V2753)
 																							V2682 := reg20798
 																							_ = V2682
 																							reg20799 := MakeSymbol("symbol")
 																							reg20800 := PrimEqual(reg20799, V2682)
 																							var reg20811 Obj
 																							if reg20800 == True {
-																								reg20801 := __e.Call(__defun__shen_4incinfs)
+																								reg20801 := Call(__e, __defun__shen_4incinfs)
 																								_ = reg20801
-																								reg20802 := __e.Call(__defun__thaw, V2754)
+																								reg20802 := Call(__e, __defun__thaw, V2754)
 																								reg20811 = reg20802
 																							} else {
-																								reg20803 := __e.Call(__defun__shen_4pvar_2, V2682)
+																								reg20803 := Call(__e, __defun__shen_4pvar_2, V2682)
 																								var reg20810 Obj
 																								if reg20803 == True {
 																									reg20804 := MakeSymbol("symbol")
-																									reg20805 := __e.Call(__defun__shen_4bindv, V2682, reg20804, V2753)
+																									reg20805 := Call(__e, __defun__shen_4bindv, V2682, reg20804, V2753)
 																									_ = reg20805
-																									reg20806 := __e.Call(__defun__shen_4incinfs)
+																									reg20806 := Call(__e, __defun__shen_4incinfs)
 																									_ = reg20806
-																									reg20807 := __e.Call(__defun__thaw, V2754)
+																									reg20807 := Call(__e, __defun__thaw, V2754)
 																									Result := reg20807
 																									_ = Result
-																									reg20808 := __e.Call(__defun__shen_4unbindv, V2682, V2753)
+																									reg20808 := Call(__e, __defun__shen_4unbindv, V2682, V2753)
 																									_ = reg20808
 																									reg20810 = Result
 																								} else {
@@ -3531,44 +3531,44 @@ func init() {
 																					reg20817 := PrimEqual(Case, reg20816)
 																					var reg20857 Obj
 																					if reg20817 == True {
-																						reg20818 := __e.Call(__defun__shen_4lazyderef, V2750, V2753)
+																						reg20818 := Call(__e, __defun__shen_4lazyderef, V2750, V2753)
 																						V2683 := reg20818
 																						_ = V2683
 																						reg20819 := PrimIsPair(V2683)
 																						var reg20841 Obj
 																						if reg20819 == True {
 																							reg20820 := PrimHead(V2683)
-																							reg20821 := __e.Call(__defun__shen_4lazyderef, reg20820, V2753)
+																							reg20821 := Call(__e, __defun__shen_4lazyderef, reg20820, V2753)
 																							V2684 := reg20821
 																							_ = V2684
 																							reg20822 := MakeSymbol("shen.synonyms-help")
 																							reg20823 := PrimEqual(reg20822, V2684)
 																							var reg20839 Obj
 																							if reg20823 == True {
-																								reg20824 := __e.Call(__defun__shen_4lazyderef, V2751, V2753)
+																								reg20824 := Call(__e, __defun__shen_4lazyderef, V2751, V2753)
 																								V2685 := reg20824
 																								_ = V2685
 																								reg20825 := MakeSymbol("symbol")
 																								reg20826 := PrimEqual(reg20825, V2685)
 																								var reg20837 Obj
 																								if reg20826 == True {
-																									reg20827 := __e.Call(__defun__shen_4incinfs)
+																									reg20827 := Call(__e, __defun__shen_4incinfs)
 																									_ = reg20827
-																									reg20828 := __e.Call(__defun__thaw, V2754)
+																									reg20828 := Call(__e, __defun__thaw, V2754)
 																									reg20837 = reg20828
 																								} else {
-																									reg20829 := __e.Call(__defun__shen_4pvar_2, V2685)
+																									reg20829 := Call(__e, __defun__shen_4pvar_2, V2685)
 																									var reg20836 Obj
 																									if reg20829 == True {
 																										reg20830 := MakeSymbol("symbol")
-																										reg20831 := __e.Call(__defun__shen_4bindv, V2685, reg20830, V2753)
+																										reg20831 := Call(__e, __defun__shen_4bindv, V2685, reg20830, V2753)
 																										_ = reg20831
-																										reg20832 := __e.Call(__defun__shen_4incinfs)
+																										reg20832 := Call(__e, __defun__shen_4incinfs)
 																										_ = reg20832
-																										reg20833 := __e.Call(__defun__thaw, V2754)
+																										reg20833 := Call(__e, __defun__thaw, V2754)
 																										Result := reg20833
 																										_ = Result
-																										reg20834 := __e.Call(__defun__shen_4unbindv, V2685, V2753)
+																										reg20834 := Call(__e, __defun__shen_4unbindv, V2685, V2753)
 																										_ = reg20834
 																										reg20836 = Result
 																									} else {
@@ -3593,23 +3593,23 @@ func init() {
 																						reg20843 := PrimEqual(Case, reg20842)
 																						var reg20856 Obj
 																						if reg20843 == True {
-																							reg20844 := __e.Call(__defun__shen_4newpv, V2753)
+																							reg20844 := Call(__e, __defun__shen_4newpv, V2753)
 																							Datatypes := reg20844
 																							_ = Datatypes
-																							reg20845 := __e.Call(__defun__shen_4incinfs)
+																							reg20845 := Call(__e, __defun__shen_4incinfs)
 																							_ = reg20845
 																							reg20846 := MakeSymbol("shen.*datatypes*")
 																							reg20847 := PrimValue(reg20846)
-																							reg20848 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+																							reg20848 := MakeNative(func(__e Evaluator, __args ...Obj) {
 																								reg20849 := MakeSymbol(":")
 																								reg20850 := Nil
 																								reg20851 := PrimCons(V2751, reg20850)
 																								reg20852 := PrimCons(reg20849, reg20851)
 																								reg20853 := PrimCons(V2750, reg20852)
-																								__ctx.TailApply(__defun__shen_4udefs_d, reg20853, V2752, Datatypes, V2753, V2754)
+																								__e.TailApply(__defun__shen_4udefs_d, reg20853, V2752, Datatypes, V2753, V2754)
 																								return
 																							}, 0)
-																							reg20855 := __e.Call(__defun__bind, Datatypes, reg20847, V2753, reg20848)
+																							reg20855 := Call(__e, __defun__bind, Datatypes, reg20847, V2753, reg20848)
 																							reg20856 = reg20855
 																						} else {
 																							reg20856 = Case
@@ -3694,12 +3694,12 @@ func init() {
 		} else {
 			reg20876 = Case
 		}
-		__ctx.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg20876)
+		__e.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg20876)
 		return
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.th*", value: __defun__shen_4th_d})
 
-	__defun__shen_4t_d_1hyps = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4t_d_1hyps = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2759 := __args[0]
 		_ = V2759
 		V2760 := __args[1]
@@ -3708,28 +3708,28 @@ func init() {
 		_ = V2761
 		V2762 := __args[3]
 		_ = V2762
-		reg20878 := __e.Call(__defun__shen_4lazyderef, V2759, V2761)
+		reg20878 := Call(__e, __defun__shen_4lazyderef, V2759, V2761)
 		V2496 := reg20878
 		_ = V2496
 		reg20879 := PrimIsPair(V2496)
 		var reg21417 Obj
 		if reg20879 == True {
 			reg20880 := PrimHead(V2496)
-			reg20881 := __e.Call(__defun__shen_4lazyderef, reg20880, V2761)
+			reg20881 := Call(__e, __defun__shen_4lazyderef, reg20880, V2761)
 			V2497 := reg20881
 			_ = V2497
 			reg20882 := PrimIsPair(V2497)
 			var reg21415 Obj
 			if reg20882 == True {
 				reg20883 := PrimHead(V2497)
-				reg20884 := __e.Call(__defun__shen_4lazyderef, reg20883, V2761)
+				reg20884 := Call(__e, __defun__shen_4lazyderef, reg20883, V2761)
 				V2498 := reg20884
 				_ = V2498
 				reg20885 := PrimIsPair(V2498)
 				var reg21413 Obj
 				if reg20885 == True {
 					reg20886 := PrimHead(V2498)
-					reg20887 := __e.Call(__defun__shen_4lazyderef, reg20886, V2761)
+					reg20887 := Call(__e, __defun__shen_4lazyderef, reg20886, V2761)
 					V2499 := reg20887
 					_ = V2499
 					reg20888 := MakeSymbol("cons")
@@ -3737,7 +3737,7 @@ func init() {
 					var reg21411 Obj
 					if reg20889 == True {
 						reg20890 := PrimTail(V2498)
-						reg20891 := __e.Call(__defun__shen_4lazyderef, reg20890, V2761)
+						reg20891 := Call(__e, __defun__shen_4lazyderef, reg20890, V2761)
 						V2500 := reg20891
 						_ = V2500
 						reg20892 := PrimIsPair(V2500)
@@ -3747,7 +3747,7 @@ func init() {
 							X := reg20893
 							_ = X
 							reg20894 := PrimTail(V2500)
-							reg20895 := __e.Call(__defun__shen_4lazyderef, reg20894, V2761)
+							reg20895 := Call(__e, __defun__shen_4lazyderef, reg20894, V2761)
 							V2501 := reg20895
 							_ = V2501
 							reg20896 := PrimIsPair(V2501)
@@ -3757,7 +3757,7 @@ func init() {
 								Y := reg20897
 								_ = Y
 								reg20898 := PrimTail(V2501)
-								reg20899 := __e.Call(__defun__shen_4lazyderef, reg20898, V2761)
+								reg20899 := Call(__e, __defun__shen_4lazyderef, reg20898, V2761)
 								V2502 := reg20899
 								_ = V2502
 								reg20900 := Nil
@@ -3765,14 +3765,14 @@ func init() {
 								var reg21405 Obj
 								if reg20901 == True {
 									reg20902 := PrimTail(V2497)
-									reg20903 := __e.Call(__defun__shen_4lazyderef, reg20902, V2761)
+									reg20903 := Call(__e, __defun__shen_4lazyderef, reg20902, V2761)
 									V2503 := reg20903
 									_ = V2503
 									reg20904 := PrimIsPair(V2503)
 									var reg21403 Obj
 									if reg20904 == True {
 										reg20905 := PrimHead(V2503)
-										reg20906 := __e.Call(__defun__shen_4lazyderef, reg20905, V2761)
+										reg20906 := Call(__e, __defun__shen_4lazyderef, reg20905, V2761)
 										V2504 := reg20906
 										_ = V2504
 										reg20907 := MakeSymbol(":")
@@ -3780,21 +3780,21 @@ func init() {
 										var reg21401 Obj
 										if reg20908 == True {
 											reg20909 := PrimTail(V2503)
-											reg20910 := __e.Call(__defun__shen_4lazyderef, reg20909, V2761)
+											reg20910 := Call(__e, __defun__shen_4lazyderef, reg20909, V2761)
 											V2505 := reg20910
 											_ = V2505
 											reg20911 := PrimIsPair(V2505)
 											var reg21399 Obj
 											if reg20911 == True {
 												reg20912 := PrimHead(V2505)
-												reg20913 := __e.Call(__defun__shen_4lazyderef, reg20912, V2761)
+												reg20913 := Call(__e, __defun__shen_4lazyderef, reg20912, V2761)
 												V2506 := reg20913
 												_ = V2506
 												reg20914 := PrimIsPair(V2506)
 												var reg21397 Obj
 												if reg20914 == True {
 													reg20915 := PrimHead(V2506)
-													reg20916 := __e.Call(__defun__shen_4lazyderef, reg20915, V2761)
+													reg20916 := Call(__e, __defun__shen_4lazyderef, reg20915, V2761)
 													V2507 := reg20916
 													_ = V2507
 													reg20917 := MakeSymbol("list")
@@ -3802,7 +3802,7 @@ func init() {
 													var reg21327 Obj
 													if reg20918 == True {
 														reg20919 := PrimTail(V2506)
-														reg20920 := __e.Call(__defun__shen_4lazyderef, reg20919, V2761)
+														reg20920 := Call(__e, __defun__shen_4lazyderef, reg20919, V2761)
 														V2508 := reg20920
 														_ = V2508
 														reg20921 := PrimIsPair(V2508)
@@ -3812,7 +3812,7 @@ func init() {
 															A := reg20922
 															_ = A
 															reg20923 := PrimTail(V2508)
-															reg20924 := __e.Call(__defun__shen_4lazyderef, reg20923, V2761)
+															reg20924 := Call(__e, __defun__shen_4lazyderef, reg20923, V2761)
 															V2509 := reg20924
 															_ = V2509
 															reg20925 := Nil
@@ -3820,7 +3820,7 @@ func init() {
 															var reg21051 Obj
 															if reg20926 == True {
 																reg20927 := PrimTail(V2505)
-																reg20928 := __e.Call(__defun__shen_4lazyderef, reg20927, V2761)
+																reg20928 := Call(__e, __defun__shen_4lazyderef, reg20927, V2761)
 																V2510 := reg20928
 																_ = V2510
 																reg20929 := Nil
@@ -3830,19 +3830,19 @@ func init() {
 																	reg20931 := PrimTail(V2496)
 																	Hyp := reg20931
 																	_ = Hyp
-																	reg20932 := __e.Call(__defun__shen_4incinfs)
+																	reg20932 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg20932
-																	reg20933 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																	reg20933 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																	reg20934 := MakeSymbol(":")
-																	reg20935 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																	reg20935 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																	reg20936 := Nil
 																	reg20937 := PrimCons(reg20935, reg20936)
 																	reg20938 := PrimCons(reg20934, reg20937)
 																	reg20939 := PrimCons(reg20933, reg20938)
-																	reg20940 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																	reg20940 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																	reg20941 := MakeSymbol(":")
 																	reg20942 := MakeSymbol("list")
-																	reg20943 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																	reg20943 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																	reg20944 := Nil
 																	reg20945 := PrimCons(reg20943, reg20944)
 																	reg20946 := PrimCons(reg20942, reg20945)
@@ -3850,34 +3850,34 @@ func init() {
 																	reg20948 := PrimCons(reg20946, reg20947)
 																	reg20949 := PrimCons(reg20941, reg20948)
 																	reg20950 := PrimCons(reg20940, reg20949)
-																	reg20951 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																	reg20951 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																	reg20952 := PrimCons(reg20950, reg20951)
 																	reg20953 := PrimCons(reg20939, reg20952)
-																	reg20954 := __e.Call(__defun__bind, V2760, reg20953, V2761, V2762)
+																	reg20954 := Call(__e, __defun__bind, V2760, reg20953, V2761, V2762)
 																	reg20985 = reg20954
 																} else {
-																	reg20955 := __e.Call(__defun__shen_4pvar_2, V2510)
+																	reg20955 := Call(__e, __defun__shen_4pvar_2, V2510)
 																	var reg20984 Obj
 																	if reg20955 == True {
 																		reg20956 := Nil
-																		reg20957 := __e.Call(__defun__shen_4bindv, V2510, reg20956, V2761)
+																		reg20957 := Call(__e, __defun__shen_4bindv, V2510, reg20956, V2761)
 																		_ = reg20957
 																		reg20958 := PrimTail(V2496)
 																		Hyp := reg20958
 																		_ = Hyp
-																		reg20959 := __e.Call(__defun__shen_4incinfs)
+																		reg20959 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg20959
-																		reg20960 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																		reg20960 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																		reg20961 := MakeSymbol(":")
-																		reg20962 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg20962 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg20963 := Nil
 																		reg20964 := PrimCons(reg20962, reg20963)
 																		reg20965 := PrimCons(reg20961, reg20964)
 																		reg20966 := PrimCons(reg20960, reg20965)
-																		reg20967 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																		reg20967 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																		reg20968 := MakeSymbol(":")
 																		reg20969 := MakeSymbol("list")
-																		reg20970 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg20970 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg20971 := Nil
 																		reg20972 := PrimCons(reg20970, reg20971)
 																		reg20973 := PrimCons(reg20969, reg20972)
@@ -3885,13 +3885,13 @@ func init() {
 																		reg20975 := PrimCons(reg20973, reg20974)
 																		reg20976 := PrimCons(reg20968, reg20975)
 																		reg20977 := PrimCons(reg20967, reg20976)
-																		reg20978 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																		reg20978 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																		reg20979 := PrimCons(reg20977, reg20978)
 																		reg20980 := PrimCons(reg20966, reg20979)
-																		reg20981 := __e.Call(__defun__bind, V2760, reg20980, V2761, V2762)
+																		reg20981 := Call(__e, __defun__bind, V2760, reg20980, V2761, V2762)
 																		Result := reg20981
 																		_ = Result
-																		reg20982 := __e.Call(__defun__shen_4unbindv, V2510, V2761)
+																		reg20982 := Call(__e, __defun__shen_4unbindv, V2510, V2761)
 																		_ = reg20982
 																		reg20984 = Result
 																	} else {
@@ -3902,14 +3902,14 @@ func init() {
 																}
 																reg21051 = reg20985
 															} else {
-																reg20986 := __e.Call(__defun__shen_4pvar_2, V2509)
+																reg20986 := Call(__e, __defun__shen_4pvar_2, V2509)
 																var reg21050 Obj
 																if reg20986 == True {
 																	reg20987 := Nil
-																	reg20988 := __e.Call(__defun__shen_4bindv, V2509, reg20987, V2761)
+																	reg20988 := Call(__e, __defun__shen_4bindv, V2509, reg20987, V2761)
 																	_ = reg20988
 																	reg20989 := PrimTail(V2505)
-																	reg20990 := __e.Call(__defun__shen_4lazyderef, reg20989, V2761)
+																	reg20990 := Call(__e, __defun__shen_4lazyderef, reg20989, V2761)
 																	V2511 := reg20990
 																	_ = V2511
 																	reg20991 := Nil
@@ -3919,19 +3919,19 @@ func init() {
 																		reg20993 := PrimTail(V2496)
 																		Hyp := reg20993
 																		_ = Hyp
-																		reg20994 := __e.Call(__defun__shen_4incinfs)
+																		reg20994 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg20994
-																		reg20995 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																		reg20995 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																		reg20996 := MakeSymbol(":")
-																		reg20997 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg20997 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg20998 := Nil
 																		reg20999 := PrimCons(reg20997, reg20998)
 																		reg21000 := PrimCons(reg20996, reg20999)
 																		reg21001 := PrimCons(reg20995, reg21000)
-																		reg21002 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																		reg21002 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																		reg21003 := MakeSymbol(":")
 																		reg21004 := MakeSymbol("list")
-																		reg21005 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg21005 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg21006 := Nil
 																		reg21007 := PrimCons(reg21005, reg21006)
 																		reg21008 := PrimCons(reg21004, reg21007)
@@ -3939,34 +3939,34 @@ func init() {
 																		reg21010 := PrimCons(reg21008, reg21009)
 																		reg21011 := PrimCons(reg21003, reg21010)
 																		reg21012 := PrimCons(reg21002, reg21011)
-																		reg21013 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																		reg21013 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																		reg21014 := PrimCons(reg21012, reg21013)
 																		reg21015 := PrimCons(reg21001, reg21014)
-																		reg21016 := __e.Call(__defun__bind, V2760, reg21015, V2761, V2762)
+																		reg21016 := Call(__e, __defun__bind, V2760, reg21015, V2761, V2762)
 																		reg21047 = reg21016
 																	} else {
-																		reg21017 := __e.Call(__defun__shen_4pvar_2, V2511)
+																		reg21017 := Call(__e, __defun__shen_4pvar_2, V2511)
 																		var reg21046 Obj
 																		if reg21017 == True {
 																			reg21018 := Nil
-																			reg21019 := __e.Call(__defun__shen_4bindv, V2511, reg21018, V2761)
+																			reg21019 := Call(__e, __defun__shen_4bindv, V2511, reg21018, V2761)
 																			_ = reg21019
 																			reg21020 := PrimTail(V2496)
 																			Hyp := reg21020
 																			_ = Hyp
-																			reg21021 := __e.Call(__defun__shen_4incinfs)
+																			reg21021 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg21021
-																			reg21022 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																			reg21022 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																			reg21023 := MakeSymbol(":")
-																			reg21024 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21024 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21025 := Nil
 																			reg21026 := PrimCons(reg21024, reg21025)
 																			reg21027 := PrimCons(reg21023, reg21026)
 																			reg21028 := PrimCons(reg21022, reg21027)
-																			reg21029 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																			reg21029 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																			reg21030 := MakeSymbol(":")
 																			reg21031 := MakeSymbol("list")
-																			reg21032 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21032 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21033 := Nil
 																			reg21034 := PrimCons(reg21032, reg21033)
 																			reg21035 := PrimCons(reg21031, reg21034)
@@ -3974,13 +3974,13 @@ func init() {
 																			reg21037 := PrimCons(reg21035, reg21036)
 																			reg21038 := PrimCons(reg21030, reg21037)
 																			reg21039 := PrimCons(reg21029, reg21038)
-																			reg21040 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																			reg21040 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																			reg21041 := PrimCons(reg21039, reg21040)
 																			reg21042 := PrimCons(reg21028, reg21041)
-																			reg21043 := __e.Call(__defun__bind, V2760, reg21042, V2761, V2762)
+																			reg21043 := Call(__e, __defun__bind, V2760, reg21042, V2761, V2762)
 																			Result := reg21043
 																			_ = Result
-																			reg21044 := __e.Call(__defun__shen_4unbindv, V2511, V2761)
+																			reg21044 := Call(__e, __defun__shen_4unbindv, V2511, V2761)
 																			_ = reg21044
 																			reg21046 = Result
 																		} else {
@@ -3991,7 +3991,7 @@ func init() {
 																	}
 																	Result := reg21047
 																	_ = Result
-																	reg21048 := __e.Call(__defun__shen_4unbindv, V2509, V2761)
+																	reg21048 := Call(__e, __defun__shen_4unbindv, V2509, V2761)
 																	_ = reg21048
 																	reg21050 = Result
 																} else {
@@ -4002,18 +4002,18 @@ func init() {
 															}
 															reg21119 = reg21051
 														} else {
-															reg21052 := __e.Call(__defun__shen_4pvar_2, V2508)
+															reg21052 := Call(__e, __defun__shen_4pvar_2, V2508)
 															var reg21118 Obj
 															if reg21052 == True {
-																reg21053 := __e.Call(__defun__shen_4newpv, V2761)
+																reg21053 := Call(__e, __defun__shen_4newpv, V2761)
 																A := reg21053
 																_ = A
 																reg21054 := Nil
 																reg21055 := PrimCons(A, reg21054)
-																reg21056 := __e.Call(__defun__shen_4bindv, V2508, reg21055, V2761)
+																reg21056 := Call(__e, __defun__shen_4bindv, V2508, reg21055, V2761)
 																_ = reg21056
 																reg21057 := PrimTail(V2505)
-																reg21058 := __e.Call(__defun__shen_4lazyderef, reg21057, V2761)
+																reg21058 := Call(__e, __defun__shen_4lazyderef, reg21057, V2761)
 																V2512 := reg21058
 																_ = V2512
 																reg21059 := Nil
@@ -4023,19 +4023,19 @@ func init() {
 																	reg21061 := PrimTail(V2496)
 																	Hyp := reg21061
 																	_ = Hyp
-																	reg21062 := __e.Call(__defun__shen_4incinfs)
+																	reg21062 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg21062
-																	reg21063 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																	reg21063 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																	reg21064 := MakeSymbol(":")
-																	reg21065 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																	reg21065 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																	reg21066 := Nil
 																	reg21067 := PrimCons(reg21065, reg21066)
 																	reg21068 := PrimCons(reg21064, reg21067)
 																	reg21069 := PrimCons(reg21063, reg21068)
-																	reg21070 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																	reg21070 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																	reg21071 := MakeSymbol(":")
 																	reg21072 := MakeSymbol("list")
-																	reg21073 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																	reg21073 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																	reg21074 := Nil
 																	reg21075 := PrimCons(reg21073, reg21074)
 																	reg21076 := PrimCons(reg21072, reg21075)
@@ -4043,34 +4043,34 @@ func init() {
 																	reg21078 := PrimCons(reg21076, reg21077)
 																	reg21079 := PrimCons(reg21071, reg21078)
 																	reg21080 := PrimCons(reg21070, reg21079)
-																	reg21081 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																	reg21081 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																	reg21082 := PrimCons(reg21080, reg21081)
 																	reg21083 := PrimCons(reg21069, reg21082)
-																	reg21084 := __e.Call(__defun__bind, V2760, reg21083, V2761, V2762)
+																	reg21084 := Call(__e, __defun__bind, V2760, reg21083, V2761, V2762)
 																	reg21115 = reg21084
 																} else {
-																	reg21085 := __e.Call(__defun__shen_4pvar_2, V2512)
+																	reg21085 := Call(__e, __defun__shen_4pvar_2, V2512)
 																	var reg21114 Obj
 																	if reg21085 == True {
 																		reg21086 := Nil
-																		reg21087 := __e.Call(__defun__shen_4bindv, V2512, reg21086, V2761)
+																		reg21087 := Call(__e, __defun__shen_4bindv, V2512, reg21086, V2761)
 																		_ = reg21087
 																		reg21088 := PrimTail(V2496)
 																		Hyp := reg21088
 																		_ = Hyp
-																		reg21089 := __e.Call(__defun__shen_4incinfs)
+																		reg21089 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg21089
-																		reg21090 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																		reg21090 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																		reg21091 := MakeSymbol(":")
-																		reg21092 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg21092 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg21093 := Nil
 																		reg21094 := PrimCons(reg21092, reg21093)
 																		reg21095 := PrimCons(reg21091, reg21094)
 																		reg21096 := PrimCons(reg21090, reg21095)
-																		reg21097 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																		reg21097 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																		reg21098 := MakeSymbol(":")
 																		reg21099 := MakeSymbol("list")
-																		reg21100 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg21100 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg21101 := Nil
 																		reg21102 := PrimCons(reg21100, reg21101)
 																		reg21103 := PrimCons(reg21099, reg21102)
@@ -4078,13 +4078,13 @@ func init() {
 																		reg21105 := PrimCons(reg21103, reg21104)
 																		reg21106 := PrimCons(reg21098, reg21105)
 																		reg21107 := PrimCons(reg21097, reg21106)
-																		reg21108 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																		reg21108 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																		reg21109 := PrimCons(reg21107, reg21108)
 																		reg21110 := PrimCons(reg21096, reg21109)
-																		reg21111 := __e.Call(__defun__bind, V2760, reg21110, V2761, V2762)
+																		reg21111 := Call(__e, __defun__bind, V2760, reg21110, V2761, V2762)
 																		Result := reg21111
 																		_ = Result
-																		reg21112 := __e.Call(__defun__shen_4unbindv, V2512, V2761)
+																		reg21112 := Call(__e, __defun__shen_4unbindv, V2512, V2761)
 																		_ = reg21112
 																		reg21114 = Result
 																	} else {
@@ -4095,7 +4095,7 @@ func init() {
 																}
 																Result := reg21115
 																_ = Result
-																reg21116 := __e.Call(__defun__shen_4unbindv, V2508, V2761)
+																reg21116 := Call(__e, __defun__shen_4unbindv, V2508, V2761)
 																_ = reg21116
 																reg21118 = Result
 															} else {
@@ -4106,14 +4106,14 @@ func init() {
 														}
 														reg21327 = reg21119
 													} else {
-														reg21120 := __e.Call(__defun__shen_4pvar_2, V2507)
+														reg21120 := Call(__e, __defun__shen_4pvar_2, V2507)
 														var reg21326 Obj
 														if reg21120 == True {
 															reg21121 := MakeSymbol("list")
-															reg21122 := __e.Call(__defun__shen_4bindv, V2507, reg21121, V2761)
+															reg21122 := Call(__e, __defun__shen_4bindv, V2507, reg21121, V2761)
 															_ = reg21122
 															reg21123 := PrimTail(V2506)
-															reg21124 := __e.Call(__defun__shen_4lazyderef, reg21123, V2761)
+															reg21124 := Call(__e, __defun__shen_4lazyderef, reg21123, V2761)
 															V2513 := reg21124
 															_ = V2513
 															reg21125 := PrimIsPair(V2513)
@@ -4123,7 +4123,7 @@ func init() {
 																A := reg21126
 																_ = A
 																reg21127 := PrimTail(V2513)
-																reg21128 := __e.Call(__defun__shen_4lazyderef, reg21127, V2761)
+																reg21128 := Call(__e, __defun__shen_4lazyderef, reg21127, V2761)
 																V2514 := reg21128
 																_ = V2514
 																reg21129 := Nil
@@ -4131,7 +4131,7 @@ func init() {
 																var reg21255 Obj
 																if reg21130 == True {
 																	reg21131 := PrimTail(V2505)
-																	reg21132 := __e.Call(__defun__shen_4lazyderef, reg21131, V2761)
+																	reg21132 := Call(__e, __defun__shen_4lazyderef, reg21131, V2761)
 																	V2515 := reg21132
 																	_ = V2515
 																	reg21133 := Nil
@@ -4141,19 +4141,19 @@ func init() {
 																		reg21135 := PrimTail(V2496)
 																		Hyp := reg21135
 																		_ = Hyp
-																		reg21136 := __e.Call(__defun__shen_4incinfs)
+																		reg21136 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg21136
-																		reg21137 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																		reg21137 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																		reg21138 := MakeSymbol(":")
-																		reg21139 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg21139 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg21140 := Nil
 																		reg21141 := PrimCons(reg21139, reg21140)
 																		reg21142 := PrimCons(reg21138, reg21141)
 																		reg21143 := PrimCons(reg21137, reg21142)
-																		reg21144 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																		reg21144 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																		reg21145 := MakeSymbol(":")
 																		reg21146 := MakeSymbol("list")
-																		reg21147 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg21147 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg21148 := Nil
 																		reg21149 := PrimCons(reg21147, reg21148)
 																		reg21150 := PrimCons(reg21146, reg21149)
@@ -4161,34 +4161,34 @@ func init() {
 																		reg21152 := PrimCons(reg21150, reg21151)
 																		reg21153 := PrimCons(reg21145, reg21152)
 																		reg21154 := PrimCons(reg21144, reg21153)
-																		reg21155 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																		reg21155 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																		reg21156 := PrimCons(reg21154, reg21155)
 																		reg21157 := PrimCons(reg21143, reg21156)
-																		reg21158 := __e.Call(__defun__bind, V2760, reg21157, V2761, V2762)
+																		reg21158 := Call(__e, __defun__bind, V2760, reg21157, V2761, V2762)
 																		reg21189 = reg21158
 																	} else {
-																		reg21159 := __e.Call(__defun__shen_4pvar_2, V2515)
+																		reg21159 := Call(__e, __defun__shen_4pvar_2, V2515)
 																		var reg21188 Obj
 																		if reg21159 == True {
 																			reg21160 := Nil
-																			reg21161 := __e.Call(__defun__shen_4bindv, V2515, reg21160, V2761)
+																			reg21161 := Call(__e, __defun__shen_4bindv, V2515, reg21160, V2761)
 																			_ = reg21161
 																			reg21162 := PrimTail(V2496)
 																			Hyp := reg21162
 																			_ = Hyp
-																			reg21163 := __e.Call(__defun__shen_4incinfs)
+																			reg21163 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg21163
-																			reg21164 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																			reg21164 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																			reg21165 := MakeSymbol(":")
-																			reg21166 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21166 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21167 := Nil
 																			reg21168 := PrimCons(reg21166, reg21167)
 																			reg21169 := PrimCons(reg21165, reg21168)
 																			reg21170 := PrimCons(reg21164, reg21169)
-																			reg21171 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																			reg21171 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																			reg21172 := MakeSymbol(":")
 																			reg21173 := MakeSymbol("list")
-																			reg21174 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21174 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21175 := Nil
 																			reg21176 := PrimCons(reg21174, reg21175)
 																			reg21177 := PrimCons(reg21173, reg21176)
@@ -4196,13 +4196,13 @@ func init() {
 																			reg21179 := PrimCons(reg21177, reg21178)
 																			reg21180 := PrimCons(reg21172, reg21179)
 																			reg21181 := PrimCons(reg21171, reg21180)
-																			reg21182 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																			reg21182 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																			reg21183 := PrimCons(reg21181, reg21182)
 																			reg21184 := PrimCons(reg21170, reg21183)
-																			reg21185 := __e.Call(__defun__bind, V2760, reg21184, V2761, V2762)
+																			reg21185 := Call(__e, __defun__bind, V2760, reg21184, V2761, V2762)
 																			Result := reg21185
 																			_ = Result
-																			reg21186 := __e.Call(__defun__shen_4unbindv, V2515, V2761)
+																			reg21186 := Call(__e, __defun__shen_4unbindv, V2515, V2761)
 																			_ = reg21186
 																			reg21188 = Result
 																		} else {
@@ -4213,14 +4213,14 @@ func init() {
 																	}
 																	reg21255 = reg21189
 																} else {
-																	reg21190 := __e.Call(__defun__shen_4pvar_2, V2514)
+																	reg21190 := Call(__e, __defun__shen_4pvar_2, V2514)
 																	var reg21254 Obj
 																	if reg21190 == True {
 																		reg21191 := Nil
-																		reg21192 := __e.Call(__defun__shen_4bindv, V2514, reg21191, V2761)
+																		reg21192 := Call(__e, __defun__shen_4bindv, V2514, reg21191, V2761)
 																		_ = reg21192
 																		reg21193 := PrimTail(V2505)
-																		reg21194 := __e.Call(__defun__shen_4lazyderef, reg21193, V2761)
+																		reg21194 := Call(__e, __defun__shen_4lazyderef, reg21193, V2761)
 																		V2516 := reg21194
 																		_ = V2516
 																		reg21195 := Nil
@@ -4230,19 +4230,19 @@ func init() {
 																			reg21197 := PrimTail(V2496)
 																			Hyp := reg21197
 																			_ = Hyp
-																			reg21198 := __e.Call(__defun__shen_4incinfs)
+																			reg21198 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg21198
-																			reg21199 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																			reg21199 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																			reg21200 := MakeSymbol(":")
-																			reg21201 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21201 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21202 := Nil
 																			reg21203 := PrimCons(reg21201, reg21202)
 																			reg21204 := PrimCons(reg21200, reg21203)
 																			reg21205 := PrimCons(reg21199, reg21204)
-																			reg21206 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																			reg21206 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																			reg21207 := MakeSymbol(":")
 																			reg21208 := MakeSymbol("list")
-																			reg21209 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21209 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21210 := Nil
 																			reg21211 := PrimCons(reg21209, reg21210)
 																			reg21212 := PrimCons(reg21208, reg21211)
@@ -4250,34 +4250,34 @@ func init() {
 																			reg21214 := PrimCons(reg21212, reg21213)
 																			reg21215 := PrimCons(reg21207, reg21214)
 																			reg21216 := PrimCons(reg21206, reg21215)
-																			reg21217 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																			reg21217 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																			reg21218 := PrimCons(reg21216, reg21217)
 																			reg21219 := PrimCons(reg21205, reg21218)
-																			reg21220 := __e.Call(__defun__bind, V2760, reg21219, V2761, V2762)
+																			reg21220 := Call(__e, __defun__bind, V2760, reg21219, V2761, V2762)
 																			reg21251 = reg21220
 																		} else {
-																			reg21221 := __e.Call(__defun__shen_4pvar_2, V2516)
+																			reg21221 := Call(__e, __defun__shen_4pvar_2, V2516)
 																			var reg21250 Obj
 																			if reg21221 == True {
 																				reg21222 := Nil
-																				reg21223 := __e.Call(__defun__shen_4bindv, V2516, reg21222, V2761)
+																				reg21223 := Call(__e, __defun__shen_4bindv, V2516, reg21222, V2761)
 																				_ = reg21223
 																				reg21224 := PrimTail(V2496)
 																				Hyp := reg21224
 																				_ = Hyp
-																				reg21225 := __e.Call(__defun__shen_4incinfs)
+																				reg21225 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg21225
-																				reg21226 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg21226 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg21227 := MakeSymbol(":")
-																				reg21228 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg21228 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg21229 := Nil
 																				reg21230 := PrimCons(reg21228, reg21229)
 																				reg21231 := PrimCons(reg21227, reg21230)
 																				reg21232 := PrimCons(reg21226, reg21231)
-																				reg21233 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg21233 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg21234 := MakeSymbol(":")
 																				reg21235 := MakeSymbol("list")
-																				reg21236 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg21236 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg21237 := Nil
 																				reg21238 := PrimCons(reg21236, reg21237)
 																				reg21239 := PrimCons(reg21235, reg21238)
@@ -4285,13 +4285,13 @@ func init() {
 																				reg21241 := PrimCons(reg21239, reg21240)
 																				reg21242 := PrimCons(reg21234, reg21241)
 																				reg21243 := PrimCons(reg21233, reg21242)
-																				reg21244 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg21244 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg21245 := PrimCons(reg21243, reg21244)
 																				reg21246 := PrimCons(reg21232, reg21245)
-																				reg21247 := __e.Call(__defun__bind, V2760, reg21246, V2761, V2762)
+																				reg21247 := Call(__e, __defun__bind, V2760, reg21246, V2761, V2762)
 																				Result := reg21247
 																				_ = Result
-																				reg21248 := __e.Call(__defun__shen_4unbindv, V2516, V2761)
+																				reg21248 := Call(__e, __defun__shen_4unbindv, V2516, V2761)
 																				_ = reg21248
 																				reg21250 = Result
 																			} else {
@@ -4302,7 +4302,7 @@ func init() {
 																		}
 																		Result := reg21251
 																		_ = Result
-																		reg21252 := __e.Call(__defun__shen_4unbindv, V2514, V2761)
+																		reg21252 := Call(__e, __defun__shen_4unbindv, V2514, V2761)
 																		_ = reg21252
 																		reg21254 = Result
 																	} else {
@@ -4313,18 +4313,18 @@ func init() {
 																}
 																reg21323 = reg21255
 															} else {
-																reg21256 := __e.Call(__defun__shen_4pvar_2, V2513)
+																reg21256 := Call(__e, __defun__shen_4pvar_2, V2513)
 																var reg21322 Obj
 																if reg21256 == True {
-																	reg21257 := __e.Call(__defun__shen_4newpv, V2761)
+																	reg21257 := Call(__e, __defun__shen_4newpv, V2761)
 																	A := reg21257
 																	_ = A
 																	reg21258 := Nil
 																	reg21259 := PrimCons(A, reg21258)
-																	reg21260 := __e.Call(__defun__shen_4bindv, V2513, reg21259, V2761)
+																	reg21260 := Call(__e, __defun__shen_4bindv, V2513, reg21259, V2761)
 																	_ = reg21260
 																	reg21261 := PrimTail(V2505)
-																	reg21262 := __e.Call(__defun__shen_4lazyderef, reg21261, V2761)
+																	reg21262 := Call(__e, __defun__shen_4lazyderef, reg21261, V2761)
 																	V2517 := reg21262
 																	_ = V2517
 																	reg21263 := Nil
@@ -4334,19 +4334,19 @@ func init() {
 																		reg21265 := PrimTail(V2496)
 																		Hyp := reg21265
 																		_ = Hyp
-																		reg21266 := __e.Call(__defun__shen_4incinfs)
+																		reg21266 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg21266
-																		reg21267 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																		reg21267 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																		reg21268 := MakeSymbol(":")
-																		reg21269 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg21269 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg21270 := Nil
 																		reg21271 := PrimCons(reg21269, reg21270)
 																		reg21272 := PrimCons(reg21268, reg21271)
 																		reg21273 := PrimCons(reg21267, reg21272)
-																		reg21274 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																		reg21274 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																		reg21275 := MakeSymbol(":")
 																		reg21276 := MakeSymbol("list")
-																		reg21277 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg21277 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg21278 := Nil
 																		reg21279 := PrimCons(reg21277, reg21278)
 																		reg21280 := PrimCons(reg21276, reg21279)
@@ -4354,34 +4354,34 @@ func init() {
 																		reg21282 := PrimCons(reg21280, reg21281)
 																		reg21283 := PrimCons(reg21275, reg21282)
 																		reg21284 := PrimCons(reg21274, reg21283)
-																		reg21285 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																		reg21285 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																		reg21286 := PrimCons(reg21284, reg21285)
 																		reg21287 := PrimCons(reg21273, reg21286)
-																		reg21288 := __e.Call(__defun__bind, V2760, reg21287, V2761, V2762)
+																		reg21288 := Call(__e, __defun__bind, V2760, reg21287, V2761, V2762)
 																		reg21319 = reg21288
 																	} else {
-																		reg21289 := __e.Call(__defun__shen_4pvar_2, V2517)
+																		reg21289 := Call(__e, __defun__shen_4pvar_2, V2517)
 																		var reg21318 Obj
 																		if reg21289 == True {
 																			reg21290 := Nil
-																			reg21291 := __e.Call(__defun__shen_4bindv, V2517, reg21290, V2761)
+																			reg21291 := Call(__e, __defun__shen_4bindv, V2517, reg21290, V2761)
 																			_ = reg21291
 																			reg21292 := PrimTail(V2496)
 																			Hyp := reg21292
 																			_ = Hyp
-																			reg21293 := __e.Call(__defun__shen_4incinfs)
+																			reg21293 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg21293
-																			reg21294 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																			reg21294 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																			reg21295 := MakeSymbol(":")
-																			reg21296 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21296 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21297 := Nil
 																			reg21298 := PrimCons(reg21296, reg21297)
 																			reg21299 := PrimCons(reg21295, reg21298)
 																			reg21300 := PrimCons(reg21294, reg21299)
-																			reg21301 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																			reg21301 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																			reg21302 := MakeSymbol(":")
 																			reg21303 := MakeSymbol("list")
-																			reg21304 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21304 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21305 := Nil
 																			reg21306 := PrimCons(reg21304, reg21305)
 																			reg21307 := PrimCons(reg21303, reg21306)
@@ -4389,13 +4389,13 @@ func init() {
 																			reg21309 := PrimCons(reg21307, reg21308)
 																			reg21310 := PrimCons(reg21302, reg21309)
 																			reg21311 := PrimCons(reg21301, reg21310)
-																			reg21312 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																			reg21312 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																			reg21313 := PrimCons(reg21311, reg21312)
 																			reg21314 := PrimCons(reg21300, reg21313)
-																			reg21315 := __e.Call(__defun__bind, V2760, reg21314, V2761, V2762)
+																			reg21315 := Call(__e, __defun__bind, V2760, reg21314, V2761, V2762)
 																			Result := reg21315
 																			_ = Result
-																			reg21316 := __e.Call(__defun__shen_4unbindv, V2517, V2761)
+																			reg21316 := Call(__e, __defun__shen_4unbindv, V2517, V2761)
 																			_ = reg21316
 																			reg21318 = Result
 																		} else {
@@ -4406,7 +4406,7 @@ func init() {
 																	}
 																	Result := reg21319
 																	_ = Result
-																	reg21320 := __e.Call(__defun__shen_4unbindv, V2513, V2761)
+																	reg21320 := Call(__e, __defun__shen_4unbindv, V2513, V2761)
 																	_ = reg21320
 																	reg21322 = Result
 																} else {
@@ -4417,7 +4417,7 @@ func init() {
 															}
 															Result := reg21323
 															_ = Result
-															reg21324 := __e.Call(__defun__shen_4unbindv, V2507, V2761)
+															reg21324 := Call(__e, __defun__shen_4unbindv, V2507, V2761)
 															_ = reg21324
 															reg21326 = Result
 														} else {
@@ -4428,20 +4428,20 @@ func init() {
 													}
 													reg21397 = reg21327
 												} else {
-													reg21328 := __e.Call(__defun__shen_4pvar_2, V2506)
+													reg21328 := Call(__e, __defun__shen_4pvar_2, V2506)
 													var reg21396 Obj
 													if reg21328 == True {
-														reg21329 := __e.Call(__defun__shen_4newpv, V2761)
+														reg21329 := Call(__e, __defun__shen_4newpv, V2761)
 														A := reg21329
 														_ = A
 														reg21330 := MakeSymbol("list")
 														reg21331 := Nil
 														reg21332 := PrimCons(A, reg21331)
 														reg21333 := PrimCons(reg21330, reg21332)
-														reg21334 := __e.Call(__defun__shen_4bindv, V2506, reg21333, V2761)
+														reg21334 := Call(__e, __defun__shen_4bindv, V2506, reg21333, V2761)
 														_ = reg21334
 														reg21335 := PrimTail(V2505)
-														reg21336 := __e.Call(__defun__shen_4lazyderef, reg21335, V2761)
+														reg21336 := Call(__e, __defun__shen_4lazyderef, reg21335, V2761)
 														V2518 := reg21336
 														_ = V2518
 														reg21337 := Nil
@@ -4451,19 +4451,19 @@ func init() {
 															reg21339 := PrimTail(V2496)
 															Hyp := reg21339
 															_ = Hyp
-															reg21340 := __e.Call(__defun__shen_4incinfs)
+															reg21340 := Call(__e, __defun__shen_4incinfs)
 															_ = reg21340
-															reg21341 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+															reg21341 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 															reg21342 := MakeSymbol(":")
-															reg21343 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+															reg21343 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 															reg21344 := Nil
 															reg21345 := PrimCons(reg21343, reg21344)
 															reg21346 := PrimCons(reg21342, reg21345)
 															reg21347 := PrimCons(reg21341, reg21346)
-															reg21348 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+															reg21348 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 															reg21349 := MakeSymbol(":")
 															reg21350 := MakeSymbol("list")
-															reg21351 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+															reg21351 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 															reg21352 := Nil
 															reg21353 := PrimCons(reg21351, reg21352)
 															reg21354 := PrimCons(reg21350, reg21353)
@@ -4471,34 +4471,34 @@ func init() {
 															reg21356 := PrimCons(reg21354, reg21355)
 															reg21357 := PrimCons(reg21349, reg21356)
 															reg21358 := PrimCons(reg21348, reg21357)
-															reg21359 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+															reg21359 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 															reg21360 := PrimCons(reg21358, reg21359)
 															reg21361 := PrimCons(reg21347, reg21360)
-															reg21362 := __e.Call(__defun__bind, V2760, reg21361, V2761, V2762)
+															reg21362 := Call(__e, __defun__bind, V2760, reg21361, V2761, V2762)
 															reg21393 = reg21362
 														} else {
-															reg21363 := __e.Call(__defun__shen_4pvar_2, V2518)
+															reg21363 := Call(__e, __defun__shen_4pvar_2, V2518)
 															var reg21392 Obj
 															if reg21363 == True {
 																reg21364 := Nil
-																reg21365 := __e.Call(__defun__shen_4bindv, V2518, reg21364, V2761)
+																reg21365 := Call(__e, __defun__shen_4bindv, V2518, reg21364, V2761)
 																_ = reg21365
 																reg21366 := PrimTail(V2496)
 																Hyp := reg21366
 																_ = Hyp
-																reg21367 := __e.Call(__defun__shen_4incinfs)
+																reg21367 := Call(__e, __defun__shen_4incinfs)
 																_ = reg21367
-																reg21368 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																reg21368 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																reg21369 := MakeSymbol(":")
-																reg21370 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																reg21370 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																reg21371 := Nil
 																reg21372 := PrimCons(reg21370, reg21371)
 																reg21373 := PrimCons(reg21369, reg21372)
 																reg21374 := PrimCons(reg21368, reg21373)
-																reg21375 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																reg21375 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																reg21376 := MakeSymbol(":")
 																reg21377 := MakeSymbol("list")
-																reg21378 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																reg21378 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																reg21379 := Nil
 																reg21380 := PrimCons(reg21378, reg21379)
 																reg21381 := PrimCons(reg21377, reg21380)
@@ -4506,13 +4506,13 @@ func init() {
 																reg21383 := PrimCons(reg21381, reg21382)
 																reg21384 := PrimCons(reg21376, reg21383)
 																reg21385 := PrimCons(reg21375, reg21384)
-																reg21386 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																reg21386 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																reg21387 := PrimCons(reg21385, reg21386)
 																reg21388 := PrimCons(reg21374, reg21387)
-																reg21389 := __e.Call(__defun__bind, V2760, reg21388, V2761, V2762)
+																reg21389 := Call(__e, __defun__bind, V2760, reg21388, V2761, V2762)
 																Result := reg21389
 																_ = Result
-																reg21390 := __e.Call(__defun__shen_4unbindv, V2518, V2761)
+																reg21390 := Call(__e, __defun__shen_4unbindv, V2518, V2761)
 																_ = reg21390
 																reg21392 = Result
 															} else {
@@ -4523,7 +4523,7 @@ func init() {
 														}
 														Result := reg21393
 														_ = Result
-														reg21394 := __e.Call(__defun__shen_4unbindv, V2506, V2761)
+														reg21394 := Call(__e, __defun__shen_4unbindv, V2506, V2761)
 														_ = reg21394
 														reg21396 = Result
 													} else {
@@ -4587,28 +4587,28 @@ func init() {
 		reg21418 := False
 		reg21419 := PrimEqual(Case, reg21418)
 		if reg21419 == True {
-			reg21420 := __e.Call(__defun__shen_4lazyderef, V2759, V2761)
+			reg21420 := Call(__e, __defun__shen_4lazyderef, V2759, V2761)
 			V2519 := reg21420
 			_ = V2519
 			reg21421 := PrimIsPair(V2519)
 			var reg21971 Obj
 			if reg21421 == True {
 				reg21422 := PrimHead(V2519)
-				reg21423 := __e.Call(__defun__shen_4lazyderef, reg21422, V2761)
+				reg21423 := Call(__e, __defun__shen_4lazyderef, reg21422, V2761)
 				V2520 := reg21423
 				_ = V2520
 				reg21424 := PrimIsPair(V2520)
 				var reg21969 Obj
 				if reg21424 == True {
 					reg21425 := PrimHead(V2520)
-					reg21426 := __e.Call(__defun__shen_4lazyderef, reg21425, V2761)
+					reg21426 := Call(__e, __defun__shen_4lazyderef, reg21425, V2761)
 					V2521 := reg21426
 					_ = V2521
 					reg21427 := PrimIsPair(V2521)
 					var reg21967 Obj
 					if reg21427 == True {
 						reg21428 := PrimHead(V2521)
-						reg21429 := __e.Call(__defun__shen_4lazyderef, reg21428, V2761)
+						reg21429 := Call(__e, __defun__shen_4lazyderef, reg21428, V2761)
 						V2522 := reg21429
 						_ = V2522
 						reg21430 := MakeSymbol("@p")
@@ -4616,7 +4616,7 @@ func init() {
 						var reg21965 Obj
 						if reg21431 == True {
 							reg21432 := PrimTail(V2521)
-							reg21433 := __e.Call(__defun__shen_4lazyderef, reg21432, V2761)
+							reg21433 := Call(__e, __defun__shen_4lazyderef, reg21432, V2761)
 							V2523 := reg21433
 							_ = V2523
 							reg21434 := PrimIsPair(V2523)
@@ -4626,7 +4626,7 @@ func init() {
 								X := reg21435
 								_ = X
 								reg21436 := PrimTail(V2523)
-								reg21437 := __e.Call(__defun__shen_4lazyderef, reg21436, V2761)
+								reg21437 := Call(__e, __defun__shen_4lazyderef, reg21436, V2761)
 								V2524 := reg21437
 								_ = V2524
 								reg21438 := PrimIsPair(V2524)
@@ -4636,7 +4636,7 @@ func init() {
 									Y := reg21439
 									_ = Y
 									reg21440 := PrimTail(V2524)
-									reg21441 := __e.Call(__defun__shen_4lazyderef, reg21440, V2761)
+									reg21441 := Call(__e, __defun__shen_4lazyderef, reg21440, V2761)
 									V2525 := reg21441
 									_ = V2525
 									reg21442 := Nil
@@ -4644,14 +4644,14 @@ func init() {
 									var reg21959 Obj
 									if reg21443 == True {
 										reg21444 := PrimTail(V2520)
-										reg21445 := __e.Call(__defun__shen_4lazyderef, reg21444, V2761)
+										reg21445 := Call(__e, __defun__shen_4lazyderef, reg21444, V2761)
 										V2526 := reg21445
 										_ = V2526
 										reg21446 := PrimIsPair(V2526)
 										var reg21957 Obj
 										if reg21446 == True {
 											reg21447 := PrimHead(V2526)
-											reg21448 := __e.Call(__defun__shen_4lazyderef, reg21447, V2761)
+											reg21448 := Call(__e, __defun__shen_4lazyderef, reg21447, V2761)
 											V2527 := reg21448
 											_ = V2527
 											reg21449 := MakeSymbol(":")
@@ -4659,14 +4659,14 @@ func init() {
 											var reg21955 Obj
 											if reg21450 == True {
 												reg21451 := PrimTail(V2526)
-												reg21452 := __e.Call(__defun__shen_4lazyderef, reg21451, V2761)
+												reg21452 := Call(__e, __defun__shen_4lazyderef, reg21451, V2761)
 												V2528 := reg21452
 												_ = V2528
 												reg21453 := PrimIsPair(V2528)
 												var reg21953 Obj
 												if reg21453 == True {
 													reg21454 := PrimHead(V2528)
-													reg21455 := __e.Call(__defun__shen_4lazyderef, reg21454, V2761)
+													reg21455 := Call(__e, __defun__shen_4lazyderef, reg21454, V2761)
 													V2529 := reg21455
 													_ = V2529
 													reg21456 := PrimIsPair(V2529)
@@ -4676,14 +4676,14 @@ func init() {
 														A := reg21457
 														_ = A
 														reg21458 := PrimTail(V2529)
-														reg21459 := __e.Call(__defun__shen_4lazyderef, reg21458, V2761)
+														reg21459 := Call(__e, __defun__shen_4lazyderef, reg21458, V2761)
 														V2530 := reg21459
 														_ = V2530
 														reg21460 := PrimIsPair(V2530)
 														var reg21887 Obj
 														if reg21460 == True {
 															reg21461 := PrimHead(V2530)
-															reg21462 := __e.Call(__defun__shen_4lazyderef, reg21461, V2761)
+															reg21462 := Call(__e, __defun__shen_4lazyderef, reg21461, V2761)
 															V2531 := reg21462
 															_ = V2531
 															reg21463 := MakeSymbol("*")
@@ -4691,7 +4691,7 @@ func init() {
 															var reg21825 Obj
 															if reg21464 == True {
 																reg21465 := PrimTail(V2530)
-																reg21466 := __e.Call(__defun__shen_4lazyderef, reg21465, V2761)
+																reg21466 := Call(__e, __defun__shen_4lazyderef, reg21465, V2761)
 																V2532 := reg21466
 																_ = V2532
 																reg21467 := PrimIsPair(V2532)
@@ -4701,7 +4701,7 @@ func init() {
 																	B := reg21468
 																	_ = B
 																	reg21469 := PrimTail(V2532)
-																	reg21470 := __e.Call(__defun__shen_4lazyderef, reg21469, V2761)
+																	reg21470 := Call(__e, __defun__shen_4lazyderef, reg21469, V2761)
 																	V2533 := reg21470
 																	_ = V2533
 																	reg21471 := Nil
@@ -4709,7 +4709,7 @@ func init() {
 																	var reg21581 Obj
 																	if reg21472 == True {
 																		reg21473 := PrimTail(V2528)
-																		reg21474 := __e.Call(__defun__shen_4lazyderef, reg21473, V2761)
+																		reg21474 := Call(__e, __defun__shen_4lazyderef, reg21473, V2761)
 																		V2534 := reg21474
 																		_ = V2534
 																		reg21475 := Nil
@@ -4719,60 +4719,60 @@ func init() {
 																			reg21477 := PrimTail(V2519)
 																			Hyp := reg21477
 																			_ = Hyp
-																			reg21478 := __e.Call(__defun__shen_4incinfs)
+																			reg21478 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg21478
-																			reg21479 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																			reg21479 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																			reg21480 := MakeSymbol(":")
-																			reg21481 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21481 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21482 := Nil
 																			reg21483 := PrimCons(reg21481, reg21482)
 																			reg21484 := PrimCons(reg21480, reg21483)
 																			reg21485 := PrimCons(reg21479, reg21484)
-																			reg21486 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																			reg21486 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																			reg21487 := MakeSymbol(":")
-																			reg21488 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																			reg21488 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																			reg21489 := Nil
 																			reg21490 := PrimCons(reg21488, reg21489)
 																			reg21491 := PrimCons(reg21487, reg21490)
 																			reg21492 := PrimCons(reg21486, reg21491)
-																			reg21493 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																			reg21493 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																			reg21494 := PrimCons(reg21492, reg21493)
 																			reg21495 := PrimCons(reg21485, reg21494)
-																			reg21496 := __e.Call(__defun__bind, V2760, reg21495, V2761, V2762)
+																			reg21496 := Call(__e, __defun__bind, V2760, reg21495, V2761, V2762)
 																			reg21523 = reg21496
 																		} else {
-																			reg21497 := __e.Call(__defun__shen_4pvar_2, V2534)
+																			reg21497 := Call(__e, __defun__shen_4pvar_2, V2534)
 																			var reg21522 Obj
 																			if reg21497 == True {
 																				reg21498 := Nil
-																				reg21499 := __e.Call(__defun__shen_4bindv, V2534, reg21498, V2761)
+																				reg21499 := Call(__e, __defun__shen_4bindv, V2534, reg21498, V2761)
 																				_ = reg21499
 																				reg21500 := PrimTail(V2519)
 																				Hyp := reg21500
 																				_ = Hyp
-																				reg21501 := __e.Call(__defun__shen_4incinfs)
+																				reg21501 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg21501
-																				reg21502 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg21502 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg21503 := MakeSymbol(":")
-																				reg21504 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg21504 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg21505 := Nil
 																				reg21506 := PrimCons(reg21504, reg21505)
 																				reg21507 := PrimCons(reg21503, reg21506)
 																				reg21508 := PrimCons(reg21502, reg21507)
-																				reg21509 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg21509 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg21510 := MakeSymbol(":")
-																				reg21511 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																				reg21511 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																				reg21512 := Nil
 																				reg21513 := PrimCons(reg21511, reg21512)
 																				reg21514 := PrimCons(reg21510, reg21513)
 																				reg21515 := PrimCons(reg21509, reg21514)
-																				reg21516 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg21516 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg21517 := PrimCons(reg21515, reg21516)
 																				reg21518 := PrimCons(reg21508, reg21517)
-																				reg21519 := __e.Call(__defun__bind, V2760, reg21518, V2761, V2762)
+																				reg21519 := Call(__e, __defun__bind, V2760, reg21518, V2761, V2762)
 																				Result := reg21519
 																				_ = Result
-																				reg21520 := __e.Call(__defun__shen_4unbindv, V2534, V2761)
+																				reg21520 := Call(__e, __defun__shen_4unbindv, V2534, V2761)
 																				_ = reg21520
 																				reg21522 = Result
 																			} else {
@@ -4783,14 +4783,14 @@ func init() {
 																		}
 																		reg21581 = reg21523
 																	} else {
-																		reg21524 := __e.Call(__defun__shen_4pvar_2, V2533)
+																		reg21524 := Call(__e, __defun__shen_4pvar_2, V2533)
 																		var reg21580 Obj
 																		if reg21524 == True {
 																			reg21525 := Nil
-																			reg21526 := __e.Call(__defun__shen_4bindv, V2533, reg21525, V2761)
+																			reg21526 := Call(__e, __defun__shen_4bindv, V2533, reg21525, V2761)
 																			_ = reg21526
 																			reg21527 := PrimTail(V2528)
-																			reg21528 := __e.Call(__defun__shen_4lazyderef, reg21527, V2761)
+																			reg21528 := Call(__e, __defun__shen_4lazyderef, reg21527, V2761)
 																			V2535 := reg21528
 																			_ = V2535
 																			reg21529 := Nil
@@ -4800,60 +4800,60 @@ func init() {
 																				reg21531 := PrimTail(V2519)
 																				Hyp := reg21531
 																				_ = Hyp
-																				reg21532 := __e.Call(__defun__shen_4incinfs)
+																				reg21532 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg21532
-																				reg21533 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg21533 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg21534 := MakeSymbol(":")
-																				reg21535 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg21535 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg21536 := Nil
 																				reg21537 := PrimCons(reg21535, reg21536)
 																				reg21538 := PrimCons(reg21534, reg21537)
 																				reg21539 := PrimCons(reg21533, reg21538)
-																				reg21540 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg21540 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg21541 := MakeSymbol(":")
-																				reg21542 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																				reg21542 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																				reg21543 := Nil
 																				reg21544 := PrimCons(reg21542, reg21543)
 																				reg21545 := PrimCons(reg21541, reg21544)
 																				reg21546 := PrimCons(reg21540, reg21545)
-																				reg21547 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg21547 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg21548 := PrimCons(reg21546, reg21547)
 																				reg21549 := PrimCons(reg21539, reg21548)
-																				reg21550 := __e.Call(__defun__bind, V2760, reg21549, V2761, V2762)
+																				reg21550 := Call(__e, __defun__bind, V2760, reg21549, V2761, V2762)
 																				reg21577 = reg21550
 																			} else {
-																				reg21551 := __e.Call(__defun__shen_4pvar_2, V2535)
+																				reg21551 := Call(__e, __defun__shen_4pvar_2, V2535)
 																				var reg21576 Obj
 																				if reg21551 == True {
 																					reg21552 := Nil
-																					reg21553 := __e.Call(__defun__shen_4bindv, V2535, reg21552, V2761)
+																					reg21553 := Call(__e, __defun__shen_4bindv, V2535, reg21552, V2761)
 																					_ = reg21553
 																					reg21554 := PrimTail(V2519)
 																					Hyp := reg21554
 																					_ = Hyp
-																					reg21555 := __e.Call(__defun__shen_4incinfs)
+																					reg21555 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg21555
-																					reg21556 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																					reg21556 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																					reg21557 := MakeSymbol(":")
-																					reg21558 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg21558 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg21559 := Nil
 																					reg21560 := PrimCons(reg21558, reg21559)
 																					reg21561 := PrimCons(reg21557, reg21560)
 																					reg21562 := PrimCons(reg21556, reg21561)
-																					reg21563 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																					reg21563 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																					reg21564 := MakeSymbol(":")
-																					reg21565 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																					reg21565 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																					reg21566 := Nil
 																					reg21567 := PrimCons(reg21565, reg21566)
 																					reg21568 := PrimCons(reg21564, reg21567)
 																					reg21569 := PrimCons(reg21563, reg21568)
-																					reg21570 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																					reg21570 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																					reg21571 := PrimCons(reg21569, reg21570)
 																					reg21572 := PrimCons(reg21562, reg21571)
-																					reg21573 := __e.Call(__defun__bind, V2760, reg21572, V2761, V2762)
+																					reg21573 := Call(__e, __defun__bind, V2760, reg21572, V2761, V2762)
 																					Result := reg21573
 																					_ = Result
-																					reg21574 := __e.Call(__defun__shen_4unbindv, V2535, V2761)
+																					reg21574 := Call(__e, __defun__shen_4unbindv, V2535, V2761)
 																					_ = reg21574
 																					reg21576 = Result
 																				} else {
@@ -4864,7 +4864,7 @@ func init() {
 																			}
 																			Result := reg21577
 																			_ = Result
-																			reg21578 := __e.Call(__defun__shen_4unbindv, V2533, V2761)
+																			reg21578 := Call(__e, __defun__shen_4unbindv, V2533, V2761)
 																			_ = reg21578
 																			reg21580 = Result
 																		} else {
@@ -4875,18 +4875,18 @@ func init() {
 																	}
 																	reg21641 = reg21581
 																} else {
-																	reg21582 := __e.Call(__defun__shen_4pvar_2, V2532)
+																	reg21582 := Call(__e, __defun__shen_4pvar_2, V2532)
 																	var reg21640 Obj
 																	if reg21582 == True {
-																		reg21583 := __e.Call(__defun__shen_4newpv, V2761)
+																		reg21583 := Call(__e, __defun__shen_4newpv, V2761)
 																		B := reg21583
 																		_ = B
 																		reg21584 := Nil
 																		reg21585 := PrimCons(B, reg21584)
-																		reg21586 := __e.Call(__defun__shen_4bindv, V2532, reg21585, V2761)
+																		reg21586 := Call(__e, __defun__shen_4bindv, V2532, reg21585, V2761)
 																		_ = reg21586
 																		reg21587 := PrimTail(V2528)
-																		reg21588 := __e.Call(__defun__shen_4lazyderef, reg21587, V2761)
+																		reg21588 := Call(__e, __defun__shen_4lazyderef, reg21587, V2761)
 																		V2536 := reg21588
 																		_ = V2536
 																		reg21589 := Nil
@@ -4896,60 +4896,60 @@ func init() {
 																			reg21591 := PrimTail(V2519)
 																			Hyp := reg21591
 																			_ = Hyp
-																			reg21592 := __e.Call(__defun__shen_4incinfs)
+																			reg21592 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg21592
-																			reg21593 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																			reg21593 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																			reg21594 := MakeSymbol(":")
-																			reg21595 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg21595 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg21596 := Nil
 																			reg21597 := PrimCons(reg21595, reg21596)
 																			reg21598 := PrimCons(reg21594, reg21597)
 																			reg21599 := PrimCons(reg21593, reg21598)
-																			reg21600 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																			reg21600 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																			reg21601 := MakeSymbol(":")
-																			reg21602 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																			reg21602 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																			reg21603 := Nil
 																			reg21604 := PrimCons(reg21602, reg21603)
 																			reg21605 := PrimCons(reg21601, reg21604)
 																			reg21606 := PrimCons(reg21600, reg21605)
-																			reg21607 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																			reg21607 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																			reg21608 := PrimCons(reg21606, reg21607)
 																			reg21609 := PrimCons(reg21599, reg21608)
-																			reg21610 := __e.Call(__defun__bind, V2760, reg21609, V2761, V2762)
+																			reg21610 := Call(__e, __defun__bind, V2760, reg21609, V2761, V2762)
 																			reg21637 = reg21610
 																		} else {
-																			reg21611 := __e.Call(__defun__shen_4pvar_2, V2536)
+																			reg21611 := Call(__e, __defun__shen_4pvar_2, V2536)
 																			var reg21636 Obj
 																			if reg21611 == True {
 																				reg21612 := Nil
-																				reg21613 := __e.Call(__defun__shen_4bindv, V2536, reg21612, V2761)
+																				reg21613 := Call(__e, __defun__shen_4bindv, V2536, reg21612, V2761)
 																				_ = reg21613
 																				reg21614 := PrimTail(V2519)
 																				Hyp := reg21614
 																				_ = Hyp
-																				reg21615 := __e.Call(__defun__shen_4incinfs)
+																				reg21615 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg21615
-																				reg21616 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg21616 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg21617 := MakeSymbol(":")
-																				reg21618 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg21618 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg21619 := Nil
 																				reg21620 := PrimCons(reg21618, reg21619)
 																				reg21621 := PrimCons(reg21617, reg21620)
 																				reg21622 := PrimCons(reg21616, reg21621)
-																				reg21623 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg21623 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg21624 := MakeSymbol(":")
-																				reg21625 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																				reg21625 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																				reg21626 := Nil
 																				reg21627 := PrimCons(reg21625, reg21626)
 																				reg21628 := PrimCons(reg21624, reg21627)
 																				reg21629 := PrimCons(reg21623, reg21628)
-																				reg21630 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg21630 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg21631 := PrimCons(reg21629, reg21630)
 																				reg21632 := PrimCons(reg21622, reg21631)
-																				reg21633 := __e.Call(__defun__bind, V2760, reg21632, V2761, V2762)
+																				reg21633 := Call(__e, __defun__bind, V2760, reg21632, V2761, V2762)
 																				Result := reg21633
 																				_ = Result
-																				reg21634 := __e.Call(__defun__shen_4unbindv, V2536, V2761)
+																				reg21634 := Call(__e, __defun__shen_4unbindv, V2536, V2761)
 																				_ = reg21634
 																				reg21636 = Result
 																			} else {
@@ -4960,7 +4960,7 @@ func init() {
 																		}
 																		Result := reg21637
 																		_ = Result
-																		reg21638 := __e.Call(__defun__shen_4unbindv, V2532, V2761)
+																		reg21638 := Call(__e, __defun__shen_4unbindv, V2532, V2761)
 																		_ = reg21638
 																		reg21640 = Result
 																	} else {
@@ -4971,14 +4971,14 @@ func init() {
 																}
 																reg21825 = reg21641
 															} else {
-																reg21642 := __e.Call(__defun__shen_4pvar_2, V2531)
+																reg21642 := Call(__e, __defun__shen_4pvar_2, V2531)
 																var reg21824 Obj
 																if reg21642 == True {
 																	reg21643 := MakeSymbol("*")
-																	reg21644 := __e.Call(__defun__shen_4bindv, V2531, reg21643, V2761)
+																	reg21644 := Call(__e, __defun__shen_4bindv, V2531, reg21643, V2761)
 																	_ = reg21644
 																	reg21645 := PrimTail(V2530)
-																	reg21646 := __e.Call(__defun__shen_4lazyderef, reg21645, V2761)
+																	reg21646 := Call(__e, __defun__shen_4lazyderef, reg21645, V2761)
 																	V2537 := reg21646
 																	_ = V2537
 																	reg21647 := PrimIsPair(V2537)
@@ -4988,7 +4988,7 @@ func init() {
 																		B := reg21648
 																		_ = B
 																		reg21649 := PrimTail(V2537)
-																		reg21650 := __e.Call(__defun__shen_4lazyderef, reg21649, V2761)
+																		reg21650 := Call(__e, __defun__shen_4lazyderef, reg21649, V2761)
 																		V2538 := reg21650
 																		_ = V2538
 																		reg21651 := Nil
@@ -4996,7 +4996,7 @@ func init() {
 																		var reg21761 Obj
 																		if reg21652 == True {
 																			reg21653 := PrimTail(V2528)
-																			reg21654 := __e.Call(__defun__shen_4lazyderef, reg21653, V2761)
+																			reg21654 := Call(__e, __defun__shen_4lazyderef, reg21653, V2761)
 																			V2539 := reg21654
 																			_ = V2539
 																			reg21655 := Nil
@@ -5006,60 +5006,60 @@ func init() {
 																				reg21657 := PrimTail(V2519)
 																				Hyp := reg21657
 																				_ = Hyp
-																				reg21658 := __e.Call(__defun__shen_4incinfs)
+																				reg21658 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg21658
-																				reg21659 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg21659 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg21660 := MakeSymbol(":")
-																				reg21661 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg21661 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg21662 := Nil
 																				reg21663 := PrimCons(reg21661, reg21662)
 																				reg21664 := PrimCons(reg21660, reg21663)
 																				reg21665 := PrimCons(reg21659, reg21664)
-																				reg21666 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg21666 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg21667 := MakeSymbol(":")
-																				reg21668 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																				reg21668 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																				reg21669 := Nil
 																				reg21670 := PrimCons(reg21668, reg21669)
 																				reg21671 := PrimCons(reg21667, reg21670)
 																				reg21672 := PrimCons(reg21666, reg21671)
-																				reg21673 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg21673 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg21674 := PrimCons(reg21672, reg21673)
 																				reg21675 := PrimCons(reg21665, reg21674)
-																				reg21676 := __e.Call(__defun__bind, V2760, reg21675, V2761, V2762)
+																				reg21676 := Call(__e, __defun__bind, V2760, reg21675, V2761, V2762)
 																				reg21703 = reg21676
 																			} else {
-																				reg21677 := __e.Call(__defun__shen_4pvar_2, V2539)
+																				reg21677 := Call(__e, __defun__shen_4pvar_2, V2539)
 																				var reg21702 Obj
 																				if reg21677 == True {
 																					reg21678 := Nil
-																					reg21679 := __e.Call(__defun__shen_4bindv, V2539, reg21678, V2761)
+																					reg21679 := Call(__e, __defun__shen_4bindv, V2539, reg21678, V2761)
 																					_ = reg21679
 																					reg21680 := PrimTail(V2519)
 																					Hyp := reg21680
 																					_ = Hyp
-																					reg21681 := __e.Call(__defun__shen_4incinfs)
+																					reg21681 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg21681
-																					reg21682 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																					reg21682 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																					reg21683 := MakeSymbol(":")
-																					reg21684 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg21684 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg21685 := Nil
 																					reg21686 := PrimCons(reg21684, reg21685)
 																					reg21687 := PrimCons(reg21683, reg21686)
 																					reg21688 := PrimCons(reg21682, reg21687)
-																					reg21689 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																					reg21689 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																					reg21690 := MakeSymbol(":")
-																					reg21691 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																					reg21691 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																					reg21692 := Nil
 																					reg21693 := PrimCons(reg21691, reg21692)
 																					reg21694 := PrimCons(reg21690, reg21693)
 																					reg21695 := PrimCons(reg21689, reg21694)
-																					reg21696 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																					reg21696 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																					reg21697 := PrimCons(reg21695, reg21696)
 																					reg21698 := PrimCons(reg21688, reg21697)
-																					reg21699 := __e.Call(__defun__bind, V2760, reg21698, V2761, V2762)
+																					reg21699 := Call(__e, __defun__bind, V2760, reg21698, V2761, V2762)
 																					Result := reg21699
 																					_ = Result
-																					reg21700 := __e.Call(__defun__shen_4unbindv, V2539, V2761)
+																					reg21700 := Call(__e, __defun__shen_4unbindv, V2539, V2761)
 																					_ = reg21700
 																					reg21702 = Result
 																				} else {
@@ -5070,14 +5070,14 @@ func init() {
 																			}
 																			reg21761 = reg21703
 																		} else {
-																			reg21704 := __e.Call(__defun__shen_4pvar_2, V2538)
+																			reg21704 := Call(__e, __defun__shen_4pvar_2, V2538)
 																			var reg21760 Obj
 																			if reg21704 == True {
 																				reg21705 := Nil
-																				reg21706 := __e.Call(__defun__shen_4bindv, V2538, reg21705, V2761)
+																				reg21706 := Call(__e, __defun__shen_4bindv, V2538, reg21705, V2761)
 																				_ = reg21706
 																				reg21707 := PrimTail(V2528)
-																				reg21708 := __e.Call(__defun__shen_4lazyderef, reg21707, V2761)
+																				reg21708 := Call(__e, __defun__shen_4lazyderef, reg21707, V2761)
 																				V2540 := reg21708
 																				_ = V2540
 																				reg21709 := Nil
@@ -5087,60 +5087,60 @@ func init() {
 																					reg21711 := PrimTail(V2519)
 																					Hyp := reg21711
 																					_ = Hyp
-																					reg21712 := __e.Call(__defun__shen_4incinfs)
+																					reg21712 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg21712
-																					reg21713 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																					reg21713 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																					reg21714 := MakeSymbol(":")
-																					reg21715 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg21715 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg21716 := Nil
 																					reg21717 := PrimCons(reg21715, reg21716)
 																					reg21718 := PrimCons(reg21714, reg21717)
 																					reg21719 := PrimCons(reg21713, reg21718)
-																					reg21720 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																					reg21720 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																					reg21721 := MakeSymbol(":")
-																					reg21722 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																					reg21722 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																					reg21723 := Nil
 																					reg21724 := PrimCons(reg21722, reg21723)
 																					reg21725 := PrimCons(reg21721, reg21724)
 																					reg21726 := PrimCons(reg21720, reg21725)
-																					reg21727 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																					reg21727 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																					reg21728 := PrimCons(reg21726, reg21727)
 																					reg21729 := PrimCons(reg21719, reg21728)
-																					reg21730 := __e.Call(__defun__bind, V2760, reg21729, V2761, V2762)
+																					reg21730 := Call(__e, __defun__bind, V2760, reg21729, V2761, V2762)
 																					reg21757 = reg21730
 																				} else {
-																					reg21731 := __e.Call(__defun__shen_4pvar_2, V2540)
+																					reg21731 := Call(__e, __defun__shen_4pvar_2, V2540)
 																					var reg21756 Obj
 																					if reg21731 == True {
 																						reg21732 := Nil
-																						reg21733 := __e.Call(__defun__shen_4bindv, V2540, reg21732, V2761)
+																						reg21733 := Call(__e, __defun__shen_4bindv, V2540, reg21732, V2761)
 																						_ = reg21733
 																						reg21734 := PrimTail(V2519)
 																						Hyp := reg21734
 																						_ = Hyp
-																						reg21735 := __e.Call(__defun__shen_4incinfs)
+																						reg21735 := Call(__e, __defun__shen_4incinfs)
 																						_ = reg21735
-																						reg21736 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																						reg21736 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																						reg21737 := MakeSymbol(":")
-																						reg21738 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																						reg21738 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																						reg21739 := Nil
 																						reg21740 := PrimCons(reg21738, reg21739)
 																						reg21741 := PrimCons(reg21737, reg21740)
 																						reg21742 := PrimCons(reg21736, reg21741)
-																						reg21743 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																						reg21743 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																						reg21744 := MakeSymbol(":")
-																						reg21745 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																						reg21745 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																						reg21746 := Nil
 																						reg21747 := PrimCons(reg21745, reg21746)
 																						reg21748 := PrimCons(reg21744, reg21747)
 																						reg21749 := PrimCons(reg21743, reg21748)
-																						reg21750 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																						reg21750 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																						reg21751 := PrimCons(reg21749, reg21750)
 																						reg21752 := PrimCons(reg21742, reg21751)
-																						reg21753 := __e.Call(__defun__bind, V2760, reg21752, V2761, V2762)
+																						reg21753 := Call(__e, __defun__bind, V2760, reg21752, V2761, V2762)
 																						Result := reg21753
 																						_ = Result
-																						reg21754 := __e.Call(__defun__shen_4unbindv, V2540, V2761)
+																						reg21754 := Call(__e, __defun__shen_4unbindv, V2540, V2761)
 																						_ = reg21754
 																						reg21756 = Result
 																					} else {
@@ -5151,7 +5151,7 @@ func init() {
 																				}
 																				Result := reg21757
 																				_ = Result
-																				reg21758 := __e.Call(__defun__shen_4unbindv, V2538, V2761)
+																				reg21758 := Call(__e, __defun__shen_4unbindv, V2538, V2761)
 																				_ = reg21758
 																				reg21760 = Result
 																			} else {
@@ -5162,18 +5162,18 @@ func init() {
 																		}
 																		reg21821 = reg21761
 																	} else {
-																		reg21762 := __e.Call(__defun__shen_4pvar_2, V2537)
+																		reg21762 := Call(__e, __defun__shen_4pvar_2, V2537)
 																		var reg21820 Obj
 																		if reg21762 == True {
-																			reg21763 := __e.Call(__defun__shen_4newpv, V2761)
+																			reg21763 := Call(__e, __defun__shen_4newpv, V2761)
 																			B := reg21763
 																			_ = B
 																			reg21764 := Nil
 																			reg21765 := PrimCons(B, reg21764)
-																			reg21766 := __e.Call(__defun__shen_4bindv, V2537, reg21765, V2761)
+																			reg21766 := Call(__e, __defun__shen_4bindv, V2537, reg21765, V2761)
 																			_ = reg21766
 																			reg21767 := PrimTail(V2528)
-																			reg21768 := __e.Call(__defun__shen_4lazyderef, reg21767, V2761)
+																			reg21768 := Call(__e, __defun__shen_4lazyderef, reg21767, V2761)
 																			V2541 := reg21768
 																			_ = V2541
 																			reg21769 := Nil
@@ -5183,60 +5183,60 @@ func init() {
 																				reg21771 := PrimTail(V2519)
 																				Hyp := reg21771
 																				_ = Hyp
-																				reg21772 := __e.Call(__defun__shen_4incinfs)
+																				reg21772 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg21772
-																				reg21773 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg21773 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg21774 := MakeSymbol(":")
-																				reg21775 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg21775 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg21776 := Nil
 																				reg21777 := PrimCons(reg21775, reg21776)
 																				reg21778 := PrimCons(reg21774, reg21777)
 																				reg21779 := PrimCons(reg21773, reg21778)
-																				reg21780 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg21780 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg21781 := MakeSymbol(":")
-																				reg21782 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																				reg21782 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																				reg21783 := Nil
 																				reg21784 := PrimCons(reg21782, reg21783)
 																				reg21785 := PrimCons(reg21781, reg21784)
 																				reg21786 := PrimCons(reg21780, reg21785)
-																				reg21787 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg21787 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg21788 := PrimCons(reg21786, reg21787)
 																				reg21789 := PrimCons(reg21779, reg21788)
-																				reg21790 := __e.Call(__defun__bind, V2760, reg21789, V2761, V2762)
+																				reg21790 := Call(__e, __defun__bind, V2760, reg21789, V2761, V2762)
 																				reg21817 = reg21790
 																			} else {
-																				reg21791 := __e.Call(__defun__shen_4pvar_2, V2541)
+																				reg21791 := Call(__e, __defun__shen_4pvar_2, V2541)
 																				var reg21816 Obj
 																				if reg21791 == True {
 																					reg21792 := Nil
-																					reg21793 := __e.Call(__defun__shen_4bindv, V2541, reg21792, V2761)
+																					reg21793 := Call(__e, __defun__shen_4bindv, V2541, reg21792, V2761)
 																					_ = reg21793
 																					reg21794 := PrimTail(V2519)
 																					Hyp := reg21794
 																					_ = Hyp
-																					reg21795 := __e.Call(__defun__shen_4incinfs)
+																					reg21795 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg21795
-																					reg21796 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																					reg21796 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																					reg21797 := MakeSymbol(":")
-																					reg21798 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg21798 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg21799 := Nil
 																					reg21800 := PrimCons(reg21798, reg21799)
 																					reg21801 := PrimCons(reg21797, reg21800)
 																					reg21802 := PrimCons(reg21796, reg21801)
-																					reg21803 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																					reg21803 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																					reg21804 := MakeSymbol(":")
-																					reg21805 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																					reg21805 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																					reg21806 := Nil
 																					reg21807 := PrimCons(reg21805, reg21806)
 																					reg21808 := PrimCons(reg21804, reg21807)
 																					reg21809 := PrimCons(reg21803, reg21808)
-																					reg21810 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																					reg21810 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																					reg21811 := PrimCons(reg21809, reg21810)
 																					reg21812 := PrimCons(reg21802, reg21811)
-																					reg21813 := __e.Call(__defun__bind, V2760, reg21812, V2761, V2762)
+																					reg21813 := Call(__e, __defun__bind, V2760, reg21812, V2761, V2762)
 																					Result := reg21813
 																					_ = Result
-																					reg21814 := __e.Call(__defun__shen_4unbindv, V2541, V2761)
+																					reg21814 := Call(__e, __defun__shen_4unbindv, V2541, V2761)
 																					_ = reg21814
 																					reg21816 = Result
 																				} else {
@@ -5247,7 +5247,7 @@ func init() {
 																			}
 																			Result := reg21817
 																			_ = Result
-																			reg21818 := __e.Call(__defun__shen_4unbindv, V2537, V2761)
+																			reg21818 := Call(__e, __defun__shen_4unbindv, V2537, V2761)
 																			_ = reg21818
 																			reg21820 = Result
 																		} else {
@@ -5258,7 +5258,7 @@ func init() {
 																	}
 																	Result := reg21821
 																	_ = Result
-																	reg21822 := __e.Call(__defun__shen_4unbindv, V2531, V2761)
+																	reg21822 := Call(__e, __defun__shen_4unbindv, V2531, V2761)
 																	_ = reg21822
 																	reg21824 = Result
 																} else {
@@ -5269,20 +5269,20 @@ func init() {
 															}
 															reg21887 = reg21825
 														} else {
-															reg21826 := __e.Call(__defun__shen_4pvar_2, V2530)
+															reg21826 := Call(__e, __defun__shen_4pvar_2, V2530)
 															var reg21886 Obj
 															if reg21826 == True {
-																reg21827 := __e.Call(__defun__shen_4newpv, V2761)
+																reg21827 := Call(__e, __defun__shen_4newpv, V2761)
 																B := reg21827
 																_ = B
 																reg21828 := MakeSymbol("*")
 																reg21829 := Nil
 																reg21830 := PrimCons(B, reg21829)
 																reg21831 := PrimCons(reg21828, reg21830)
-																reg21832 := __e.Call(__defun__shen_4bindv, V2530, reg21831, V2761)
+																reg21832 := Call(__e, __defun__shen_4bindv, V2530, reg21831, V2761)
 																_ = reg21832
 																reg21833 := PrimTail(V2528)
-																reg21834 := __e.Call(__defun__shen_4lazyderef, reg21833, V2761)
+																reg21834 := Call(__e, __defun__shen_4lazyderef, reg21833, V2761)
 																V2542 := reg21834
 																_ = V2542
 																reg21835 := Nil
@@ -5292,60 +5292,60 @@ func init() {
 																	reg21837 := PrimTail(V2519)
 																	Hyp := reg21837
 																	_ = Hyp
-																	reg21838 := __e.Call(__defun__shen_4incinfs)
+																	reg21838 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg21838
-																	reg21839 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																	reg21839 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																	reg21840 := MakeSymbol(":")
-																	reg21841 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																	reg21841 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																	reg21842 := Nil
 																	reg21843 := PrimCons(reg21841, reg21842)
 																	reg21844 := PrimCons(reg21840, reg21843)
 																	reg21845 := PrimCons(reg21839, reg21844)
-																	reg21846 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																	reg21846 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																	reg21847 := MakeSymbol(":")
-																	reg21848 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																	reg21848 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																	reg21849 := Nil
 																	reg21850 := PrimCons(reg21848, reg21849)
 																	reg21851 := PrimCons(reg21847, reg21850)
 																	reg21852 := PrimCons(reg21846, reg21851)
-																	reg21853 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																	reg21853 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																	reg21854 := PrimCons(reg21852, reg21853)
 																	reg21855 := PrimCons(reg21845, reg21854)
-																	reg21856 := __e.Call(__defun__bind, V2760, reg21855, V2761, V2762)
+																	reg21856 := Call(__e, __defun__bind, V2760, reg21855, V2761, V2762)
 																	reg21883 = reg21856
 																} else {
-																	reg21857 := __e.Call(__defun__shen_4pvar_2, V2542)
+																	reg21857 := Call(__e, __defun__shen_4pvar_2, V2542)
 																	var reg21882 Obj
 																	if reg21857 == True {
 																		reg21858 := Nil
-																		reg21859 := __e.Call(__defun__shen_4bindv, V2542, reg21858, V2761)
+																		reg21859 := Call(__e, __defun__shen_4bindv, V2542, reg21858, V2761)
 																		_ = reg21859
 																		reg21860 := PrimTail(V2519)
 																		Hyp := reg21860
 																		_ = Hyp
-																		reg21861 := __e.Call(__defun__shen_4incinfs)
+																		reg21861 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg21861
-																		reg21862 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																		reg21862 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																		reg21863 := MakeSymbol(":")
-																		reg21864 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg21864 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg21865 := Nil
 																		reg21866 := PrimCons(reg21864, reg21865)
 																		reg21867 := PrimCons(reg21863, reg21866)
 																		reg21868 := PrimCons(reg21862, reg21867)
-																		reg21869 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																		reg21869 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																		reg21870 := MakeSymbol(":")
-																		reg21871 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																		reg21871 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																		reg21872 := Nil
 																		reg21873 := PrimCons(reg21871, reg21872)
 																		reg21874 := PrimCons(reg21870, reg21873)
 																		reg21875 := PrimCons(reg21869, reg21874)
-																		reg21876 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																		reg21876 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																		reg21877 := PrimCons(reg21875, reg21876)
 																		reg21878 := PrimCons(reg21868, reg21877)
-																		reg21879 := __e.Call(__defun__bind, V2760, reg21878, V2761, V2762)
+																		reg21879 := Call(__e, __defun__bind, V2760, reg21878, V2761, V2762)
 																		Result := reg21879
 																		_ = Result
-																		reg21880 := __e.Call(__defun__shen_4unbindv, V2542, V2761)
+																		reg21880 := Call(__e, __defun__shen_4unbindv, V2542, V2761)
 																		_ = reg21880
 																		reg21882 = Result
 																	} else {
@@ -5356,7 +5356,7 @@ func init() {
 																}
 																Result := reg21883
 																_ = Result
-																reg21884 := __e.Call(__defun__shen_4unbindv, V2530, V2761)
+																reg21884 := Call(__e, __defun__shen_4unbindv, V2530, V2761)
 																_ = reg21884
 																reg21886 = Result
 															} else {
@@ -5367,13 +5367,13 @@ func init() {
 														}
 														reg21951 = reg21887
 													} else {
-														reg21888 := __e.Call(__defun__shen_4pvar_2, V2529)
+														reg21888 := Call(__e, __defun__shen_4pvar_2, V2529)
 														var reg21950 Obj
 														if reg21888 == True {
-															reg21889 := __e.Call(__defun__shen_4newpv, V2761)
+															reg21889 := Call(__e, __defun__shen_4newpv, V2761)
 															A := reg21889
 															_ = A
-															reg21890 := __e.Call(__defun__shen_4newpv, V2761)
+															reg21890 := Call(__e, __defun__shen_4newpv, V2761)
 															B := reg21890
 															_ = B
 															reg21891 := MakeSymbol("*")
@@ -5381,10 +5381,10 @@ func init() {
 															reg21893 := PrimCons(B, reg21892)
 															reg21894 := PrimCons(reg21891, reg21893)
 															reg21895 := PrimCons(A, reg21894)
-															reg21896 := __e.Call(__defun__shen_4bindv, V2529, reg21895, V2761)
+															reg21896 := Call(__e, __defun__shen_4bindv, V2529, reg21895, V2761)
 															_ = reg21896
 															reg21897 := PrimTail(V2528)
-															reg21898 := __e.Call(__defun__shen_4lazyderef, reg21897, V2761)
+															reg21898 := Call(__e, __defun__shen_4lazyderef, reg21897, V2761)
 															V2543 := reg21898
 															_ = V2543
 															reg21899 := Nil
@@ -5394,60 +5394,60 @@ func init() {
 																reg21901 := PrimTail(V2519)
 																Hyp := reg21901
 																_ = Hyp
-																reg21902 := __e.Call(__defun__shen_4incinfs)
+																reg21902 := Call(__e, __defun__shen_4incinfs)
 																_ = reg21902
-																reg21903 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																reg21903 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																reg21904 := MakeSymbol(":")
-																reg21905 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																reg21905 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																reg21906 := Nil
 																reg21907 := PrimCons(reg21905, reg21906)
 																reg21908 := PrimCons(reg21904, reg21907)
 																reg21909 := PrimCons(reg21903, reg21908)
-																reg21910 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																reg21910 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																reg21911 := MakeSymbol(":")
-																reg21912 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																reg21912 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																reg21913 := Nil
 																reg21914 := PrimCons(reg21912, reg21913)
 																reg21915 := PrimCons(reg21911, reg21914)
 																reg21916 := PrimCons(reg21910, reg21915)
-																reg21917 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																reg21917 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																reg21918 := PrimCons(reg21916, reg21917)
 																reg21919 := PrimCons(reg21909, reg21918)
-																reg21920 := __e.Call(__defun__bind, V2760, reg21919, V2761, V2762)
+																reg21920 := Call(__e, __defun__bind, V2760, reg21919, V2761, V2762)
 																reg21947 = reg21920
 															} else {
-																reg21921 := __e.Call(__defun__shen_4pvar_2, V2543)
+																reg21921 := Call(__e, __defun__shen_4pvar_2, V2543)
 																var reg21946 Obj
 																if reg21921 == True {
 																	reg21922 := Nil
-																	reg21923 := __e.Call(__defun__shen_4bindv, V2543, reg21922, V2761)
+																	reg21923 := Call(__e, __defun__shen_4bindv, V2543, reg21922, V2761)
 																	_ = reg21923
 																	reg21924 := PrimTail(V2519)
 																	Hyp := reg21924
 																	_ = Hyp
-																	reg21925 := __e.Call(__defun__shen_4incinfs)
+																	reg21925 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg21925
-																	reg21926 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																	reg21926 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																	reg21927 := MakeSymbol(":")
-																	reg21928 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																	reg21928 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																	reg21929 := Nil
 																	reg21930 := PrimCons(reg21928, reg21929)
 																	reg21931 := PrimCons(reg21927, reg21930)
 																	reg21932 := PrimCons(reg21926, reg21931)
-																	reg21933 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																	reg21933 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																	reg21934 := MakeSymbol(":")
-																	reg21935 := __e.Call(__defun__shen_4lazyderef, B, V2761)
+																	reg21935 := Call(__e, __defun__shen_4lazyderef, B, V2761)
 																	reg21936 := Nil
 																	reg21937 := PrimCons(reg21935, reg21936)
 																	reg21938 := PrimCons(reg21934, reg21937)
 																	reg21939 := PrimCons(reg21933, reg21938)
-																	reg21940 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																	reg21940 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																	reg21941 := PrimCons(reg21939, reg21940)
 																	reg21942 := PrimCons(reg21932, reg21941)
-																	reg21943 := __e.Call(__defun__bind, V2760, reg21942, V2761, V2762)
+																	reg21943 := Call(__e, __defun__bind, V2760, reg21942, V2761, V2762)
 																	Result := reg21943
 																	_ = Result
-																	reg21944 := __e.Call(__defun__shen_4unbindv, V2543, V2761)
+																	reg21944 := Call(__e, __defun__shen_4unbindv, V2543, V2761)
 																	_ = reg21944
 																	reg21946 = Result
 																} else {
@@ -5458,7 +5458,7 @@ func init() {
 															}
 															Result := reg21947
 															_ = Result
-															reg21948 := __e.Call(__defun__shen_4unbindv, V2529, V2761)
+															reg21948 := Call(__e, __defun__shen_4unbindv, V2529, V2761)
 															_ = reg21948
 															reg21950 = Result
 														} else {
@@ -5522,28 +5522,28 @@ func init() {
 			reg21972 := False
 			reg21973 := PrimEqual(Case, reg21972)
 			if reg21973 == True {
-				reg21974 := __e.Call(__defun__shen_4lazyderef, V2759, V2761)
+				reg21974 := Call(__e, __defun__shen_4lazyderef, V2759, V2761)
 				V2544 := reg21974
 				_ = V2544
 				reg21975 := PrimIsPair(V2544)
 				var reg22513 Obj
 				if reg21975 == True {
 					reg21976 := PrimHead(V2544)
-					reg21977 := __e.Call(__defun__shen_4lazyderef, reg21976, V2761)
+					reg21977 := Call(__e, __defun__shen_4lazyderef, reg21976, V2761)
 					V2545 := reg21977
 					_ = V2545
 					reg21978 := PrimIsPair(V2545)
 					var reg22511 Obj
 					if reg21978 == True {
 						reg21979 := PrimHead(V2545)
-						reg21980 := __e.Call(__defun__shen_4lazyderef, reg21979, V2761)
+						reg21980 := Call(__e, __defun__shen_4lazyderef, reg21979, V2761)
 						V2546 := reg21980
 						_ = V2546
 						reg21981 := PrimIsPair(V2546)
 						var reg22509 Obj
 						if reg21981 == True {
 							reg21982 := PrimHead(V2546)
-							reg21983 := __e.Call(__defun__shen_4lazyderef, reg21982, V2761)
+							reg21983 := Call(__e, __defun__shen_4lazyderef, reg21982, V2761)
 							V2547 := reg21983
 							_ = V2547
 							reg21984 := MakeSymbol("@v")
@@ -5551,7 +5551,7 @@ func init() {
 							var reg22507 Obj
 							if reg21985 == True {
 								reg21986 := PrimTail(V2546)
-								reg21987 := __e.Call(__defun__shen_4lazyderef, reg21986, V2761)
+								reg21987 := Call(__e, __defun__shen_4lazyderef, reg21986, V2761)
 								V2548 := reg21987
 								_ = V2548
 								reg21988 := PrimIsPair(V2548)
@@ -5561,7 +5561,7 @@ func init() {
 									X := reg21989
 									_ = X
 									reg21990 := PrimTail(V2548)
-									reg21991 := __e.Call(__defun__shen_4lazyderef, reg21990, V2761)
+									reg21991 := Call(__e, __defun__shen_4lazyderef, reg21990, V2761)
 									V2549 := reg21991
 									_ = V2549
 									reg21992 := PrimIsPair(V2549)
@@ -5571,7 +5571,7 @@ func init() {
 										Y := reg21993
 										_ = Y
 										reg21994 := PrimTail(V2549)
-										reg21995 := __e.Call(__defun__shen_4lazyderef, reg21994, V2761)
+										reg21995 := Call(__e, __defun__shen_4lazyderef, reg21994, V2761)
 										V2550 := reg21995
 										_ = V2550
 										reg21996 := Nil
@@ -5579,14 +5579,14 @@ func init() {
 										var reg22501 Obj
 										if reg21997 == True {
 											reg21998 := PrimTail(V2545)
-											reg21999 := __e.Call(__defun__shen_4lazyderef, reg21998, V2761)
+											reg21999 := Call(__e, __defun__shen_4lazyderef, reg21998, V2761)
 											V2551 := reg21999
 											_ = V2551
 											reg22000 := PrimIsPair(V2551)
 											var reg22499 Obj
 											if reg22000 == True {
 												reg22001 := PrimHead(V2551)
-												reg22002 := __e.Call(__defun__shen_4lazyderef, reg22001, V2761)
+												reg22002 := Call(__e, __defun__shen_4lazyderef, reg22001, V2761)
 												V2552 := reg22002
 												_ = V2552
 												reg22003 := MakeSymbol(":")
@@ -5594,21 +5594,21 @@ func init() {
 												var reg22497 Obj
 												if reg22004 == True {
 													reg22005 := PrimTail(V2551)
-													reg22006 := __e.Call(__defun__shen_4lazyderef, reg22005, V2761)
+													reg22006 := Call(__e, __defun__shen_4lazyderef, reg22005, V2761)
 													V2553 := reg22006
 													_ = V2553
 													reg22007 := PrimIsPair(V2553)
 													var reg22495 Obj
 													if reg22007 == True {
 														reg22008 := PrimHead(V2553)
-														reg22009 := __e.Call(__defun__shen_4lazyderef, reg22008, V2761)
+														reg22009 := Call(__e, __defun__shen_4lazyderef, reg22008, V2761)
 														V2554 := reg22009
 														_ = V2554
 														reg22010 := PrimIsPair(V2554)
 														var reg22493 Obj
 														if reg22010 == True {
 															reg22011 := PrimHead(V2554)
-															reg22012 := __e.Call(__defun__shen_4lazyderef, reg22011, V2761)
+															reg22012 := Call(__e, __defun__shen_4lazyderef, reg22011, V2761)
 															V2555 := reg22012
 															_ = V2555
 															reg22013 := MakeSymbol("vector")
@@ -5616,7 +5616,7 @@ func init() {
 															var reg22423 Obj
 															if reg22014 == True {
 																reg22015 := PrimTail(V2554)
-																reg22016 := __e.Call(__defun__shen_4lazyderef, reg22015, V2761)
+																reg22016 := Call(__e, __defun__shen_4lazyderef, reg22015, V2761)
 																V2556 := reg22016
 																_ = V2556
 																reg22017 := PrimIsPair(V2556)
@@ -5626,7 +5626,7 @@ func init() {
 																	A := reg22018
 																	_ = A
 																	reg22019 := PrimTail(V2556)
-																	reg22020 := __e.Call(__defun__shen_4lazyderef, reg22019, V2761)
+																	reg22020 := Call(__e, __defun__shen_4lazyderef, reg22019, V2761)
 																	V2557 := reg22020
 																	_ = V2557
 																	reg22021 := Nil
@@ -5634,7 +5634,7 @@ func init() {
 																	var reg22147 Obj
 																	if reg22022 == True {
 																		reg22023 := PrimTail(V2553)
-																		reg22024 := __e.Call(__defun__shen_4lazyderef, reg22023, V2761)
+																		reg22024 := Call(__e, __defun__shen_4lazyderef, reg22023, V2761)
 																		V2558 := reg22024
 																		_ = V2558
 																		reg22025 := Nil
@@ -5644,19 +5644,19 @@ func init() {
 																			reg22027 := PrimTail(V2544)
 																			Hyp := reg22027
 																			_ = Hyp
-																			reg22028 := __e.Call(__defun__shen_4incinfs)
+																			reg22028 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg22028
-																			reg22029 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																			reg22029 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																			reg22030 := MakeSymbol(":")
-																			reg22031 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg22031 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg22032 := Nil
 																			reg22033 := PrimCons(reg22031, reg22032)
 																			reg22034 := PrimCons(reg22030, reg22033)
 																			reg22035 := PrimCons(reg22029, reg22034)
-																			reg22036 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																			reg22036 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																			reg22037 := MakeSymbol(":")
 																			reg22038 := MakeSymbol("vector")
-																			reg22039 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg22039 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg22040 := Nil
 																			reg22041 := PrimCons(reg22039, reg22040)
 																			reg22042 := PrimCons(reg22038, reg22041)
@@ -5664,34 +5664,34 @@ func init() {
 																			reg22044 := PrimCons(reg22042, reg22043)
 																			reg22045 := PrimCons(reg22037, reg22044)
 																			reg22046 := PrimCons(reg22036, reg22045)
-																			reg22047 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																			reg22047 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																			reg22048 := PrimCons(reg22046, reg22047)
 																			reg22049 := PrimCons(reg22035, reg22048)
-																			reg22050 := __e.Call(__defun__bind, V2760, reg22049, V2761, V2762)
+																			reg22050 := Call(__e, __defun__bind, V2760, reg22049, V2761, V2762)
 																			reg22081 = reg22050
 																		} else {
-																			reg22051 := __e.Call(__defun__shen_4pvar_2, V2558)
+																			reg22051 := Call(__e, __defun__shen_4pvar_2, V2558)
 																			var reg22080 Obj
 																			if reg22051 == True {
 																				reg22052 := Nil
-																				reg22053 := __e.Call(__defun__shen_4bindv, V2558, reg22052, V2761)
+																				reg22053 := Call(__e, __defun__shen_4bindv, V2558, reg22052, V2761)
 																				_ = reg22053
 																				reg22054 := PrimTail(V2544)
 																				Hyp := reg22054
 																				_ = Hyp
-																				reg22055 := __e.Call(__defun__shen_4incinfs)
+																				reg22055 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg22055
-																				reg22056 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg22056 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg22057 := MakeSymbol(":")
-																				reg22058 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22058 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22059 := Nil
 																				reg22060 := PrimCons(reg22058, reg22059)
 																				reg22061 := PrimCons(reg22057, reg22060)
 																				reg22062 := PrimCons(reg22056, reg22061)
-																				reg22063 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg22063 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg22064 := MakeSymbol(":")
 																				reg22065 := MakeSymbol("vector")
-																				reg22066 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22066 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22067 := Nil
 																				reg22068 := PrimCons(reg22066, reg22067)
 																				reg22069 := PrimCons(reg22065, reg22068)
@@ -5699,13 +5699,13 @@ func init() {
 																				reg22071 := PrimCons(reg22069, reg22070)
 																				reg22072 := PrimCons(reg22064, reg22071)
 																				reg22073 := PrimCons(reg22063, reg22072)
-																				reg22074 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg22074 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg22075 := PrimCons(reg22073, reg22074)
 																				reg22076 := PrimCons(reg22062, reg22075)
-																				reg22077 := __e.Call(__defun__bind, V2760, reg22076, V2761, V2762)
+																				reg22077 := Call(__e, __defun__bind, V2760, reg22076, V2761, V2762)
 																				Result := reg22077
 																				_ = Result
-																				reg22078 := __e.Call(__defun__shen_4unbindv, V2558, V2761)
+																				reg22078 := Call(__e, __defun__shen_4unbindv, V2558, V2761)
 																				_ = reg22078
 																				reg22080 = Result
 																			} else {
@@ -5716,14 +5716,14 @@ func init() {
 																		}
 																		reg22147 = reg22081
 																	} else {
-																		reg22082 := __e.Call(__defun__shen_4pvar_2, V2557)
+																		reg22082 := Call(__e, __defun__shen_4pvar_2, V2557)
 																		var reg22146 Obj
 																		if reg22082 == True {
 																			reg22083 := Nil
-																			reg22084 := __e.Call(__defun__shen_4bindv, V2557, reg22083, V2761)
+																			reg22084 := Call(__e, __defun__shen_4bindv, V2557, reg22083, V2761)
 																			_ = reg22084
 																			reg22085 := PrimTail(V2553)
-																			reg22086 := __e.Call(__defun__shen_4lazyderef, reg22085, V2761)
+																			reg22086 := Call(__e, __defun__shen_4lazyderef, reg22085, V2761)
 																			V2559 := reg22086
 																			_ = V2559
 																			reg22087 := Nil
@@ -5733,19 +5733,19 @@ func init() {
 																				reg22089 := PrimTail(V2544)
 																				Hyp := reg22089
 																				_ = Hyp
-																				reg22090 := __e.Call(__defun__shen_4incinfs)
+																				reg22090 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg22090
-																				reg22091 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg22091 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg22092 := MakeSymbol(":")
-																				reg22093 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22093 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22094 := Nil
 																				reg22095 := PrimCons(reg22093, reg22094)
 																				reg22096 := PrimCons(reg22092, reg22095)
 																				reg22097 := PrimCons(reg22091, reg22096)
-																				reg22098 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg22098 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg22099 := MakeSymbol(":")
 																				reg22100 := MakeSymbol("vector")
-																				reg22101 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22101 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22102 := Nil
 																				reg22103 := PrimCons(reg22101, reg22102)
 																				reg22104 := PrimCons(reg22100, reg22103)
@@ -5753,34 +5753,34 @@ func init() {
 																				reg22106 := PrimCons(reg22104, reg22105)
 																				reg22107 := PrimCons(reg22099, reg22106)
 																				reg22108 := PrimCons(reg22098, reg22107)
-																				reg22109 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg22109 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg22110 := PrimCons(reg22108, reg22109)
 																				reg22111 := PrimCons(reg22097, reg22110)
-																				reg22112 := __e.Call(__defun__bind, V2760, reg22111, V2761, V2762)
+																				reg22112 := Call(__e, __defun__bind, V2760, reg22111, V2761, V2762)
 																				reg22143 = reg22112
 																			} else {
-																				reg22113 := __e.Call(__defun__shen_4pvar_2, V2559)
+																				reg22113 := Call(__e, __defun__shen_4pvar_2, V2559)
 																				var reg22142 Obj
 																				if reg22113 == True {
 																					reg22114 := Nil
-																					reg22115 := __e.Call(__defun__shen_4bindv, V2559, reg22114, V2761)
+																					reg22115 := Call(__e, __defun__shen_4bindv, V2559, reg22114, V2761)
 																					_ = reg22115
 																					reg22116 := PrimTail(V2544)
 																					Hyp := reg22116
 																					_ = Hyp
-																					reg22117 := __e.Call(__defun__shen_4incinfs)
+																					reg22117 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg22117
-																					reg22118 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																					reg22118 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																					reg22119 := MakeSymbol(":")
-																					reg22120 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg22120 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg22121 := Nil
 																					reg22122 := PrimCons(reg22120, reg22121)
 																					reg22123 := PrimCons(reg22119, reg22122)
 																					reg22124 := PrimCons(reg22118, reg22123)
-																					reg22125 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																					reg22125 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																					reg22126 := MakeSymbol(":")
 																					reg22127 := MakeSymbol("vector")
-																					reg22128 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg22128 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg22129 := Nil
 																					reg22130 := PrimCons(reg22128, reg22129)
 																					reg22131 := PrimCons(reg22127, reg22130)
@@ -5788,13 +5788,13 @@ func init() {
 																					reg22133 := PrimCons(reg22131, reg22132)
 																					reg22134 := PrimCons(reg22126, reg22133)
 																					reg22135 := PrimCons(reg22125, reg22134)
-																					reg22136 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																					reg22136 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																					reg22137 := PrimCons(reg22135, reg22136)
 																					reg22138 := PrimCons(reg22124, reg22137)
-																					reg22139 := __e.Call(__defun__bind, V2760, reg22138, V2761, V2762)
+																					reg22139 := Call(__e, __defun__bind, V2760, reg22138, V2761, V2762)
 																					Result := reg22139
 																					_ = Result
-																					reg22140 := __e.Call(__defun__shen_4unbindv, V2559, V2761)
+																					reg22140 := Call(__e, __defun__shen_4unbindv, V2559, V2761)
 																					_ = reg22140
 																					reg22142 = Result
 																				} else {
@@ -5805,7 +5805,7 @@ func init() {
 																			}
 																			Result := reg22143
 																			_ = Result
-																			reg22144 := __e.Call(__defun__shen_4unbindv, V2557, V2761)
+																			reg22144 := Call(__e, __defun__shen_4unbindv, V2557, V2761)
 																			_ = reg22144
 																			reg22146 = Result
 																		} else {
@@ -5816,18 +5816,18 @@ func init() {
 																	}
 																	reg22215 = reg22147
 																} else {
-																	reg22148 := __e.Call(__defun__shen_4pvar_2, V2556)
+																	reg22148 := Call(__e, __defun__shen_4pvar_2, V2556)
 																	var reg22214 Obj
 																	if reg22148 == True {
-																		reg22149 := __e.Call(__defun__shen_4newpv, V2761)
+																		reg22149 := Call(__e, __defun__shen_4newpv, V2761)
 																		A := reg22149
 																		_ = A
 																		reg22150 := Nil
 																		reg22151 := PrimCons(A, reg22150)
-																		reg22152 := __e.Call(__defun__shen_4bindv, V2556, reg22151, V2761)
+																		reg22152 := Call(__e, __defun__shen_4bindv, V2556, reg22151, V2761)
 																		_ = reg22152
 																		reg22153 := PrimTail(V2553)
-																		reg22154 := __e.Call(__defun__shen_4lazyderef, reg22153, V2761)
+																		reg22154 := Call(__e, __defun__shen_4lazyderef, reg22153, V2761)
 																		V2560 := reg22154
 																		_ = V2560
 																		reg22155 := Nil
@@ -5837,19 +5837,19 @@ func init() {
 																			reg22157 := PrimTail(V2544)
 																			Hyp := reg22157
 																			_ = Hyp
-																			reg22158 := __e.Call(__defun__shen_4incinfs)
+																			reg22158 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg22158
-																			reg22159 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																			reg22159 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																			reg22160 := MakeSymbol(":")
-																			reg22161 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg22161 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg22162 := Nil
 																			reg22163 := PrimCons(reg22161, reg22162)
 																			reg22164 := PrimCons(reg22160, reg22163)
 																			reg22165 := PrimCons(reg22159, reg22164)
-																			reg22166 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																			reg22166 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																			reg22167 := MakeSymbol(":")
 																			reg22168 := MakeSymbol("vector")
-																			reg22169 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																			reg22169 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																			reg22170 := Nil
 																			reg22171 := PrimCons(reg22169, reg22170)
 																			reg22172 := PrimCons(reg22168, reg22171)
@@ -5857,34 +5857,34 @@ func init() {
 																			reg22174 := PrimCons(reg22172, reg22173)
 																			reg22175 := PrimCons(reg22167, reg22174)
 																			reg22176 := PrimCons(reg22166, reg22175)
-																			reg22177 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																			reg22177 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																			reg22178 := PrimCons(reg22176, reg22177)
 																			reg22179 := PrimCons(reg22165, reg22178)
-																			reg22180 := __e.Call(__defun__bind, V2760, reg22179, V2761, V2762)
+																			reg22180 := Call(__e, __defun__bind, V2760, reg22179, V2761, V2762)
 																			reg22211 = reg22180
 																		} else {
-																			reg22181 := __e.Call(__defun__shen_4pvar_2, V2560)
+																			reg22181 := Call(__e, __defun__shen_4pvar_2, V2560)
 																			var reg22210 Obj
 																			if reg22181 == True {
 																				reg22182 := Nil
-																				reg22183 := __e.Call(__defun__shen_4bindv, V2560, reg22182, V2761)
+																				reg22183 := Call(__e, __defun__shen_4bindv, V2560, reg22182, V2761)
 																				_ = reg22183
 																				reg22184 := PrimTail(V2544)
 																				Hyp := reg22184
 																				_ = Hyp
-																				reg22185 := __e.Call(__defun__shen_4incinfs)
+																				reg22185 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg22185
-																				reg22186 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg22186 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg22187 := MakeSymbol(":")
-																				reg22188 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22188 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22189 := Nil
 																				reg22190 := PrimCons(reg22188, reg22189)
 																				reg22191 := PrimCons(reg22187, reg22190)
 																				reg22192 := PrimCons(reg22186, reg22191)
-																				reg22193 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg22193 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg22194 := MakeSymbol(":")
 																				reg22195 := MakeSymbol("vector")
-																				reg22196 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22196 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22197 := Nil
 																				reg22198 := PrimCons(reg22196, reg22197)
 																				reg22199 := PrimCons(reg22195, reg22198)
@@ -5892,13 +5892,13 @@ func init() {
 																				reg22201 := PrimCons(reg22199, reg22200)
 																				reg22202 := PrimCons(reg22194, reg22201)
 																				reg22203 := PrimCons(reg22193, reg22202)
-																				reg22204 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg22204 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg22205 := PrimCons(reg22203, reg22204)
 																				reg22206 := PrimCons(reg22192, reg22205)
-																				reg22207 := __e.Call(__defun__bind, V2760, reg22206, V2761, V2762)
+																				reg22207 := Call(__e, __defun__bind, V2760, reg22206, V2761, V2762)
 																				Result := reg22207
 																				_ = Result
-																				reg22208 := __e.Call(__defun__shen_4unbindv, V2560, V2761)
+																				reg22208 := Call(__e, __defun__shen_4unbindv, V2560, V2761)
 																				_ = reg22208
 																				reg22210 = Result
 																			} else {
@@ -5909,7 +5909,7 @@ func init() {
 																		}
 																		Result := reg22211
 																		_ = Result
-																		reg22212 := __e.Call(__defun__shen_4unbindv, V2556, V2761)
+																		reg22212 := Call(__e, __defun__shen_4unbindv, V2556, V2761)
 																		_ = reg22212
 																		reg22214 = Result
 																	} else {
@@ -5920,14 +5920,14 @@ func init() {
 																}
 																reg22423 = reg22215
 															} else {
-																reg22216 := __e.Call(__defun__shen_4pvar_2, V2555)
+																reg22216 := Call(__e, __defun__shen_4pvar_2, V2555)
 																var reg22422 Obj
 																if reg22216 == True {
 																	reg22217 := MakeSymbol("vector")
-																	reg22218 := __e.Call(__defun__shen_4bindv, V2555, reg22217, V2761)
+																	reg22218 := Call(__e, __defun__shen_4bindv, V2555, reg22217, V2761)
 																	_ = reg22218
 																	reg22219 := PrimTail(V2554)
-																	reg22220 := __e.Call(__defun__shen_4lazyderef, reg22219, V2761)
+																	reg22220 := Call(__e, __defun__shen_4lazyderef, reg22219, V2761)
 																	V2561 := reg22220
 																	_ = V2561
 																	reg22221 := PrimIsPair(V2561)
@@ -5937,7 +5937,7 @@ func init() {
 																		A := reg22222
 																		_ = A
 																		reg22223 := PrimTail(V2561)
-																		reg22224 := __e.Call(__defun__shen_4lazyderef, reg22223, V2761)
+																		reg22224 := Call(__e, __defun__shen_4lazyderef, reg22223, V2761)
 																		V2562 := reg22224
 																		_ = V2562
 																		reg22225 := Nil
@@ -5945,7 +5945,7 @@ func init() {
 																		var reg22351 Obj
 																		if reg22226 == True {
 																			reg22227 := PrimTail(V2553)
-																			reg22228 := __e.Call(__defun__shen_4lazyderef, reg22227, V2761)
+																			reg22228 := Call(__e, __defun__shen_4lazyderef, reg22227, V2761)
 																			V2563 := reg22228
 																			_ = V2563
 																			reg22229 := Nil
@@ -5955,19 +5955,19 @@ func init() {
 																				reg22231 := PrimTail(V2544)
 																				Hyp := reg22231
 																				_ = Hyp
-																				reg22232 := __e.Call(__defun__shen_4incinfs)
+																				reg22232 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg22232
-																				reg22233 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg22233 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg22234 := MakeSymbol(":")
-																				reg22235 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22235 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22236 := Nil
 																				reg22237 := PrimCons(reg22235, reg22236)
 																				reg22238 := PrimCons(reg22234, reg22237)
 																				reg22239 := PrimCons(reg22233, reg22238)
-																				reg22240 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg22240 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg22241 := MakeSymbol(":")
 																				reg22242 := MakeSymbol("vector")
-																				reg22243 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22243 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22244 := Nil
 																				reg22245 := PrimCons(reg22243, reg22244)
 																				reg22246 := PrimCons(reg22242, reg22245)
@@ -5975,34 +5975,34 @@ func init() {
 																				reg22248 := PrimCons(reg22246, reg22247)
 																				reg22249 := PrimCons(reg22241, reg22248)
 																				reg22250 := PrimCons(reg22240, reg22249)
-																				reg22251 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg22251 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg22252 := PrimCons(reg22250, reg22251)
 																				reg22253 := PrimCons(reg22239, reg22252)
-																				reg22254 := __e.Call(__defun__bind, V2760, reg22253, V2761, V2762)
+																				reg22254 := Call(__e, __defun__bind, V2760, reg22253, V2761, V2762)
 																				reg22285 = reg22254
 																			} else {
-																				reg22255 := __e.Call(__defun__shen_4pvar_2, V2563)
+																				reg22255 := Call(__e, __defun__shen_4pvar_2, V2563)
 																				var reg22284 Obj
 																				if reg22255 == True {
 																					reg22256 := Nil
-																					reg22257 := __e.Call(__defun__shen_4bindv, V2563, reg22256, V2761)
+																					reg22257 := Call(__e, __defun__shen_4bindv, V2563, reg22256, V2761)
 																					_ = reg22257
 																					reg22258 := PrimTail(V2544)
 																					Hyp := reg22258
 																					_ = Hyp
-																					reg22259 := __e.Call(__defun__shen_4incinfs)
+																					reg22259 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg22259
-																					reg22260 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																					reg22260 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																					reg22261 := MakeSymbol(":")
-																					reg22262 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg22262 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg22263 := Nil
 																					reg22264 := PrimCons(reg22262, reg22263)
 																					reg22265 := PrimCons(reg22261, reg22264)
 																					reg22266 := PrimCons(reg22260, reg22265)
-																					reg22267 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																					reg22267 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																					reg22268 := MakeSymbol(":")
 																					reg22269 := MakeSymbol("vector")
-																					reg22270 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg22270 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg22271 := Nil
 																					reg22272 := PrimCons(reg22270, reg22271)
 																					reg22273 := PrimCons(reg22269, reg22272)
@@ -6010,13 +6010,13 @@ func init() {
 																					reg22275 := PrimCons(reg22273, reg22274)
 																					reg22276 := PrimCons(reg22268, reg22275)
 																					reg22277 := PrimCons(reg22267, reg22276)
-																					reg22278 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																					reg22278 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																					reg22279 := PrimCons(reg22277, reg22278)
 																					reg22280 := PrimCons(reg22266, reg22279)
-																					reg22281 := __e.Call(__defun__bind, V2760, reg22280, V2761, V2762)
+																					reg22281 := Call(__e, __defun__bind, V2760, reg22280, V2761, V2762)
 																					Result := reg22281
 																					_ = Result
-																					reg22282 := __e.Call(__defun__shen_4unbindv, V2563, V2761)
+																					reg22282 := Call(__e, __defun__shen_4unbindv, V2563, V2761)
 																					_ = reg22282
 																					reg22284 = Result
 																				} else {
@@ -6027,14 +6027,14 @@ func init() {
 																			}
 																			reg22351 = reg22285
 																		} else {
-																			reg22286 := __e.Call(__defun__shen_4pvar_2, V2562)
+																			reg22286 := Call(__e, __defun__shen_4pvar_2, V2562)
 																			var reg22350 Obj
 																			if reg22286 == True {
 																				reg22287 := Nil
-																				reg22288 := __e.Call(__defun__shen_4bindv, V2562, reg22287, V2761)
+																				reg22288 := Call(__e, __defun__shen_4bindv, V2562, reg22287, V2761)
 																				_ = reg22288
 																				reg22289 := PrimTail(V2553)
-																				reg22290 := __e.Call(__defun__shen_4lazyderef, reg22289, V2761)
+																				reg22290 := Call(__e, __defun__shen_4lazyderef, reg22289, V2761)
 																				V2564 := reg22290
 																				_ = V2564
 																				reg22291 := Nil
@@ -6044,19 +6044,19 @@ func init() {
 																					reg22293 := PrimTail(V2544)
 																					Hyp := reg22293
 																					_ = Hyp
-																					reg22294 := __e.Call(__defun__shen_4incinfs)
+																					reg22294 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg22294
-																					reg22295 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																					reg22295 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																					reg22296 := MakeSymbol(":")
-																					reg22297 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg22297 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg22298 := Nil
 																					reg22299 := PrimCons(reg22297, reg22298)
 																					reg22300 := PrimCons(reg22296, reg22299)
 																					reg22301 := PrimCons(reg22295, reg22300)
-																					reg22302 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																					reg22302 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																					reg22303 := MakeSymbol(":")
 																					reg22304 := MakeSymbol("vector")
-																					reg22305 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg22305 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg22306 := Nil
 																					reg22307 := PrimCons(reg22305, reg22306)
 																					reg22308 := PrimCons(reg22304, reg22307)
@@ -6064,34 +6064,34 @@ func init() {
 																					reg22310 := PrimCons(reg22308, reg22309)
 																					reg22311 := PrimCons(reg22303, reg22310)
 																					reg22312 := PrimCons(reg22302, reg22311)
-																					reg22313 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																					reg22313 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																					reg22314 := PrimCons(reg22312, reg22313)
 																					reg22315 := PrimCons(reg22301, reg22314)
-																					reg22316 := __e.Call(__defun__bind, V2760, reg22315, V2761, V2762)
+																					reg22316 := Call(__e, __defun__bind, V2760, reg22315, V2761, V2762)
 																					reg22347 = reg22316
 																				} else {
-																					reg22317 := __e.Call(__defun__shen_4pvar_2, V2564)
+																					reg22317 := Call(__e, __defun__shen_4pvar_2, V2564)
 																					var reg22346 Obj
 																					if reg22317 == True {
 																						reg22318 := Nil
-																						reg22319 := __e.Call(__defun__shen_4bindv, V2564, reg22318, V2761)
+																						reg22319 := Call(__e, __defun__shen_4bindv, V2564, reg22318, V2761)
 																						_ = reg22319
 																						reg22320 := PrimTail(V2544)
 																						Hyp := reg22320
 																						_ = Hyp
-																						reg22321 := __e.Call(__defun__shen_4incinfs)
+																						reg22321 := Call(__e, __defun__shen_4incinfs)
 																						_ = reg22321
-																						reg22322 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																						reg22322 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																						reg22323 := MakeSymbol(":")
-																						reg22324 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																						reg22324 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																						reg22325 := Nil
 																						reg22326 := PrimCons(reg22324, reg22325)
 																						reg22327 := PrimCons(reg22323, reg22326)
 																						reg22328 := PrimCons(reg22322, reg22327)
-																						reg22329 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																						reg22329 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																						reg22330 := MakeSymbol(":")
 																						reg22331 := MakeSymbol("vector")
-																						reg22332 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																						reg22332 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																						reg22333 := Nil
 																						reg22334 := PrimCons(reg22332, reg22333)
 																						reg22335 := PrimCons(reg22331, reg22334)
@@ -6099,13 +6099,13 @@ func init() {
 																						reg22337 := PrimCons(reg22335, reg22336)
 																						reg22338 := PrimCons(reg22330, reg22337)
 																						reg22339 := PrimCons(reg22329, reg22338)
-																						reg22340 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																						reg22340 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																						reg22341 := PrimCons(reg22339, reg22340)
 																						reg22342 := PrimCons(reg22328, reg22341)
-																						reg22343 := __e.Call(__defun__bind, V2760, reg22342, V2761, V2762)
+																						reg22343 := Call(__e, __defun__bind, V2760, reg22342, V2761, V2762)
 																						Result := reg22343
 																						_ = Result
-																						reg22344 := __e.Call(__defun__shen_4unbindv, V2564, V2761)
+																						reg22344 := Call(__e, __defun__shen_4unbindv, V2564, V2761)
 																						_ = reg22344
 																						reg22346 = Result
 																					} else {
@@ -6116,7 +6116,7 @@ func init() {
 																				}
 																				Result := reg22347
 																				_ = Result
-																				reg22348 := __e.Call(__defun__shen_4unbindv, V2562, V2761)
+																				reg22348 := Call(__e, __defun__shen_4unbindv, V2562, V2761)
 																				_ = reg22348
 																				reg22350 = Result
 																			} else {
@@ -6127,18 +6127,18 @@ func init() {
 																		}
 																		reg22419 = reg22351
 																	} else {
-																		reg22352 := __e.Call(__defun__shen_4pvar_2, V2561)
+																		reg22352 := Call(__e, __defun__shen_4pvar_2, V2561)
 																		var reg22418 Obj
 																		if reg22352 == True {
-																			reg22353 := __e.Call(__defun__shen_4newpv, V2761)
+																			reg22353 := Call(__e, __defun__shen_4newpv, V2761)
 																			A := reg22353
 																			_ = A
 																			reg22354 := Nil
 																			reg22355 := PrimCons(A, reg22354)
-																			reg22356 := __e.Call(__defun__shen_4bindv, V2561, reg22355, V2761)
+																			reg22356 := Call(__e, __defun__shen_4bindv, V2561, reg22355, V2761)
 																			_ = reg22356
 																			reg22357 := PrimTail(V2553)
-																			reg22358 := __e.Call(__defun__shen_4lazyderef, reg22357, V2761)
+																			reg22358 := Call(__e, __defun__shen_4lazyderef, reg22357, V2761)
 																			V2565 := reg22358
 																			_ = V2565
 																			reg22359 := Nil
@@ -6148,19 +6148,19 @@ func init() {
 																				reg22361 := PrimTail(V2544)
 																				Hyp := reg22361
 																				_ = Hyp
-																				reg22362 := __e.Call(__defun__shen_4incinfs)
+																				reg22362 := Call(__e, __defun__shen_4incinfs)
 																				_ = reg22362
-																				reg22363 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																				reg22363 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																				reg22364 := MakeSymbol(":")
-																				reg22365 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22365 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22366 := Nil
 																				reg22367 := PrimCons(reg22365, reg22366)
 																				reg22368 := PrimCons(reg22364, reg22367)
 																				reg22369 := PrimCons(reg22363, reg22368)
-																				reg22370 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																				reg22370 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																				reg22371 := MakeSymbol(":")
 																				reg22372 := MakeSymbol("vector")
-																				reg22373 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																				reg22373 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																				reg22374 := Nil
 																				reg22375 := PrimCons(reg22373, reg22374)
 																				reg22376 := PrimCons(reg22372, reg22375)
@@ -6168,34 +6168,34 @@ func init() {
 																				reg22378 := PrimCons(reg22376, reg22377)
 																				reg22379 := PrimCons(reg22371, reg22378)
 																				reg22380 := PrimCons(reg22370, reg22379)
-																				reg22381 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																				reg22381 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																				reg22382 := PrimCons(reg22380, reg22381)
 																				reg22383 := PrimCons(reg22369, reg22382)
-																				reg22384 := __e.Call(__defun__bind, V2760, reg22383, V2761, V2762)
+																				reg22384 := Call(__e, __defun__bind, V2760, reg22383, V2761, V2762)
 																				reg22415 = reg22384
 																			} else {
-																				reg22385 := __e.Call(__defun__shen_4pvar_2, V2565)
+																				reg22385 := Call(__e, __defun__shen_4pvar_2, V2565)
 																				var reg22414 Obj
 																				if reg22385 == True {
 																					reg22386 := Nil
-																					reg22387 := __e.Call(__defun__shen_4bindv, V2565, reg22386, V2761)
+																					reg22387 := Call(__e, __defun__shen_4bindv, V2565, reg22386, V2761)
 																					_ = reg22387
 																					reg22388 := PrimTail(V2544)
 																					Hyp := reg22388
 																					_ = Hyp
-																					reg22389 := __e.Call(__defun__shen_4incinfs)
+																					reg22389 := Call(__e, __defun__shen_4incinfs)
 																					_ = reg22389
-																					reg22390 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																					reg22390 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																					reg22391 := MakeSymbol(":")
-																					reg22392 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg22392 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg22393 := Nil
 																					reg22394 := PrimCons(reg22392, reg22393)
 																					reg22395 := PrimCons(reg22391, reg22394)
 																					reg22396 := PrimCons(reg22390, reg22395)
-																					reg22397 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																					reg22397 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																					reg22398 := MakeSymbol(":")
 																					reg22399 := MakeSymbol("vector")
-																					reg22400 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																					reg22400 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																					reg22401 := Nil
 																					reg22402 := PrimCons(reg22400, reg22401)
 																					reg22403 := PrimCons(reg22399, reg22402)
@@ -6203,13 +6203,13 @@ func init() {
 																					reg22405 := PrimCons(reg22403, reg22404)
 																					reg22406 := PrimCons(reg22398, reg22405)
 																					reg22407 := PrimCons(reg22397, reg22406)
-																					reg22408 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																					reg22408 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																					reg22409 := PrimCons(reg22407, reg22408)
 																					reg22410 := PrimCons(reg22396, reg22409)
-																					reg22411 := __e.Call(__defun__bind, V2760, reg22410, V2761, V2762)
+																					reg22411 := Call(__e, __defun__bind, V2760, reg22410, V2761, V2762)
 																					Result := reg22411
 																					_ = Result
-																					reg22412 := __e.Call(__defun__shen_4unbindv, V2565, V2761)
+																					reg22412 := Call(__e, __defun__shen_4unbindv, V2565, V2761)
 																					_ = reg22412
 																					reg22414 = Result
 																				} else {
@@ -6220,7 +6220,7 @@ func init() {
 																			}
 																			Result := reg22415
 																			_ = Result
-																			reg22416 := __e.Call(__defun__shen_4unbindv, V2561, V2761)
+																			reg22416 := Call(__e, __defun__shen_4unbindv, V2561, V2761)
 																			_ = reg22416
 																			reg22418 = Result
 																		} else {
@@ -6231,7 +6231,7 @@ func init() {
 																	}
 																	Result := reg22419
 																	_ = Result
-																	reg22420 := __e.Call(__defun__shen_4unbindv, V2555, V2761)
+																	reg22420 := Call(__e, __defun__shen_4unbindv, V2555, V2761)
 																	_ = reg22420
 																	reg22422 = Result
 																} else {
@@ -6242,20 +6242,20 @@ func init() {
 															}
 															reg22493 = reg22423
 														} else {
-															reg22424 := __e.Call(__defun__shen_4pvar_2, V2554)
+															reg22424 := Call(__e, __defun__shen_4pvar_2, V2554)
 															var reg22492 Obj
 															if reg22424 == True {
-																reg22425 := __e.Call(__defun__shen_4newpv, V2761)
+																reg22425 := Call(__e, __defun__shen_4newpv, V2761)
 																A := reg22425
 																_ = A
 																reg22426 := MakeSymbol("vector")
 																reg22427 := Nil
 																reg22428 := PrimCons(A, reg22427)
 																reg22429 := PrimCons(reg22426, reg22428)
-																reg22430 := __e.Call(__defun__shen_4bindv, V2554, reg22429, V2761)
+																reg22430 := Call(__e, __defun__shen_4bindv, V2554, reg22429, V2761)
 																_ = reg22430
 																reg22431 := PrimTail(V2553)
-																reg22432 := __e.Call(__defun__shen_4lazyderef, reg22431, V2761)
+																reg22432 := Call(__e, __defun__shen_4lazyderef, reg22431, V2761)
 																V2566 := reg22432
 																_ = V2566
 																reg22433 := Nil
@@ -6265,19 +6265,19 @@ func init() {
 																	reg22435 := PrimTail(V2544)
 																	Hyp := reg22435
 																	_ = Hyp
-																	reg22436 := __e.Call(__defun__shen_4incinfs)
+																	reg22436 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg22436
-																	reg22437 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																	reg22437 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																	reg22438 := MakeSymbol(":")
-																	reg22439 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																	reg22439 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																	reg22440 := Nil
 																	reg22441 := PrimCons(reg22439, reg22440)
 																	reg22442 := PrimCons(reg22438, reg22441)
 																	reg22443 := PrimCons(reg22437, reg22442)
-																	reg22444 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																	reg22444 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																	reg22445 := MakeSymbol(":")
 																	reg22446 := MakeSymbol("vector")
-																	reg22447 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																	reg22447 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																	reg22448 := Nil
 																	reg22449 := PrimCons(reg22447, reg22448)
 																	reg22450 := PrimCons(reg22446, reg22449)
@@ -6285,34 +6285,34 @@ func init() {
 																	reg22452 := PrimCons(reg22450, reg22451)
 																	reg22453 := PrimCons(reg22445, reg22452)
 																	reg22454 := PrimCons(reg22444, reg22453)
-																	reg22455 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																	reg22455 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																	reg22456 := PrimCons(reg22454, reg22455)
 																	reg22457 := PrimCons(reg22443, reg22456)
-																	reg22458 := __e.Call(__defun__bind, V2760, reg22457, V2761, V2762)
+																	reg22458 := Call(__e, __defun__bind, V2760, reg22457, V2761, V2762)
 																	reg22489 = reg22458
 																} else {
-																	reg22459 := __e.Call(__defun__shen_4pvar_2, V2566)
+																	reg22459 := Call(__e, __defun__shen_4pvar_2, V2566)
 																	var reg22488 Obj
 																	if reg22459 == True {
 																		reg22460 := Nil
-																		reg22461 := __e.Call(__defun__shen_4bindv, V2566, reg22460, V2761)
+																		reg22461 := Call(__e, __defun__shen_4bindv, V2566, reg22460, V2761)
 																		_ = reg22461
 																		reg22462 := PrimTail(V2544)
 																		Hyp := reg22462
 																		_ = Hyp
-																		reg22463 := __e.Call(__defun__shen_4incinfs)
+																		reg22463 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg22463
-																		reg22464 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																		reg22464 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																		reg22465 := MakeSymbol(":")
-																		reg22466 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg22466 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg22467 := Nil
 																		reg22468 := PrimCons(reg22466, reg22467)
 																		reg22469 := PrimCons(reg22465, reg22468)
 																		reg22470 := PrimCons(reg22464, reg22469)
-																		reg22471 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																		reg22471 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																		reg22472 := MakeSymbol(":")
 																		reg22473 := MakeSymbol("vector")
-																		reg22474 := __e.Call(__defun__shen_4lazyderef, A, V2761)
+																		reg22474 := Call(__e, __defun__shen_4lazyderef, A, V2761)
 																		reg22475 := Nil
 																		reg22476 := PrimCons(reg22474, reg22475)
 																		reg22477 := PrimCons(reg22473, reg22476)
@@ -6320,13 +6320,13 @@ func init() {
 																		reg22479 := PrimCons(reg22477, reg22478)
 																		reg22480 := PrimCons(reg22472, reg22479)
 																		reg22481 := PrimCons(reg22471, reg22480)
-																		reg22482 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																		reg22482 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																		reg22483 := PrimCons(reg22481, reg22482)
 																		reg22484 := PrimCons(reg22470, reg22483)
-																		reg22485 := __e.Call(__defun__bind, V2760, reg22484, V2761, V2762)
+																		reg22485 := Call(__e, __defun__bind, V2760, reg22484, V2761, V2762)
 																		Result := reg22485
 																		_ = Result
-																		reg22486 := __e.Call(__defun__shen_4unbindv, V2566, V2761)
+																		reg22486 := Call(__e, __defun__shen_4unbindv, V2566, V2761)
 																		_ = reg22486
 																		reg22488 = Result
 																	} else {
@@ -6337,7 +6337,7 @@ func init() {
 																}
 																Result := reg22489
 																_ = Result
-																reg22490 := __e.Call(__defun__shen_4unbindv, V2554, V2761)
+																reg22490 := Call(__e, __defun__shen_4unbindv, V2554, V2761)
 																_ = reg22490
 																reg22492 = Result
 															} else {
@@ -6401,28 +6401,28 @@ func init() {
 				reg22514 := False
 				reg22515 := PrimEqual(Case, reg22514)
 				if reg22515 == True {
-					reg22516 := __e.Call(__defun__shen_4lazyderef, V2759, V2761)
+					reg22516 := Call(__e, __defun__shen_4lazyderef, V2759, V2761)
 					V2567 := reg22516
 					_ = V2567
 					reg22517 := PrimIsPair(V2567)
 					var reg22682 Obj
 					if reg22517 == True {
 						reg22518 := PrimHead(V2567)
-						reg22519 := __e.Call(__defun__shen_4lazyderef, reg22518, V2761)
+						reg22519 := Call(__e, __defun__shen_4lazyderef, reg22518, V2761)
 						V2568 := reg22519
 						_ = V2568
 						reg22520 := PrimIsPair(V2568)
 						var reg22680 Obj
 						if reg22520 == True {
 							reg22521 := PrimHead(V2568)
-							reg22522 := __e.Call(__defun__shen_4lazyderef, reg22521, V2761)
+							reg22522 := Call(__e, __defun__shen_4lazyderef, reg22521, V2761)
 							V2569 := reg22522
 							_ = V2569
 							reg22523 := PrimIsPair(V2569)
 							var reg22678 Obj
 							if reg22523 == True {
 								reg22524 := PrimHead(V2569)
-								reg22525 := __e.Call(__defun__shen_4lazyderef, reg22524, V2761)
+								reg22525 := Call(__e, __defun__shen_4lazyderef, reg22524, V2761)
 								V2570 := reg22525
 								_ = V2570
 								reg22526 := MakeSymbol("@s")
@@ -6430,7 +6430,7 @@ func init() {
 								var reg22676 Obj
 								if reg22527 == True {
 									reg22528 := PrimTail(V2569)
-									reg22529 := __e.Call(__defun__shen_4lazyderef, reg22528, V2761)
+									reg22529 := Call(__e, __defun__shen_4lazyderef, reg22528, V2761)
 									V2571 := reg22529
 									_ = V2571
 									reg22530 := PrimIsPair(V2571)
@@ -6440,7 +6440,7 @@ func init() {
 										X := reg22531
 										_ = X
 										reg22532 := PrimTail(V2571)
-										reg22533 := __e.Call(__defun__shen_4lazyderef, reg22532, V2761)
+										reg22533 := Call(__e, __defun__shen_4lazyderef, reg22532, V2761)
 										V2572 := reg22533
 										_ = V2572
 										reg22534 := PrimIsPair(V2572)
@@ -6450,7 +6450,7 @@ func init() {
 											Y := reg22535
 											_ = Y
 											reg22536 := PrimTail(V2572)
-											reg22537 := __e.Call(__defun__shen_4lazyderef, reg22536, V2761)
+											reg22537 := Call(__e, __defun__shen_4lazyderef, reg22536, V2761)
 											V2573 := reg22537
 											_ = V2573
 											reg22538 := Nil
@@ -6458,14 +6458,14 @@ func init() {
 											var reg22670 Obj
 											if reg22539 == True {
 												reg22540 := PrimTail(V2568)
-												reg22541 := __e.Call(__defun__shen_4lazyderef, reg22540, V2761)
+												reg22541 := Call(__e, __defun__shen_4lazyderef, reg22540, V2761)
 												V2574 := reg22541
 												_ = V2574
 												reg22542 := PrimIsPair(V2574)
 												var reg22668 Obj
 												if reg22542 == True {
 													reg22543 := PrimHead(V2574)
-													reg22544 := __e.Call(__defun__shen_4lazyderef, reg22543, V2761)
+													reg22544 := Call(__e, __defun__shen_4lazyderef, reg22543, V2761)
 													V2575 := reg22544
 													_ = V2575
 													reg22545 := MakeSymbol(":")
@@ -6473,14 +6473,14 @@ func init() {
 													var reg22666 Obj
 													if reg22546 == True {
 														reg22547 := PrimTail(V2574)
-														reg22548 := __e.Call(__defun__shen_4lazyderef, reg22547, V2761)
+														reg22548 := Call(__e, __defun__shen_4lazyderef, reg22547, V2761)
 														V2576 := reg22548
 														_ = V2576
 														reg22549 := PrimIsPair(V2576)
 														var reg22664 Obj
 														if reg22549 == True {
 															reg22550 := PrimHead(V2576)
-															reg22551 := __e.Call(__defun__shen_4lazyderef, reg22550, V2761)
+															reg22551 := Call(__e, __defun__shen_4lazyderef, reg22550, V2761)
 															V2577 := reg22551
 															_ = V2577
 															reg22552 := MakeSymbol("string")
@@ -6488,7 +6488,7 @@ func init() {
 															var reg22662 Obj
 															if reg22553 == True {
 																reg22554 := PrimTail(V2576)
-																reg22555 := __e.Call(__defun__shen_4lazyderef, reg22554, V2761)
+																reg22555 := Call(__e, __defun__shen_4lazyderef, reg22554, V2761)
 																V2578 := reg22555
 																_ = V2578
 																reg22556 := Nil
@@ -6498,60 +6498,60 @@ func init() {
 																	reg22558 := PrimTail(V2567)
 																	Hyp := reg22558
 																	_ = Hyp
-																	reg22559 := __e.Call(__defun__shen_4incinfs)
+																	reg22559 := Call(__e, __defun__shen_4incinfs)
 																	_ = reg22559
-																	reg22560 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																	reg22560 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																	reg22561 := MakeSymbol(":")
 																	reg22562 := MakeSymbol("string")
 																	reg22563 := Nil
 																	reg22564 := PrimCons(reg22562, reg22563)
 																	reg22565 := PrimCons(reg22561, reg22564)
 																	reg22566 := PrimCons(reg22560, reg22565)
-																	reg22567 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																	reg22567 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																	reg22568 := MakeSymbol(":")
 																	reg22569 := MakeSymbol("string")
 																	reg22570 := Nil
 																	reg22571 := PrimCons(reg22569, reg22570)
 																	reg22572 := PrimCons(reg22568, reg22571)
 																	reg22573 := PrimCons(reg22567, reg22572)
-																	reg22574 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																	reg22574 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																	reg22575 := PrimCons(reg22573, reg22574)
 																	reg22576 := PrimCons(reg22566, reg22575)
-																	reg22577 := __e.Call(__defun__bind, V2760, reg22576, V2761, V2762)
+																	reg22577 := Call(__e, __defun__bind, V2760, reg22576, V2761, V2762)
 																	reg22604 = reg22577
 																} else {
-																	reg22578 := __e.Call(__defun__shen_4pvar_2, V2578)
+																	reg22578 := Call(__e, __defun__shen_4pvar_2, V2578)
 																	var reg22603 Obj
 																	if reg22578 == True {
 																		reg22579 := Nil
-																		reg22580 := __e.Call(__defun__shen_4bindv, V2578, reg22579, V2761)
+																		reg22580 := Call(__e, __defun__shen_4bindv, V2578, reg22579, V2761)
 																		_ = reg22580
 																		reg22581 := PrimTail(V2567)
 																		Hyp := reg22581
 																		_ = Hyp
-																		reg22582 := __e.Call(__defun__shen_4incinfs)
+																		reg22582 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg22582
-																		reg22583 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																		reg22583 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																		reg22584 := MakeSymbol(":")
 																		reg22585 := MakeSymbol("string")
 																		reg22586 := Nil
 																		reg22587 := PrimCons(reg22585, reg22586)
 																		reg22588 := PrimCons(reg22584, reg22587)
 																		reg22589 := PrimCons(reg22583, reg22588)
-																		reg22590 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																		reg22590 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																		reg22591 := MakeSymbol(":")
 																		reg22592 := MakeSymbol("string")
 																		reg22593 := Nil
 																		reg22594 := PrimCons(reg22592, reg22593)
 																		reg22595 := PrimCons(reg22591, reg22594)
 																		reg22596 := PrimCons(reg22590, reg22595)
-																		reg22597 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																		reg22597 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																		reg22598 := PrimCons(reg22596, reg22597)
 																		reg22599 := PrimCons(reg22589, reg22598)
-																		reg22600 := __e.Call(__defun__bind, V2760, reg22599, V2761, V2762)
+																		reg22600 := Call(__e, __defun__bind, V2760, reg22599, V2761, V2762)
 																		Result := reg22600
 																		_ = Result
-																		reg22601 := __e.Call(__defun__shen_4unbindv, V2578, V2761)
+																		reg22601 := Call(__e, __defun__shen_4unbindv, V2578, V2761)
 																		_ = reg22601
 																		reg22603 = Result
 																	} else {
@@ -6562,14 +6562,14 @@ func init() {
 																}
 																reg22662 = reg22604
 															} else {
-																reg22605 := __e.Call(__defun__shen_4pvar_2, V2577)
+																reg22605 := Call(__e, __defun__shen_4pvar_2, V2577)
 																var reg22661 Obj
 																if reg22605 == True {
 																	reg22606 := MakeSymbol("string")
-																	reg22607 := __e.Call(__defun__shen_4bindv, V2577, reg22606, V2761)
+																	reg22607 := Call(__e, __defun__shen_4bindv, V2577, reg22606, V2761)
 																	_ = reg22607
 																	reg22608 := PrimTail(V2576)
-																	reg22609 := __e.Call(__defun__shen_4lazyderef, reg22608, V2761)
+																	reg22609 := Call(__e, __defun__shen_4lazyderef, reg22608, V2761)
 																	V2579 := reg22609
 																	_ = V2579
 																	reg22610 := Nil
@@ -6579,60 +6579,60 @@ func init() {
 																		reg22612 := PrimTail(V2567)
 																		Hyp := reg22612
 																		_ = Hyp
-																		reg22613 := __e.Call(__defun__shen_4incinfs)
+																		reg22613 := Call(__e, __defun__shen_4incinfs)
 																		_ = reg22613
-																		reg22614 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																		reg22614 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																		reg22615 := MakeSymbol(":")
 																		reg22616 := MakeSymbol("string")
 																		reg22617 := Nil
 																		reg22618 := PrimCons(reg22616, reg22617)
 																		reg22619 := PrimCons(reg22615, reg22618)
 																		reg22620 := PrimCons(reg22614, reg22619)
-																		reg22621 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																		reg22621 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																		reg22622 := MakeSymbol(":")
 																		reg22623 := MakeSymbol("string")
 																		reg22624 := Nil
 																		reg22625 := PrimCons(reg22623, reg22624)
 																		reg22626 := PrimCons(reg22622, reg22625)
 																		reg22627 := PrimCons(reg22621, reg22626)
-																		reg22628 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																		reg22628 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																		reg22629 := PrimCons(reg22627, reg22628)
 																		reg22630 := PrimCons(reg22620, reg22629)
-																		reg22631 := __e.Call(__defun__bind, V2760, reg22630, V2761, V2762)
+																		reg22631 := Call(__e, __defun__bind, V2760, reg22630, V2761, V2762)
 																		reg22658 = reg22631
 																	} else {
-																		reg22632 := __e.Call(__defun__shen_4pvar_2, V2579)
+																		reg22632 := Call(__e, __defun__shen_4pvar_2, V2579)
 																		var reg22657 Obj
 																		if reg22632 == True {
 																			reg22633 := Nil
-																			reg22634 := __e.Call(__defun__shen_4bindv, V2579, reg22633, V2761)
+																			reg22634 := Call(__e, __defun__shen_4bindv, V2579, reg22633, V2761)
 																			_ = reg22634
 																			reg22635 := PrimTail(V2567)
 																			Hyp := reg22635
 																			_ = Hyp
-																			reg22636 := __e.Call(__defun__shen_4incinfs)
+																			reg22636 := Call(__e, __defun__shen_4incinfs)
 																			_ = reg22636
-																			reg22637 := __e.Call(__defun__shen_4lazyderef, X, V2761)
+																			reg22637 := Call(__e, __defun__shen_4lazyderef, X, V2761)
 																			reg22638 := MakeSymbol(":")
 																			reg22639 := MakeSymbol("string")
 																			reg22640 := Nil
 																			reg22641 := PrimCons(reg22639, reg22640)
 																			reg22642 := PrimCons(reg22638, reg22641)
 																			reg22643 := PrimCons(reg22637, reg22642)
-																			reg22644 := __e.Call(__defun__shen_4lazyderef, Y, V2761)
+																			reg22644 := Call(__e, __defun__shen_4lazyderef, Y, V2761)
 																			reg22645 := MakeSymbol(":")
 																			reg22646 := MakeSymbol("string")
 																			reg22647 := Nil
 																			reg22648 := PrimCons(reg22646, reg22647)
 																			reg22649 := PrimCons(reg22645, reg22648)
 																			reg22650 := PrimCons(reg22644, reg22649)
-																			reg22651 := __e.Call(__defun__shen_4lazyderef, Hyp, V2761)
+																			reg22651 := Call(__e, __defun__shen_4lazyderef, Hyp, V2761)
 																			reg22652 := PrimCons(reg22650, reg22651)
 																			reg22653 := PrimCons(reg22643, reg22652)
-																			reg22654 := __e.Call(__defun__bind, V2760, reg22653, V2761, V2762)
+																			reg22654 := Call(__e, __defun__bind, V2760, reg22653, V2761, V2762)
 																			Result := reg22654
 																			_ = Result
-																			reg22655 := __e.Call(__defun__shen_4unbindv, V2579, V2761)
+																			reg22655 := Call(__e, __defun__shen_4unbindv, V2579, V2761)
 																			_ = reg22655
 																			reg22657 = Result
 																		} else {
@@ -6643,7 +6643,7 @@ func init() {
 																	}
 																	Result := reg22658
 																	_ = Result
-																	reg22659 := __e.Call(__defun__shen_4unbindv, V2577, V2761)
+																	reg22659 := Call(__e, __defun__shen_4unbindv, V2577, V2761)
 																	_ = reg22659
 																	reg22661 = Result
 																} else {
@@ -6707,7 +6707,7 @@ func init() {
 					reg22683 := False
 					reg22684 := PrimEqual(Case, reg22683)
 					if reg22684 == True {
-						reg22685 := __e.Call(__defun__shen_4lazyderef, V2759, V2761)
+						reg22685 := Call(__e, __defun__shen_4lazyderef, V2759, V2761)
 						V2580 := reg22685
 						_ = V2580
 						reg22686 := PrimIsPair(V2580)
@@ -6718,45 +6718,45 @@ func init() {
 							reg22688 := PrimTail(V2580)
 							Hyp := reg22688
 							_ = Hyp
-							reg22689 := __e.Call(__defun__shen_4newpv, V2761)
+							reg22689 := Call(__e, __defun__shen_4newpv, V2761)
 							NewHyps := reg22689
 							_ = NewHyps
-							reg22690 := __e.Call(__defun__shen_4incinfs)
+							reg22690 := Call(__e, __defun__shen_4incinfs)
 							_ = reg22690
-							reg22691 := __e.Call(__defun__shen_4lazyderef, X, V2761)
-							reg22692 := __e.Call(__defun__shen_4lazyderef, NewHyps, V2761)
+							reg22691 := Call(__e, __defun__shen_4lazyderef, X, V2761)
+							reg22692 := Call(__e, __defun__shen_4lazyderef, NewHyps, V2761)
 							reg22693 := PrimCons(reg22691, reg22692)
-							reg22694 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-								__ctx.TailApply(__defun__shen_4t_d_1hyps, Hyp, NewHyps, V2761, V2762)
+							reg22694 := MakeNative(func(__e Evaluator, __args ...Obj) {
+								__e.TailApply(__defun__shen_4t_d_1hyps, Hyp, NewHyps, V2761, V2762)
 								return
 							}, 0)
-							__ctx.TailApply(__defun__bind, V2760, reg22693, V2761, reg22694)
+							__e.TailApply(__defun__bind, V2760, reg22693, V2761, reg22694)
 							return
 						} else {
 							reg22697 := False
-							__ctx.Return(reg22697)
+							__e.Return(reg22697)
 							return
 						}
 					} else {
-						__ctx.Return(Case)
+						__e.Return(Case)
 						return
 					}
 				} else {
-					__ctx.Return(Case)
+					__e.Return(Case)
 					return
 				}
 			} else {
-				__ctx.Return(Case)
+				__e.Return(Case)
 				return
 			}
 		} else {
-			__ctx.Return(Case)
+			__e.Return(Case)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.t*-hyps", value: __defun__shen_4t_d_1hyps})
 
-	__defun__shen_4show = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4show = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2779 := __args[0]
 		_ = V2779
 		V2780 := __args[1]
@@ -6768,38 +6768,38 @@ func init() {
 		reg22698 := MakeSymbol("shen.*spy*")
 		reg22699 := PrimValue(reg22698)
 		if reg22699 == True {
-			reg22700 := __e.Call(__defun__shen_4line)
+			reg22700 := Call(__e, __defun__shen_4line)
 			_ = reg22700
-			reg22701 := __e.Call(__defun__shen_4deref, V2779, V2781)
-			reg22702 := __e.Call(__defun__shen_4show_1p, reg22701)
+			reg22701 := Call(__e, __defun__shen_4deref, V2779, V2781)
+			reg22702 := Call(__e, __defun__shen_4show_1p, reg22701)
 			_ = reg22702
 			reg22703 := MakeNumber(1)
-			reg22704 := __e.Call(__defun__nl, reg22703)
+			reg22704 := Call(__e, __defun__nl, reg22703)
 			_ = reg22704
 			reg22705 := MakeNumber(1)
-			reg22706 := __e.Call(__defun__nl, reg22705)
+			reg22706 := Call(__e, __defun__nl, reg22705)
 			_ = reg22706
-			reg22707 := __e.Call(__defun__shen_4deref, V2780, V2781)
+			reg22707 := Call(__e, __defun__shen_4deref, V2780, V2781)
 			reg22708 := MakeNumber(1)
-			reg22709 := __e.Call(__defun__shen_4show_1assumptions, reg22707, reg22708)
+			reg22709 := Call(__e, __defun__shen_4show_1assumptions, reg22707, reg22708)
 			_ = reg22709
 			reg22710 := MakeString("\n> ")
-			reg22711 := __e.Call(__defun__stoutput)
-			reg22712 := __e.Call(__defun__shen_4prhush, reg22710, reg22711)
+			reg22711 := Call(__e, __defun__stoutput)
+			reg22712 := Call(__e, __defun__shen_4prhush, reg22710, reg22711)
 			_ = reg22712
-			reg22713 := __e.Call(__defun__shen_4pause_1for_1user)
+			reg22713 := Call(__e, __defun__shen_4pause_1for_1user)
 			_ = reg22713
-			__ctx.TailApply(__defun__thaw, V2782)
+			__e.TailApply(__defun__thaw, V2782)
 			return
 		} else {
-			__ctx.TailApply(__defun__thaw, V2782)
+			__e.TailApply(__defun__thaw, V2782)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.show", value: __defun__shen_4show})
 
-	__defun__shen_4line = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-		reg22716 := __e.Call(__defun__inferences)
+	__defun__shen_4line = MakeNative(func(__e Evaluator, __args ...Obj) {
+		reg22716 := Call(__e, __defun__inferences)
 		Infs := reg22716
 		_ = Infs
 		reg22717 := MakeString("____________________________________________________________ ")
@@ -6816,18 +6816,18 @@ func init() {
 		}
 		reg22724 := MakeString(" \n?- ")
 		reg22725 := MakeSymbol("shen.a")
-		reg22726 := __e.Call(__defun__shen_4app, reg22723, reg22724, reg22725)
+		reg22726 := Call(__e, __defun__shen_4app, reg22723, reg22724, reg22725)
 		reg22727 := PrimStringConcat(reg22718, reg22726)
 		reg22728 := MakeSymbol("shen.a")
-		reg22729 := __e.Call(__defun__shen_4app, Infs, reg22727, reg22728)
+		reg22729 := Call(__e, __defun__shen_4app, Infs, reg22727, reg22728)
 		reg22730 := PrimStringConcat(reg22717, reg22729)
-		reg22731 := __e.Call(__defun__stoutput)
-		__ctx.TailApply(__defun__shen_4prhush, reg22730, reg22731)
+		reg22731 := Call(__e, __defun__stoutput)
+		__e.TailApply(__defun__shen_4prhush, reg22730, reg22731)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.line", value: __defun__shen_4line})
 
-	__defun__shen_4show_1p = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4show_1p = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2784 := __args[0]
 		_ = V2784
 		reg22733 := PrimIsPair(V2784)
@@ -6913,25 +6913,25 @@ func init() {
 			reg22772 := PrimHead(reg22771)
 			reg22773 := MakeString("")
 			reg22774 := MakeSymbol("shen.r")
-			reg22775 := __e.Call(__defun__shen_4app, reg22772, reg22773, reg22774)
+			reg22775 := Call(__e, __defun__shen_4app, reg22772, reg22773, reg22774)
 			reg22776 := PrimStringConcat(reg22769, reg22775)
 			reg22777 := MakeSymbol("shen.r")
-			reg22778 := __e.Call(__defun__shen_4app, reg22768, reg22776, reg22777)
-			reg22779 := __e.Call(__defun__stoutput)
-			__ctx.TailApply(__defun__shen_4prhush, reg22778, reg22779)
+			reg22778 := Call(__e, __defun__shen_4app, reg22768, reg22776, reg22777)
+			reg22779 := Call(__e, __defun__stoutput)
+			__e.TailApply(__defun__shen_4prhush, reg22778, reg22779)
 			return
 		} else {
 			reg22781 := MakeString("")
 			reg22782 := MakeSymbol("shen.r")
-			reg22783 := __e.Call(__defun__shen_4app, V2784, reg22781, reg22782)
-			reg22784 := __e.Call(__defun__stoutput)
-			__ctx.TailApply(__defun__shen_4prhush, reg22783, reg22784)
+			reg22783 := Call(__e, __defun__shen_4app, V2784, reg22781, reg22782)
+			reg22784 := Call(__e, __defun__stoutput)
+			__e.TailApply(__defun__shen_4prhush, reg22783, reg22784)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.show-p", value: __defun__shen_4show_1p})
 
-	__defun__shen_4show_1assumptions = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4show_1assumptions = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2789 := __args[0]
 		_ = V2789
 		V2790 := __args[1]
@@ -6940,39 +6940,39 @@ func init() {
 		reg22787 := PrimEqual(reg22786, V2789)
 		if reg22787 == True {
 			reg22788 := MakeSymbol("shen.skip")
-			__ctx.Return(reg22788)
+			__e.Return(reg22788)
 			return
 		} else {
 			reg22789 := PrimIsPair(V2789)
 			if reg22789 == True {
 				reg22790 := MakeString(". ")
 				reg22791 := MakeSymbol("shen.a")
-				reg22792 := __e.Call(__defun__shen_4app, V2790, reg22790, reg22791)
-				reg22793 := __e.Call(__defun__stoutput)
-				reg22794 := __e.Call(__defun__shen_4prhush, reg22792, reg22793)
+				reg22792 := Call(__e, __defun__shen_4app, V2790, reg22790, reg22791)
+				reg22793 := Call(__e, __defun__stoutput)
+				reg22794 := Call(__e, __defun__shen_4prhush, reg22792, reg22793)
 				_ = reg22794
 				reg22795 := PrimHead(V2789)
-				reg22796 := __e.Call(__defun__shen_4show_1p, reg22795)
+				reg22796 := Call(__e, __defun__shen_4show_1p, reg22795)
 				_ = reg22796
 				reg22797 := MakeNumber(1)
-				reg22798 := __e.Call(__defun__nl, reg22797)
+				reg22798 := Call(__e, __defun__nl, reg22797)
 				_ = reg22798
 				reg22799 := PrimTail(V2789)
 				reg22800 := MakeNumber(1)
 				reg22801 := PrimNumberAdd(V2790, reg22800)
-				__ctx.TailApply(__defun__shen_4show_1assumptions, reg22799, reg22801)
+				__e.TailApply(__defun__shen_4show_1assumptions, reg22799, reg22801)
 				return
 			} else {
 				reg22803 := MakeSymbol("shen.show-assumptions")
-				__ctx.TailApply(__defun__shen_4f__error, reg22803)
+				__e.TailApply(__defun__shen_4f__error, reg22803)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.show-assumptions", value: __defun__shen_4show_1assumptions})
 
-	__defun__shen_4pause_1for_1user = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-		reg22805 := __e.Call(__defun__stinput)
+	__defun__shen_4pause_1for_1user = MakeNative(func(__e Evaluator, __args ...Obj) {
+		reg22805 := Call(__e, __defun__stinput)
 		reg22806 := PrimReadByte(reg22805)
 		Byte := reg22806
 		_ = Byte
@@ -6981,45 +6981,45 @@ func init() {
 		if reg22808 == True {
 			reg22809 := MakeString("input aborted\n")
 			reg22810 := PrimSimpleError(reg22809)
-			__ctx.Return(reg22810)
+			__e.Return(reg22810)
 			return
 		} else {
 			reg22811 := MakeNumber(1)
-			__ctx.TailApply(__defun__nl, reg22811)
+			__e.TailApply(__defun__nl, reg22811)
 			return
 		}
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.pause-for-user", value: __defun__shen_4pause_1for_1user})
 
-	__defun__shen_4typedf_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4typedf_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2792 := __args[0]
 		_ = V2792
 		reg22813 := MakeSymbol("shen.*signedfuncs*")
 		reg22814 := PrimValue(reg22813)
-		reg22815 := __e.Call(__defun__assoc, V2792, reg22814)
+		reg22815 := Call(__e, __defun__assoc, V2792, reg22814)
 		reg22816 := PrimIsPair(reg22815)
-		__ctx.Return(reg22816)
+		__e.Return(reg22816)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.typedf?", value: __defun__shen_4typedf_2})
 
-	__defun__shen_4sigf = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4sigf = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2794 := __args[0]
 		_ = V2794
 		reg22817 := MakeSymbol("shen.type-signature-of-")
-		__ctx.TailApply(__defun__concat, reg22817, V2794)
+		__e.TailApply(__defun__concat, reg22817, V2794)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.sigf", value: __defun__shen_4sigf})
 
-	__defun__shen_4placeholder = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4placeholder = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg22819 := MakeSymbol("&&")
-		__ctx.TailApply(__defun__gensym, reg22819)
+		__e.TailApply(__defun__gensym, reg22819)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.placeholder", value: __defun__shen_4placeholder})
 
-	__defun__shen_4base = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4base = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2799 := __args[0]
 		_ = V2799
 		V2800 := __args[1]
@@ -7028,34 +7028,34 @@ func init() {
 		_ = V2801
 		V2802 := __args[3]
 		_ = V2802
-		reg22821 := __e.Call(__defun__shen_4lazyderef, V2800, V2801)
+		reg22821 := Call(__e, __defun__shen_4lazyderef, V2800, V2801)
 		V2483 := reg22821
 		_ = V2483
 		reg22822 := MakeSymbol("number")
 		reg22823 := PrimEqual(reg22822, V2483)
 		var reg22838 Obj
 		if reg22823 == True {
-			reg22824 := __e.Call(__defun__shen_4incinfs)
+			reg22824 := Call(__e, __defun__shen_4incinfs)
 			_ = reg22824
-			reg22825 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
+			reg22825 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
 			reg22826 := PrimIsNumber(reg22825)
-			reg22827 := __e.Call(__defun__fwhen, reg22826, V2801, V2802)
+			reg22827 := Call(__e, __defun__fwhen, reg22826, V2801, V2802)
 			reg22838 = reg22827
 		} else {
-			reg22828 := __e.Call(__defun__shen_4pvar_2, V2483)
+			reg22828 := Call(__e, __defun__shen_4pvar_2, V2483)
 			var reg22837 Obj
 			if reg22828 == True {
 				reg22829 := MakeSymbol("number")
-				reg22830 := __e.Call(__defun__shen_4bindv, V2483, reg22829, V2801)
+				reg22830 := Call(__e, __defun__shen_4bindv, V2483, reg22829, V2801)
 				_ = reg22830
-				reg22831 := __e.Call(__defun__shen_4incinfs)
+				reg22831 := Call(__e, __defun__shen_4incinfs)
 				_ = reg22831
-				reg22832 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
+				reg22832 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
 				reg22833 := PrimIsNumber(reg22832)
-				reg22834 := __e.Call(__defun__fwhen, reg22833, V2801, V2802)
+				reg22834 := Call(__e, __defun__fwhen, reg22833, V2801, V2802)
 				Result := reg22834
 				_ = Result
-				reg22835 := __e.Call(__defun__shen_4unbindv, V2483, V2801)
+				reg22835 := Call(__e, __defun__shen_4unbindv, V2483, V2801)
 				_ = reg22835
 				reg22837 = Result
 			} else {
@@ -7069,34 +7069,34 @@ func init() {
 		reg22839 := False
 		reg22840 := PrimEqual(Case, reg22839)
 		if reg22840 == True {
-			reg22841 := __e.Call(__defun__shen_4lazyderef, V2800, V2801)
+			reg22841 := Call(__e, __defun__shen_4lazyderef, V2800, V2801)
 			V2484 := reg22841
 			_ = V2484
 			reg22842 := MakeSymbol("boolean")
 			reg22843 := PrimEqual(reg22842, V2484)
 			var reg22858 Obj
 			if reg22843 == True {
-				reg22844 := __e.Call(__defun__shen_4incinfs)
+				reg22844 := Call(__e, __defun__shen_4incinfs)
 				_ = reg22844
-				reg22845 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
-				reg22846 := __e.Call(__defun__boolean_2, reg22845)
-				reg22847 := __e.Call(__defun__fwhen, reg22846, V2801, V2802)
+				reg22845 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
+				reg22846 := Call(__e, __defun__boolean_2, reg22845)
+				reg22847 := Call(__e, __defun__fwhen, reg22846, V2801, V2802)
 				reg22858 = reg22847
 			} else {
-				reg22848 := __e.Call(__defun__shen_4pvar_2, V2484)
+				reg22848 := Call(__e, __defun__shen_4pvar_2, V2484)
 				var reg22857 Obj
 				if reg22848 == True {
 					reg22849 := MakeSymbol("boolean")
-					reg22850 := __e.Call(__defun__shen_4bindv, V2484, reg22849, V2801)
+					reg22850 := Call(__e, __defun__shen_4bindv, V2484, reg22849, V2801)
 					_ = reg22850
-					reg22851 := __e.Call(__defun__shen_4incinfs)
+					reg22851 := Call(__e, __defun__shen_4incinfs)
 					_ = reg22851
-					reg22852 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
-					reg22853 := __e.Call(__defun__boolean_2, reg22852)
-					reg22854 := __e.Call(__defun__fwhen, reg22853, V2801, V2802)
+					reg22852 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
+					reg22853 := Call(__e, __defun__boolean_2, reg22852)
+					reg22854 := Call(__e, __defun__fwhen, reg22853, V2801, V2802)
 					Result := reg22854
 					_ = Result
-					reg22855 := __e.Call(__defun__shen_4unbindv, V2484, V2801)
+					reg22855 := Call(__e, __defun__shen_4unbindv, V2484, V2801)
 					_ = reg22855
 					reg22857 = Result
 				} else {
@@ -7110,34 +7110,34 @@ func init() {
 			reg22859 := False
 			reg22860 := PrimEqual(Case, reg22859)
 			if reg22860 == True {
-				reg22861 := __e.Call(__defun__shen_4lazyderef, V2800, V2801)
+				reg22861 := Call(__e, __defun__shen_4lazyderef, V2800, V2801)
 				V2485 := reg22861
 				_ = V2485
 				reg22862 := MakeSymbol("string")
 				reg22863 := PrimEqual(reg22862, V2485)
 				var reg22878 Obj
 				if reg22863 == True {
-					reg22864 := __e.Call(__defun__shen_4incinfs)
+					reg22864 := Call(__e, __defun__shen_4incinfs)
 					_ = reg22864
-					reg22865 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
+					reg22865 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
 					reg22866 := PrimIsString(reg22865)
-					reg22867 := __e.Call(__defun__fwhen, reg22866, V2801, V2802)
+					reg22867 := Call(__e, __defun__fwhen, reg22866, V2801, V2802)
 					reg22878 = reg22867
 				} else {
-					reg22868 := __e.Call(__defun__shen_4pvar_2, V2485)
+					reg22868 := Call(__e, __defun__shen_4pvar_2, V2485)
 					var reg22877 Obj
 					if reg22868 == True {
 						reg22869 := MakeSymbol("string")
-						reg22870 := __e.Call(__defun__shen_4bindv, V2485, reg22869, V2801)
+						reg22870 := Call(__e, __defun__shen_4bindv, V2485, reg22869, V2801)
 						_ = reg22870
-						reg22871 := __e.Call(__defun__shen_4incinfs)
+						reg22871 := Call(__e, __defun__shen_4incinfs)
 						_ = reg22871
-						reg22872 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
+						reg22872 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
 						reg22873 := PrimIsString(reg22872)
-						reg22874 := __e.Call(__defun__fwhen, reg22873, V2801, V2802)
+						reg22874 := Call(__e, __defun__fwhen, reg22873, V2801, V2802)
 						Result := reg22874
 						_ = Result
-						reg22875 := __e.Call(__defun__shen_4unbindv, V2485, V2801)
+						reg22875 := Call(__e, __defun__shen_4unbindv, V2485, V2801)
 						_ = reg22875
 						reg22877 = Result
 					} else {
@@ -7151,48 +7151,48 @@ func init() {
 				reg22879 := False
 				reg22880 := PrimEqual(Case, reg22879)
 				if reg22880 == True {
-					reg22881 := __e.Call(__defun__shen_4lazyderef, V2800, V2801)
+					reg22881 := Call(__e, __defun__shen_4lazyderef, V2800, V2801)
 					V2486 := reg22881
 					_ = V2486
 					reg22882 := MakeSymbol("symbol")
 					reg22883 := PrimEqual(reg22882, V2486)
 					var reg22908 Obj
 					if reg22883 == True {
-						reg22884 := __e.Call(__defun__shen_4incinfs)
+						reg22884 := Call(__e, __defun__shen_4incinfs)
 						_ = reg22884
-						reg22885 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
+						reg22885 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
 						reg22886 := PrimIsSymbol(reg22885)
-						reg22887 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-							reg22888 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
-							reg22889 := __e.Call(__defun__shen_4ue_2, reg22888)
+						reg22887 := MakeNative(func(__e Evaluator, __args ...Obj) {
+							reg22888 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
+							reg22889 := Call(__e, __defun__shen_4ue_2, reg22888)
 							reg22890 := PrimNot(reg22889)
-							__ctx.TailApply(__defun__fwhen, reg22890, V2801, V2802)
+							__e.TailApply(__defun__fwhen, reg22890, V2801, V2802)
 							return
 						}, 0)
-						reg22892 := __e.Call(__defun__fwhen, reg22886, V2801, reg22887)
+						reg22892 := Call(__e, __defun__fwhen, reg22886, V2801, reg22887)
 						reg22908 = reg22892
 					} else {
-						reg22893 := __e.Call(__defun__shen_4pvar_2, V2486)
+						reg22893 := Call(__e, __defun__shen_4pvar_2, V2486)
 						var reg22907 Obj
 						if reg22893 == True {
 							reg22894 := MakeSymbol("symbol")
-							reg22895 := __e.Call(__defun__shen_4bindv, V2486, reg22894, V2801)
+							reg22895 := Call(__e, __defun__shen_4bindv, V2486, reg22894, V2801)
 							_ = reg22895
-							reg22896 := __e.Call(__defun__shen_4incinfs)
+							reg22896 := Call(__e, __defun__shen_4incinfs)
 							_ = reg22896
-							reg22897 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
+							reg22897 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
 							reg22898 := PrimIsSymbol(reg22897)
-							reg22899 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-								reg22900 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
-								reg22901 := __e.Call(__defun__shen_4ue_2, reg22900)
+							reg22899 := MakeNative(func(__e Evaluator, __args ...Obj) {
+								reg22900 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
+								reg22901 := Call(__e, __defun__shen_4ue_2, reg22900)
 								reg22902 := PrimNot(reg22901)
-								__ctx.TailApply(__defun__fwhen, reg22902, V2801, V2802)
+								__e.TailApply(__defun__fwhen, reg22902, V2801, V2802)
 								return
 							}, 0)
-							reg22904 := __e.Call(__defun__fwhen, reg22898, V2801, reg22899)
+							reg22904 := Call(__e, __defun__fwhen, reg22898, V2801, reg22899)
 							Result := reg22904
 							_ = Result
-							reg22905 := __e.Call(__defun__shen_4unbindv, V2486, V2801)
+							reg22905 := Call(__e, __defun__shen_4unbindv, V2486, V2801)
 							_ = reg22905
 							reg22907 = Result
 						} else {
@@ -7206,26 +7206,26 @@ func init() {
 					reg22909 := False
 					reg22910 := PrimEqual(Case, reg22909)
 					if reg22910 == True {
-						reg22911 := __e.Call(__defun__shen_4lazyderef, V2799, V2801)
+						reg22911 := Call(__e, __defun__shen_4lazyderef, V2799, V2801)
 						V2487 := reg22911
 						_ = V2487
 						reg22912 := Nil
 						reg22913 := PrimEqual(reg22912, V2487)
 						if reg22913 == True {
-							reg22914 := __e.Call(__defun__shen_4lazyderef, V2800, V2801)
+							reg22914 := Call(__e, __defun__shen_4lazyderef, V2800, V2801)
 							V2488 := reg22914
 							_ = V2488
 							reg22915 := PrimIsPair(V2488)
 							if reg22915 == True {
 								reg22916 := PrimHead(V2488)
-								reg22917 := __e.Call(__defun__shen_4lazyderef, reg22916, V2801)
+								reg22917 := Call(__e, __defun__shen_4lazyderef, reg22916, V2801)
 								V2489 := reg22917
 								_ = V2489
 								reg22918 := MakeSymbol("list")
 								reg22919 := PrimEqual(reg22918, V2489)
 								if reg22919 == True {
 									reg22920 := PrimTail(V2488)
-									reg22921 := __e.Call(__defun__shen_4lazyderef, reg22920, V2801)
+									reg22921 := Call(__e, __defun__shen_4lazyderef, reg22920, V2801)
 									V2490 := reg22921
 									_ = V2490
 									reg22922 := PrimIsPair(V2490)
@@ -7234,70 +7234,70 @@ func init() {
 										A := reg22923
 										_ = A
 										reg22924 := PrimTail(V2490)
-										reg22925 := __e.Call(__defun__shen_4lazyderef, reg22924, V2801)
+										reg22925 := Call(__e, __defun__shen_4lazyderef, reg22924, V2801)
 										V2491 := reg22925
 										_ = V2491
 										reg22926 := Nil
 										reg22927 := PrimEqual(reg22926, V2491)
 										if reg22927 == True {
-											reg22928 := __e.Call(__defun__shen_4incinfs)
+											reg22928 := Call(__e, __defun__shen_4incinfs)
 											_ = reg22928
-											__ctx.TailApply(__defun__thaw, V2802)
+											__e.TailApply(__defun__thaw, V2802)
 											return
 										} else {
-											reg22930 := __e.Call(__defun__shen_4pvar_2, V2491)
+											reg22930 := Call(__e, __defun__shen_4pvar_2, V2491)
 											if reg22930 == True {
 												reg22931 := Nil
-												reg22932 := __e.Call(__defun__shen_4bindv, V2491, reg22931, V2801)
+												reg22932 := Call(__e, __defun__shen_4bindv, V2491, reg22931, V2801)
 												_ = reg22932
-												reg22933 := __e.Call(__defun__shen_4incinfs)
+												reg22933 := Call(__e, __defun__shen_4incinfs)
 												_ = reg22933
-												reg22934 := __e.Call(__defun__thaw, V2802)
+												reg22934 := Call(__e, __defun__thaw, V2802)
 												Result := reg22934
 												_ = Result
-												reg22935 := __e.Call(__defun__shen_4unbindv, V2491, V2801)
+												reg22935 := Call(__e, __defun__shen_4unbindv, V2491, V2801)
 												_ = reg22935
-												__ctx.Return(Result)
+												__e.Return(Result)
 												return
 											} else {
 												reg22936 := False
-												__ctx.Return(reg22936)
+												__e.Return(reg22936)
 												return
 											}
 										}
 									} else {
-										reg22937 := __e.Call(__defun__shen_4pvar_2, V2490)
+										reg22937 := Call(__e, __defun__shen_4pvar_2, V2490)
 										if reg22937 == True {
-											reg22938 := __e.Call(__defun__shen_4newpv, V2801)
+											reg22938 := Call(__e, __defun__shen_4newpv, V2801)
 											A := reg22938
 											_ = A
 											reg22939 := Nil
 											reg22940 := PrimCons(A, reg22939)
-											reg22941 := __e.Call(__defun__shen_4bindv, V2490, reg22940, V2801)
+											reg22941 := Call(__e, __defun__shen_4bindv, V2490, reg22940, V2801)
 											_ = reg22941
-											reg22942 := __e.Call(__defun__shen_4incinfs)
+											reg22942 := Call(__e, __defun__shen_4incinfs)
 											_ = reg22942
-											reg22943 := __e.Call(__defun__thaw, V2802)
+											reg22943 := Call(__e, __defun__thaw, V2802)
 											Result := reg22943
 											_ = Result
-											reg22944 := __e.Call(__defun__shen_4unbindv, V2490, V2801)
+											reg22944 := Call(__e, __defun__shen_4unbindv, V2490, V2801)
 											_ = reg22944
-											__ctx.Return(Result)
+											__e.Return(Result)
 											return
 										} else {
 											reg22945 := False
-											__ctx.Return(reg22945)
+											__e.Return(reg22945)
 											return
 										}
 									}
 								} else {
-									reg22946 := __e.Call(__defun__shen_4pvar_2, V2489)
+									reg22946 := Call(__e, __defun__shen_4pvar_2, V2489)
 									if reg22946 == True {
 										reg22947 := MakeSymbol("list")
-										reg22948 := __e.Call(__defun__shen_4bindv, V2489, reg22947, V2801)
+										reg22948 := Call(__e, __defun__shen_4bindv, V2489, reg22947, V2801)
 										_ = reg22948
 										reg22949 := PrimTail(V2488)
-										reg22950 := __e.Call(__defun__shen_4lazyderef, reg22949, V2801)
+										reg22950 := Call(__e, __defun__shen_4lazyderef, reg22949, V2801)
 										V2492 := reg22950
 										_ = V2492
 										reg22951 := PrimIsPair(V2492)
@@ -7307,30 +7307,30 @@ func init() {
 											A := reg22952
 											_ = A
 											reg22953 := PrimTail(V2492)
-											reg22954 := __e.Call(__defun__shen_4lazyderef, reg22953, V2801)
+											reg22954 := Call(__e, __defun__shen_4lazyderef, reg22953, V2801)
 											V2493 := reg22954
 											_ = V2493
 											reg22955 := Nil
 											reg22956 := PrimEqual(reg22955, V2493)
 											var reg22967 Obj
 											if reg22956 == True {
-												reg22957 := __e.Call(__defun__shen_4incinfs)
+												reg22957 := Call(__e, __defun__shen_4incinfs)
 												_ = reg22957
-												reg22958 := __e.Call(__defun__thaw, V2802)
+												reg22958 := Call(__e, __defun__thaw, V2802)
 												reg22967 = reg22958
 											} else {
-												reg22959 := __e.Call(__defun__shen_4pvar_2, V2493)
+												reg22959 := Call(__e, __defun__shen_4pvar_2, V2493)
 												var reg22966 Obj
 												if reg22959 == True {
 													reg22960 := Nil
-													reg22961 := __e.Call(__defun__shen_4bindv, V2493, reg22960, V2801)
+													reg22961 := Call(__e, __defun__shen_4bindv, V2493, reg22960, V2801)
 													_ = reg22961
-													reg22962 := __e.Call(__defun__shen_4incinfs)
+													reg22962 := Call(__e, __defun__shen_4incinfs)
 													_ = reg22962
-													reg22963 := __e.Call(__defun__thaw, V2802)
+													reg22963 := Call(__e, __defun__thaw, V2802)
 													Result := reg22963
 													_ = Result
-													reg22964 := __e.Call(__defun__shen_4unbindv, V2493, V2801)
+													reg22964 := Call(__e, __defun__shen_4unbindv, V2493, V2801)
 													_ = reg22964
 													reg22966 = Result
 												} else {
@@ -7341,22 +7341,22 @@ func init() {
 											}
 											reg22978 = reg22967
 										} else {
-											reg22968 := __e.Call(__defun__shen_4pvar_2, V2492)
+											reg22968 := Call(__e, __defun__shen_4pvar_2, V2492)
 											var reg22977 Obj
 											if reg22968 == True {
-												reg22969 := __e.Call(__defun__shen_4newpv, V2801)
+												reg22969 := Call(__e, __defun__shen_4newpv, V2801)
 												A := reg22969
 												_ = A
 												reg22970 := Nil
 												reg22971 := PrimCons(A, reg22970)
-												reg22972 := __e.Call(__defun__shen_4bindv, V2492, reg22971, V2801)
+												reg22972 := Call(__e, __defun__shen_4bindv, V2492, reg22971, V2801)
 												_ = reg22972
-												reg22973 := __e.Call(__defun__shen_4incinfs)
+												reg22973 := Call(__e, __defun__shen_4incinfs)
 												_ = reg22973
-												reg22974 := __e.Call(__defun__thaw, V2802)
+												reg22974 := Call(__e, __defun__thaw, V2802)
 												Result := reg22974
 												_ = Result
-												reg22975 := __e.Call(__defun__shen_4unbindv, V2492, V2801)
+												reg22975 := Call(__e, __defun__shen_4unbindv, V2492, V2801)
 												_ = reg22975
 												reg22977 = Result
 											} else {
@@ -7367,68 +7367,68 @@ func init() {
 										}
 										Result := reg22978
 										_ = Result
-										reg22979 := __e.Call(__defun__shen_4unbindv, V2489, V2801)
+										reg22979 := Call(__e, __defun__shen_4unbindv, V2489, V2801)
 										_ = reg22979
-										__ctx.Return(Result)
+										__e.Return(Result)
 										return
 									} else {
 										reg22980 := False
-										__ctx.Return(reg22980)
+										__e.Return(reg22980)
 										return
 									}
 								}
 							} else {
-								reg22981 := __e.Call(__defun__shen_4pvar_2, V2488)
+								reg22981 := Call(__e, __defun__shen_4pvar_2, V2488)
 								if reg22981 == True {
-									reg22982 := __e.Call(__defun__shen_4newpv, V2801)
+									reg22982 := Call(__e, __defun__shen_4newpv, V2801)
 									A := reg22982
 									_ = A
 									reg22983 := MakeSymbol("list")
 									reg22984 := Nil
 									reg22985 := PrimCons(A, reg22984)
 									reg22986 := PrimCons(reg22983, reg22985)
-									reg22987 := __e.Call(__defun__shen_4bindv, V2488, reg22986, V2801)
+									reg22987 := Call(__e, __defun__shen_4bindv, V2488, reg22986, V2801)
 									_ = reg22987
-									reg22988 := __e.Call(__defun__shen_4incinfs)
+									reg22988 := Call(__e, __defun__shen_4incinfs)
 									_ = reg22988
-									reg22989 := __e.Call(__defun__thaw, V2802)
+									reg22989 := Call(__e, __defun__thaw, V2802)
 									Result := reg22989
 									_ = Result
-									reg22990 := __e.Call(__defun__shen_4unbindv, V2488, V2801)
+									reg22990 := Call(__e, __defun__shen_4unbindv, V2488, V2801)
 									_ = reg22990
-									__ctx.Return(Result)
+									__e.Return(Result)
 									return
 								} else {
 									reg22991 := False
-									__ctx.Return(reg22991)
+									__e.Return(reg22991)
 									return
 								}
 							}
 						} else {
 							reg22992 := False
-							__ctx.Return(reg22992)
+							__e.Return(reg22992)
 							return
 						}
 					} else {
-						__ctx.Return(Case)
+						__e.Return(Case)
 						return
 					}
 				} else {
-					__ctx.Return(Case)
+					__e.Return(Case)
 					return
 				}
 			} else {
-				__ctx.Return(Case)
+				__e.Return(Case)
 				return
 			}
 		} else {
-			__ctx.Return(Case)
+			__e.Return(Case)
 			return
 		}
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.base", value: __defun__shen_4base})
 
-	__defun__shen_4by__hypothesis = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4by__hypothesis = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2808 := __args[0]
 		_ = V2808
 		V2809 := __args[1]
@@ -7439,14 +7439,14 @@ func init() {
 		_ = V2811
 		V2812 := __args[4]
 		_ = V2812
-		reg22993 := __e.Call(__defun__shen_4lazyderef, V2810, V2811)
+		reg22993 := Call(__e, __defun__shen_4lazyderef, V2810, V2811)
 		V2474 := reg22993
 		_ = V2474
 		reg22994 := PrimIsPair(V2474)
 		var reg23029 Obj
 		if reg22994 == True {
 			reg22995 := PrimHead(V2474)
-			reg22996 := __e.Call(__defun__shen_4lazyderef, reg22995, V2811)
+			reg22996 := Call(__e, __defun__shen_4lazyderef, reg22995, V2811)
 			V2475 := reg22996
 			_ = V2475
 			reg22997 := PrimIsPair(V2475)
@@ -7456,14 +7456,14 @@ func init() {
 				Y := reg22998
 				_ = Y
 				reg22999 := PrimTail(V2475)
-				reg23000 := __e.Call(__defun__shen_4lazyderef, reg22999, V2811)
+				reg23000 := Call(__e, __defun__shen_4lazyderef, reg22999, V2811)
 				V2476 := reg23000
 				_ = V2476
 				reg23001 := PrimIsPair(V2476)
 				var reg23025 Obj
 				if reg23001 == True {
 					reg23002 := PrimHead(V2476)
-					reg23003 := __e.Call(__defun__shen_4lazyderef, reg23002, V2811)
+					reg23003 := Call(__e, __defun__shen_4lazyderef, reg23002, V2811)
 					V2477 := reg23003
 					_ = V2477
 					reg23004 := MakeSymbol(":")
@@ -7471,7 +7471,7 @@ func init() {
 					var reg23023 Obj
 					if reg23005 == True {
 						reg23006 := PrimTail(V2476)
-						reg23007 := __e.Call(__defun__shen_4lazyderef, reg23006, V2811)
+						reg23007 := Call(__e, __defun__shen_4lazyderef, reg23006, V2811)
 						V2478 := reg23007
 						_ = V2478
 						reg23008 := PrimIsPair(V2478)
@@ -7481,20 +7481,20 @@ func init() {
 							B := reg23009
 							_ = B
 							reg23010 := PrimTail(V2478)
-							reg23011 := __e.Call(__defun__shen_4lazyderef, reg23010, V2811)
+							reg23011 := Call(__e, __defun__shen_4lazyderef, reg23010, V2811)
 							V2479 := reg23011
 							_ = V2479
 							reg23012 := Nil
 							reg23013 := PrimEqual(reg23012, V2479)
 							var reg23019 Obj
 							if reg23013 == True {
-								reg23014 := __e.Call(__defun__shen_4incinfs)
+								reg23014 := Call(__e, __defun__shen_4incinfs)
 								_ = reg23014
-								reg23015 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-									__ctx.TailApply(__defun__unify_b, V2809, B, V2811, V2812)
+								reg23015 := MakeNative(func(__e Evaluator, __args ...Obj) {
+									__e.TailApply(__defun__unify_b, V2809, B, V2811, V2812)
 									return
 								}, 0)
-								reg23017 := __e.Call(__defun__identical, V2808, Y, V2811, reg23015)
+								reg23017 := Call(__e, __defun__identical, V2808, Y, V2811, reg23015)
 								reg23019 = reg23017
 							} else {
 								reg23018 := False
@@ -7530,7 +7530,7 @@ func init() {
 		reg23030 := False
 		reg23031 := PrimEqual(Case, reg23030)
 		if reg23031 == True {
-			reg23032 := __e.Call(__defun__shen_4lazyderef, V2810, V2811)
+			reg23032 := Call(__e, __defun__shen_4lazyderef, V2810, V2811)
 			V2480 := reg23032
 			_ = V2480
 			reg23033 := PrimIsPair(V2480)
@@ -7538,23 +7538,23 @@ func init() {
 				reg23034 := PrimTail(V2480)
 				Hyp := reg23034
 				_ = Hyp
-				reg23035 := __e.Call(__defun__shen_4incinfs)
+				reg23035 := Call(__e, __defun__shen_4incinfs)
 				_ = reg23035
-				__ctx.TailApply(__defun__shen_4by__hypothesis, V2808, V2809, Hyp, V2811, V2812)
+				__e.TailApply(__defun__shen_4by__hypothesis, V2808, V2809, Hyp, V2811, V2812)
 				return
 			} else {
 				reg23037 := False
-				__ctx.Return(reg23037)
+				__e.Return(reg23037)
 				return
 			}
 		} else {
-			__ctx.Return(Case)
+			__e.Return(Case)
 			return
 		}
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.by_hypothesis", value: __defun__shen_4by__hypothesis})
 
-	__defun__shen_4t_d_1def = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4t_d_1def = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2818 := __args[0]
 		_ = V2818
 		V2819 := __args[1]
@@ -7565,20 +7565,20 @@ func init() {
 		_ = V2821
 		V2822 := __args[4]
 		_ = V2822
-		reg23038 := __e.Call(__defun__shen_4lazyderef, V2818, V2821)
+		reg23038 := Call(__e, __defun__shen_4lazyderef, V2818, V2821)
 		V2468 := reg23038
 		_ = V2468
 		reg23039 := PrimIsPair(V2468)
 		if reg23039 == True {
 			reg23040 := PrimHead(V2468)
-			reg23041 := __e.Call(__defun__shen_4lazyderef, reg23040, V2821)
+			reg23041 := Call(__e, __defun__shen_4lazyderef, reg23040, V2821)
 			V2469 := reg23041
 			_ = V2469
 			reg23042 := MakeSymbol("define")
 			reg23043 := PrimEqual(reg23042, V2469)
 			if reg23043 == True {
 				reg23044 := PrimTail(V2468)
-				reg23045 := __e.Call(__defun__shen_4lazyderef, reg23044, V2821)
+				reg23045 := Call(__e, __defun__shen_4lazyderef, reg23044, V2821)
 				V2470 := reg23045
 				_ = V2470
 				reg23046 := PrimIsPair(V2470)
@@ -7589,21 +7589,21 @@ func init() {
 					reg23048 := PrimTail(V2470)
 					X := reg23048
 					_ = X
-					reg23049 := __e.Call(__defun__shen_4newpv, V2821)
+					reg23049 := Call(__e, __defun__shen_4newpv, V2821)
 					Y := reg23049
 					_ = Y
-					reg23050 := __e.Call(__defun__shen_4newpv, V2821)
+					reg23050 := Call(__e, __defun__shen_4newpv, V2821)
 					E := reg23050
 					_ = E
-					reg23051 := __e.Call(__defun__shen_4incinfs)
+					reg23051 := Call(__e, __defun__shen_4incinfs)
 					_ = reg23051
-					reg23052 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg23052 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						Y := __args[0]
 						_ = Y
-						__ctx.TailApply(__defun__shen_4_5sig_7rules_6, Y)
+						__e.TailApply(__defun__shen_4_5sig_7rules_6, Y)
 						return
 					}, 1)
-					reg23054 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+					reg23054 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						E := __args[0]
 						_ = E
 						reg23055 := PrimIsPair(E)
@@ -7611,40 +7611,40 @@ func init() {
 							reg23056 := MakeString("parse error here: ")
 							reg23057 := MakeString("\n")
 							reg23058 := MakeSymbol("shen.s")
-							reg23059 := __e.Call(__defun__shen_4app, E, reg23057, reg23058)
+							reg23059 := Call(__e, __defun__shen_4app, E, reg23057, reg23058)
 							reg23060 := PrimStringConcat(reg23056, reg23059)
 							reg23061 := PrimSimpleError(reg23060)
-							__ctx.Return(reg23061)
+							__e.Return(reg23061)
 							return
 						} else {
 							reg23062 := MakeString("parse error\n")
 							reg23063 := PrimSimpleError(reg23062)
-							__ctx.Return(reg23063)
+							__e.Return(reg23063)
 							return
 						}
 					}, 1)
-					reg23064 := __e.Call(__defun__compile, reg23052, X, reg23054)
-					__ctx.TailApply(__defun__shen_4t_d_1defh, reg23064, F, V2819, V2820, V2821, V2822)
+					reg23064 := Call(__e, __defun__compile, reg23052, X, reg23054)
+					__e.TailApply(__defun__shen_4t_d_1defh, reg23064, F, V2819, V2820, V2821, V2822)
 					return
 				} else {
 					reg23066 := False
-					__ctx.Return(reg23066)
+					__e.Return(reg23066)
 					return
 				}
 			} else {
 				reg23067 := False
-				__ctx.Return(reg23067)
+				__e.Return(reg23067)
 				return
 			}
 		} else {
 			reg23068 := False
-			__ctx.Return(reg23068)
+			__e.Return(reg23068)
 			return
 		}
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.t*-def", value: __defun__shen_4t_d_1def})
 
-	__defun__shen_4t_d_1defh = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4t_d_1defh = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2829 := __args[0]
 		_ = V2829
 		V2830 := __args[1]
@@ -7657,7 +7657,7 @@ func init() {
 		_ = V2833
 		V2834 := __args[5]
 		_ = V2834
-		reg23069 := __e.Call(__defun__shen_4lazyderef, V2829, V2833)
+		reg23069 := Call(__e, __defun__shen_4lazyderef, V2829, V2833)
 		V2464 := reg23069
 		_ = V2464
 		reg23070 := PrimIsPair(V2464)
@@ -7668,20 +7668,20 @@ func init() {
 			reg23072 := PrimTail(V2464)
 			Rules := reg23072
 			_ = Rules
-			reg23073 := __e.Call(__defun__shen_4incinfs)
+			reg23073 := Call(__e, __defun__shen_4incinfs)
 			_ = reg23073
-			reg23074 := __e.Call(__defun__shen_4ue_1sig, Sig)
-			__ctx.TailApply(__defun__shen_4t_d_1defhh, Sig, reg23074, V2830, V2831, V2832, Rules, V2833, V2834)
+			reg23074 := Call(__e, __defun__shen_4ue_1sig, Sig)
+			__e.TailApply(__defun__shen_4t_d_1defhh, Sig, reg23074, V2830, V2831, V2832, Rules, V2833, V2834)
 			return
 		} else {
 			reg23076 := False
-			__ctx.Return(reg23076)
+			__e.Return(reg23076)
 			return
 		}
 	}, 6)
 	__initDefs = append(__initDefs, defType{name: "shen.t*-defh", value: __defun__shen_4t_d_1defh})
 
-	__defun__shen_4t_d_1defhh = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4t_d_1defhh = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2843 := __args[0]
 		_ = V2843
 		V2844 := __args[1]
@@ -7698,7 +7698,7 @@ func init() {
 		_ = V2849
 		V2850 := __args[7]
 		_ = V2850
-		reg23077 := __e.Call(__defun__shen_4incinfs)
+		reg23077 := Call(__e, __defun__shen_4incinfs)
 		_ = reg23077
 		reg23078 := MakeNumber(1)
 		reg23079 := MakeSymbol(":")
@@ -7707,16 +7707,16 @@ func init() {
 		reg23082 := PrimCons(reg23079, reg23081)
 		reg23083 := PrimCons(V2845, reg23082)
 		reg23084 := PrimCons(reg23083, V2847)
-		reg23085 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			__ctx.TailApply(__defun__shen_4memo, V2845, V2843, V2846, V2849, V2850)
+		reg23085 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			__e.TailApply(__defun__shen_4memo, V2845, V2843, V2846, V2849, V2850)
 			return
 		}, 0)
-		__ctx.TailApply(__defun__shen_4t_d_1rules, V2848, V2844, reg23078, V2845, reg23084, V2849, reg23085)
+		__e.TailApply(__defun__shen_4t_d_1rules, V2848, V2844, reg23078, V2845, reg23084, V2849, reg23085)
 		return
 	}, 8)
 	__initDefs = append(__initDefs, defType{name: "shen.t*-defhh", value: __defun__shen_4t_d_1defhh})
 
-	__defun__shen_4memo = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4memo = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2856 := __args[0]
 		_ = V2856
 		V2857 := __args[1]
@@ -7727,121 +7727,121 @@ func init() {
 		_ = V2859
 		V2860 := __args[4]
 		_ = V2860
-		reg23088 := __e.Call(__defun__shen_4newpv, V2859)
+		reg23088 := Call(__e, __defun__shen_4newpv, V2859)
 		Jnk := reg23088
 		_ = Jnk
-		reg23089 := __e.Call(__defun__shen_4incinfs)
+		reg23089 := Call(__e, __defun__shen_4incinfs)
 		_ = reg23089
-		reg23090 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			reg23091 := __e.Call(__defun__shen_4lazyderef, V2856, V2859)
-			reg23092 := __e.Call(__defun__shen_4lazyderef, V2858, V2859)
-			reg23093 := __e.Call(__defun__declare, reg23091, reg23092)
-			__ctx.TailApply(__defun__bind, Jnk, reg23093, V2859, V2860)
+		reg23090 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			reg23091 := Call(__e, __defun__shen_4lazyderef, V2856, V2859)
+			reg23092 := Call(__e, __defun__shen_4lazyderef, V2858, V2859)
+			reg23093 := Call(__e, __defun__declare, reg23091, reg23092)
+			__e.TailApply(__defun__bind, Jnk, reg23093, V2859, V2860)
 			return
 		}, 0)
-		__ctx.TailApply(__defun__unify_b, V2858, V2857, V2859, reg23090)
+		__e.TailApply(__defun__unify_b, V2858, V2857, V2859, reg23090)
 		return
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.memo", value: __defun__shen_4memo})
 
-	__defun__shen_4_5sig_7rules_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5sig_7rules_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2862 := __args[0]
 		_ = V2862
-		reg23096 := __e.Call(__defun__shen_4_5signature_6, V2862)
+		reg23096 := Call(__e, __defun__shen_4_5signature_6, V2862)
 		Parse__shen_4_5signature_6 := reg23096
 		_ = Parse__shen_4_5signature_6
-		reg23097 := __e.Call(__defun__fail)
+		reg23097 := Call(__e, __defun__fail)
 		reg23098 := PrimEqual(reg23097, Parse__shen_4_5signature_6)
 		reg23099 := PrimNot(reg23098)
 		if reg23099 == True {
-			reg23100 := __e.Call(__defun__shen_4_5non_1ll_1rules_6, Parse__shen_4_5signature_6)
+			reg23100 := Call(__e, __defun__shen_4_5non_1ll_1rules_6, Parse__shen_4_5signature_6)
 			Parse__shen_4_5non_1ll_1rules_6 := reg23100
 			_ = Parse__shen_4_5non_1ll_1rules_6
-			reg23101 := __e.Call(__defun__fail)
+			reg23101 := Call(__e, __defun__fail)
 			reg23102 := PrimEqual(reg23101, Parse__shen_4_5non_1ll_1rules_6)
 			reg23103 := PrimNot(reg23102)
 			if reg23103 == True {
 				reg23104 := PrimHead(Parse__shen_4_5non_1ll_1rules_6)
-				reg23105 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5signature_6)
-				reg23106 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5non_1ll_1rules_6)
+				reg23105 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5signature_6)
+				reg23106 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5non_1ll_1rules_6)
 				reg23107 := PrimCons(reg23105, reg23106)
-				__ctx.TailApply(__defun__shen_4pair, reg23104, reg23107)
+				__e.TailApply(__defun__shen_4pair, reg23104, reg23107)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<sig+rules>", value: __defun__shen_4_5sig_7rules_6})
 
-	__defun__shen_4_5non_1ll_1rules_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4_5non_1ll_1rules_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2864 := __args[0]
 		_ = V2864
-		reg23111 := __e.Call(__defun__shen_4_5rule_6, V2864)
+		reg23111 := Call(__e, __defun__shen_4_5rule_6, V2864)
 		Parse__shen_4_5rule_6 := reg23111
 		_ = Parse__shen_4_5rule_6
-		reg23112 := __e.Call(__defun__fail)
+		reg23112 := Call(__e, __defun__fail)
 		reg23113 := PrimEqual(reg23112, Parse__shen_4_5rule_6)
 		reg23114 := PrimNot(reg23113)
 		var reg23127 Obj
 		if reg23114 == True {
-			reg23115 := __e.Call(__defun__shen_4_5non_1ll_1rules_6, Parse__shen_4_5rule_6)
+			reg23115 := Call(__e, __defun__shen_4_5non_1ll_1rules_6, Parse__shen_4_5rule_6)
 			Parse__shen_4_5non_1ll_1rules_6 := reg23115
 			_ = Parse__shen_4_5non_1ll_1rules_6
-			reg23116 := __e.Call(__defun__fail)
+			reg23116 := Call(__e, __defun__fail)
 			reg23117 := PrimEqual(reg23116, Parse__shen_4_5non_1ll_1rules_6)
 			reg23118 := PrimNot(reg23117)
 			var reg23125 Obj
 			if reg23118 == True {
 				reg23119 := PrimHead(Parse__shen_4_5non_1ll_1rules_6)
-				reg23120 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5rule_6)
-				reg23121 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5non_1ll_1rules_6)
+				reg23120 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5rule_6)
+				reg23121 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5non_1ll_1rules_6)
 				reg23122 := PrimCons(reg23120, reg23121)
-				reg23123 := __e.Call(__defun__shen_4pair, reg23119, reg23122)
+				reg23123 := Call(__e, __defun__shen_4pair, reg23119, reg23122)
 				reg23125 = reg23123
 			} else {
-				reg23124 := __e.Call(__defun__fail)
+				reg23124 := Call(__e, __defun__fail)
 				reg23125 = reg23124
 			}
 			reg23127 = reg23125
 		} else {
-			reg23126 := __e.Call(__defun__fail)
+			reg23126 := Call(__e, __defun__fail)
 			reg23127 = reg23126
 		}
 		YaccParse := reg23127
 		_ = YaccParse
-		reg23128 := __e.Call(__defun__fail)
+		reg23128 := Call(__e, __defun__fail)
 		reg23129 := PrimEqual(YaccParse, reg23128)
 		if reg23129 == True {
-			reg23130 := __e.Call(__defun__shen_4_5rule_6, V2864)
+			reg23130 := Call(__e, __defun__shen_4_5rule_6, V2864)
 			Parse__shen_4_5rule_6 := reg23130
 			_ = Parse__shen_4_5rule_6
-			reg23131 := __e.Call(__defun__fail)
+			reg23131 := Call(__e, __defun__fail)
 			reg23132 := PrimEqual(reg23131, Parse__shen_4_5rule_6)
 			reg23133 := PrimNot(reg23132)
 			if reg23133 == True {
 				reg23134 := PrimHead(Parse__shen_4_5rule_6)
-				reg23135 := __e.Call(__defun__shen_4hdtl, Parse__shen_4_5rule_6)
+				reg23135 := Call(__e, __defun__shen_4hdtl, Parse__shen_4_5rule_6)
 				reg23136 := Nil
 				reg23137 := PrimCons(reg23135, reg23136)
-				__ctx.TailApply(__defun__shen_4pair, reg23134, reg23137)
+				__e.TailApply(__defun__shen_4pair, reg23134, reg23137)
 				return
 			} else {
-				__ctx.TailApply(__defun__fail)
+				__e.TailApply(__defun__fail)
 				return
 			}
 		} else {
-			__ctx.Return(YaccParse)
+			__e.Return(YaccParse)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.<non-ll-rules>", value: __defun__shen_4_5non_1ll_1rules_6})
 
-	__defun__shen_4ue = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4ue = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2866 := __args[0]
 		_ = V2866
 		reg23140 := PrimIsPair(V2866)
@@ -7900,27 +7900,27 @@ func init() {
 			reg23164 = reg23163
 		}
 		if reg23164 == True {
-			__ctx.Return(V2866)
+			__e.Return(V2866)
 			return
 		} else {
 			reg23165 := PrimIsPair(V2866)
 			if reg23165 == True {
-				reg23166 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg23166 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					Z := __args[0]
 					_ = Z
-					__ctx.TailApply(__defun__shen_4ue, Z)
+					__e.TailApply(__defun__shen_4ue, Z)
 					return
 				}, 1)
-				__ctx.TailApply(__defun__map, reg23166, V2866)
+				__e.TailApply(__defun__map, reg23166, V2866)
 				return
 			} else {
 				reg23169 := PrimIsVariable(V2866)
 				if reg23169 == True {
 					reg23170 := MakeSymbol("&&")
-					__ctx.TailApply(__defun__concat, reg23170, V2866)
+					__e.TailApply(__defun__concat, reg23170, V2866)
 					return
 				} else {
-					__ctx.Return(V2866)
+					__e.Return(V2866)
 					return
 				}
 			}
@@ -7928,88 +7928,88 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.ue", value: __defun__shen_4ue})
 
-	__defun__shen_4ue_1sig = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4ue_1sig = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2868 := __args[0]
 		_ = V2868
 		reg23172 := PrimIsPair(V2868)
 		if reg23172 == True {
-			reg23173 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg23173 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				Z := __args[0]
 				_ = Z
-				__ctx.TailApply(__defun__shen_4ue_1sig, Z)
+				__e.TailApply(__defun__shen_4ue_1sig, Z)
 				return
 			}, 1)
-			__ctx.TailApply(__defun__map, reg23173, V2868)
+			__e.TailApply(__defun__map, reg23173, V2868)
 			return
 		} else {
 			reg23176 := PrimIsVariable(V2868)
 			if reg23176 == True {
 				reg23177 := MakeSymbol("&&&")
-				__ctx.TailApply(__defun__concat, reg23177, V2868)
+				__e.TailApply(__defun__concat, reg23177, V2868)
 				return
 			} else {
-				__ctx.Return(V2868)
+				__e.Return(V2868)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.ue-sig", value: __defun__shen_4ue_1sig})
 
-	__defun__shen_4ues = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4ues = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2874 := __args[0]
 		_ = V2874
-		reg23179 := __e.Call(__defun__shen_4ue_2, V2874)
+		reg23179 := Call(__e, __defun__shen_4ue_2, V2874)
 		if reg23179 == True {
 			reg23180 := Nil
 			reg23181 := PrimCons(V2874, reg23180)
-			__ctx.Return(reg23181)
+			__e.Return(reg23181)
 			return
 		} else {
 			reg23182 := PrimIsPair(V2874)
 			if reg23182 == True {
 				reg23183 := PrimHead(V2874)
-				reg23184 := __e.Call(__defun__shen_4ues, reg23183)
+				reg23184 := Call(__e, __defun__shen_4ues, reg23183)
 				reg23185 := PrimTail(V2874)
-				reg23186 := __e.Call(__defun__shen_4ues, reg23185)
-				__ctx.TailApply(__defun__union, reg23184, reg23186)
+				reg23186 := Call(__e, __defun__shen_4ues, reg23185)
+				__e.TailApply(__defun__union, reg23184, reg23186)
 				return
 			} else {
 				reg23188 := Nil
-				__ctx.Return(reg23188)
+				__e.Return(reg23188)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.ues", value: __defun__shen_4ues})
 
-	__defun__shen_4ue_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4ue_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2876 := __args[0]
 		_ = V2876
 		reg23189 := PrimIsSymbol(V2876)
 		if reg23189 == True {
 			reg23190 := PrimStr(V2876)
-			reg23191 := __e.Call(__defun__shen_4ue_1h_2, reg23190)
+			reg23191 := Call(__e, __defun__shen_4ue_1h_2, reg23190)
 			if reg23191 == True {
 				reg23192 := True
-				__ctx.Return(reg23192)
+				__e.Return(reg23192)
 				return
 			} else {
 				reg23193 := False
-				__ctx.Return(reg23193)
+				__e.Return(reg23193)
 				return
 			}
 		} else {
 			reg23194 := False
-			__ctx.Return(reg23194)
+			__e.Return(reg23194)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.ue?", value: __defun__shen_4ue_2})
 
-	__defun__shen_4ue_1h_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4ue_1h_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2884 := __args[0]
 		_ = V2884
-		reg23195 := __e.Call(__defun__shen_4_7string_2, V2884)
+		reg23195 := Call(__e, __defun__shen_4_7string_2, V2884)
 		var reg23221 Obj
 		if reg23195 == True {
 			reg23196 := MakeString("&")
@@ -8019,7 +8019,7 @@ func init() {
 			var reg23216 Obj
 			if reg23199 == True {
 				reg23200 := PrimTailString(V2884)
-				reg23201 := __e.Call(__defun__shen_4_7string_2, reg23200)
+				reg23201 := Call(__e, __defun__shen_4_7string_2, reg23200)
 				var reg23211 Obj
 				if reg23201 == True {
 					reg23202 := MakeString("&")
@@ -8068,17 +8068,17 @@ func init() {
 		}
 		if reg23221 == True {
 			reg23222 := True
-			__ctx.Return(reg23222)
+			__e.Return(reg23222)
 			return
 		} else {
 			reg23223 := False
-			__ctx.Return(reg23223)
+			__e.Return(reg23223)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.ue-h?", value: __defun__shen_4ue_1h_2})
 
-	__defun__shen_4t_d_1rules = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4t_d_1rules = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2892 := __args[0]
 		_ = V2892
 		V2893 := __args[1]
@@ -8093,19 +8093,19 @@ func init() {
 		_ = V2897
 		V2898 := __args[6]
 		_ = V2898
-		reg23224 := __e.Call(__defun__shen_4catchpoint)
+		reg23224 := Call(__e, __defun__shen_4catchpoint)
 		Throwcontrol := reg23224
 		_ = Throwcontrol
-		reg23225 := __e.Call(__defun__shen_4lazyderef, V2892, V2897)
+		reg23225 := Call(__e, __defun__shen_4lazyderef, V2892, V2897)
 		V2448 := reg23225
 		_ = V2448
 		reg23226 := Nil
 		reg23227 := PrimEqual(reg23226, V2448)
 		var reg23231 Obj
 		if reg23227 == True {
-			reg23228 := __e.Call(__defun__shen_4incinfs)
+			reg23228 := Call(__e, __defun__shen_4incinfs)
 			_ = reg23228
-			reg23229 := __e.Call(__defun__thaw, V2898)
+			reg23229 := Call(__e, __defun__thaw, V2898)
 			reg23231 = reg23229
 		} else {
 			reg23230 := False
@@ -8117,7 +8117,7 @@ func init() {
 		reg23233 := PrimEqual(Case, reg23232)
 		var reg23267 Obj
 		if reg23233 == True {
-			reg23234 := __e.Call(__defun__shen_4lazyderef, V2892, V2897)
+			reg23234 := Call(__e, __defun__shen_4lazyderef, V2892, V2897)
 			V2449 := reg23234
 			_ = V2449
 			reg23235 := PrimIsPair(V2449)
@@ -8129,20 +8129,20 @@ func init() {
 				reg23237 := PrimTail(V2449)
 				Rules := reg23237
 				_ = Rules
-				reg23238 := __e.Call(__defun__shen_4incinfs)
+				reg23238 := Call(__e, __defun__shen_4incinfs)
 				_ = reg23238
-				reg23239 := __e.Call(__defun__shen_4ue, Rule)
-				reg23240 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-					reg23241 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg23239 := Call(__e, __defun__shen_4ue, Rule)
+				reg23240 := MakeNative(func(__e Evaluator, __args ...Obj) {
+					reg23241 := MakeNative(func(__e Evaluator, __args ...Obj) {
 						reg23242 := MakeNumber(1)
 						reg23243 := PrimNumberAdd(V2894, reg23242)
-						__ctx.TailApply(__defun__shen_4t_d_1rules, Rules, V2893, reg23243, V2895, V2896, V2897, V2898)
+						__e.TailApply(__defun__shen_4t_d_1rules, Rules, V2893, reg23243, V2895, V2896, V2897, V2898)
 						return
 					}, 0)
-					__ctx.TailApply(__defun__cut, Throwcontrol, V2897, reg23241)
+					__e.TailApply(__defun__cut, Throwcontrol, V2897, reg23241)
 					return
 				}, 0)
-				reg23246 := __e.Call(__defun__shen_4t_d_1rule, reg23239, V2893, V2896, V2897, reg23240)
+				reg23246 := Call(__e, __defun__shen_4t_d_1rule, reg23239, V2893, V2896, V2897, reg23240)
 				reg23248 = reg23246
 			} else {
 				reg23247 := False
@@ -8154,24 +8154,24 @@ func init() {
 			reg23250 := PrimEqual(Case, reg23249)
 			var reg23266 Obj
 			if reg23250 == True {
-				reg23251 := __e.Call(__defun__shen_4newpv, V2897)
+				reg23251 := Call(__e, __defun__shen_4newpv, V2897)
 				Err := reg23251
 				_ = Err
-				reg23252 := __e.Call(__defun__shen_4incinfs)
+				reg23252 := Call(__e, __defun__shen_4incinfs)
 				_ = reg23252
 				reg23253 := MakeString("type error in rule ")
-				reg23254 := __e.Call(__defun__shen_4lazyderef, V2894, V2897)
+				reg23254 := Call(__e, __defun__shen_4lazyderef, V2894, V2897)
 				reg23255 := MakeString(" of ")
-				reg23256 := __e.Call(__defun__shen_4lazyderef, V2895, V2897)
+				reg23256 := Call(__e, __defun__shen_4lazyderef, V2895, V2897)
 				reg23257 := MakeString("")
 				reg23258 := MakeSymbol("shen.a")
-				reg23259 := __e.Call(__defun__shen_4app, reg23256, reg23257, reg23258)
+				reg23259 := Call(__e, __defun__shen_4app, reg23256, reg23257, reg23258)
 				reg23260 := PrimStringConcat(reg23255, reg23259)
 				reg23261 := MakeSymbol("shen.a")
-				reg23262 := __e.Call(__defun__shen_4app, reg23254, reg23260, reg23261)
+				reg23262 := Call(__e, __defun__shen_4app, reg23254, reg23260, reg23261)
 				reg23263 := PrimStringConcat(reg23253, reg23262)
 				reg23264 := PrimSimpleError(reg23263)
-				reg23265 := __e.Call(__defun__bind, Err, reg23264, V2897, V2898)
+				reg23265 := Call(__e, __defun__bind, Err, reg23264, V2897, V2898)
 				reg23266 = reg23265
 			} else {
 				reg23266 = Case
@@ -8180,12 +8180,12 @@ func init() {
 		} else {
 			reg23267 = Case
 		}
-		__ctx.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg23267)
+		__e.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg23267)
 		return
 	}, 7)
 	__initDefs = append(__initDefs, defType{name: "shen.t*-rules", value: __defun__shen_4t_d_1rules})
 
-	__defun__shen_4t_d_1rule = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4t_d_1rule = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2904 := __args[0]
 		_ = V2904
 		V2905 := __args[1]
@@ -8196,10 +8196,10 @@ func init() {
 		_ = V2907
 		V2908 := __args[4]
 		_ = V2908
-		reg23269 := __e.Call(__defun__shen_4catchpoint)
+		reg23269 := Call(__e, __defun__shen_4catchpoint)
 		Throwcontrol := reg23269
 		_ = Throwcontrol
-		reg23270 := __e.Call(__defun__shen_4lazyderef, V2904, V2907)
+		reg23270 := Call(__e, __defun__shen_4lazyderef, V2904, V2907)
 		V2440 := reg23270
 		_ = V2440
 		reg23271 := PrimIsPair(V2440)
@@ -8209,7 +8209,7 @@ func init() {
 			Patterns := reg23272
 			_ = Patterns
 			reg23273 := PrimTail(V2440)
-			reg23274 := __e.Call(__defun__shen_4lazyderef, reg23273, V2907)
+			reg23274 := Call(__e, __defun__shen_4lazyderef, reg23273, V2907)
 			V2441 := reg23274
 			_ = V2441
 			reg23275 := PrimIsPair(V2441)
@@ -8219,36 +8219,36 @@ func init() {
 				Action := reg23276
 				_ = Action
 				reg23277 := PrimTail(V2441)
-				reg23278 := __e.Call(__defun__shen_4lazyderef, reg23277, V2907)
+				reg23278 := Call(__e, __defun__shen_4lazyderef, reg23277, V2907)
 				V2442 := reg23278
 				_ = V2442
 				reg23279 := Nil
 				reg23280 := PrimEqual(reg23279, V2442)
 				var reg23296 Obj
 				if reg23280 == True {
-					reg23281 := __e.Call(__defun__shen_4newpv, V2907)
+					reg23281 := Call(__e, __defun__shen_4newpv, V2907)
 					NewHyps := reg23281
 					_ = NewHyps
-					reg23282 := __e.Call(__defun__shen_4incinfs)
+					reg23282 := Call(__e, __defun__shen_4incinfs)
 					_ = reg23282
-					reg23283 := __e.Call(__defun__shen_4placeholders, Patterns)
-					reg23284 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-						reg23285 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-							reg23286 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-								reg23287 := __e.Call(__defun__shen_4ue, Action)
-								reg23288 := __e.Call(__defun__shen_4curry, reg23287)
-								reg23289 := __e.Call(__defun__shen_4result_1type, Patterns, V2905)
-								reg23290 := __e.Call(__defun__shen_4patthyps, Patterns, V2905, V2906)
-								__ctx.TailApply(__defun__shen_4t_d_1action, reg23288, reg23289, reg23290, V2907, V2908)
+					reg23283 := Call(__e, __defun__shen_4placeholders, Patterns)
+					reg23284 := MakeNative(func(__e Evaluator, __args ...Obj) {
+						reg23285 := MakeNative(func(__e Evaluator, __args ...Obj) {
+							reg23286 := MakeNative(func(__e Evaluator, __args ...Obj) {
+								reg23287 := Call(__e, __defun__shen_4ue, Action)
+								reg23288 := Call(__e, __defun__shen_4curry, reg23287)
+								reg23289 := Call(__e, __defun__shen_4result_1type, Patterns, V2905)
+								reg23290 := Call(__e, __defun__shen_4patthyps, Patterns, V2905, V2906)
+								__e.TailApply(__defun__shen_4t_d_1action, reg23288, reg23289, reg23290, V2907, V2908)
 								return
 							}, 0)
-							__ctx.TailApply(__defun__cut, Throwcontrol, V2907, reg23286)
+							__e.TailApply(__defun__cut, Throwcontrol, V2907, reg23286)
 							return
 						}, 0)
-						__ctx.TailApply(__defun__shen_4t_d_1patterns, Patterns, V2905, NewHyps, V2907, reg23285)
+						__e.TailApply(__defun__shen_4t_d_1patterns, Patterns, V2905, NewHyps, V2907, reg23285)
 						return
 					}, 0)
-					reg23294 := __e.Call(__defun__shen_4newhyps, reg23283, V2906, NewHyps, V2907, reg23284)
+					reg23294 := Call(__e, __defun__shen_4newhyps, reg23283, V2906, NewHyps, V2907, reg23284)
 					reg23296 = reg23294
 				} else {
 					reg23295 := False
@@ -8264,39 +8264,39 @@ func init() {
 			reg23299 := False
 			reg23300 = reg23299
 		}
-		__ctx.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg23300)
+		__e.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg23300)
 		return
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.t*-rule", value: __defun__shen_4t_d_1rule})
 
-	__defun__shen_4placeholders = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4placeholders = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2914 := __args[0]
 		_ = V2914
-		reg23302 := __e.Call(__defun__shen_4ue_2, V2914)
+		reg23302 := Call(__e, __defun__shen_4ue_2, V2914)
 		if reg23302 == True {
 			reg23303 := Nil
 			reg23304 := PrimCons(V2914, reg23303)
-			__ctx.Return(reg23304)
+			__e.Return(reg23304)
 			return
 		} else {
 			reg23305 := PrimIsPair(V2914)
 			if reg23305 == True {
 				reg23306 := PrimHead(V2914)
-				reg23307 := __e.Call(__defun__shen_4placeholders, reg23306)
+				reg23307 := Call(__e, __defun__shen_4placeholders, reg23306)
 				reg23308 := PrimTail(V2914)
-				reg23309 := __e.Call(__defun__shen_4placeholders, reg23308)
-				__ctx.TailApply(__defun__union, reg23307, reg23309)
+				reg23309 := Call(__e, __defun__shen_4placeholders, reg23308)
+				__e.TailApply(__defun__union, reg23307, reg23309)
 				return
 			} else {
 				reg23311 := Nil
-				__ctx.Return(reg23311)
+				__e.Return(reg23311)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.placeholders", value: __defun__shen_4placeholders})
 
-	__defun__shen_4newhyps = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4newhyps = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2920 := __args[0]
 		_ = V2920
 		V2921 := __args[1]
@@ -8307,16 +8307,16 @@ func init() {
 		_ = V2923
 		V2924 := __args[4]
 		_ = V2924
-		reg23312 := __e.Call(__defun__shen_4lazyderef, V2920, V2923)
+		reg23312 := Call(__e, __defun__shen_4lazyderef, V2920, V2923)
 		V2427 := reg23312
 		_ = V2427
 		reg23313 := Nil
 		reg23314 := PrimEqual(reg23313, V2427)
 		var reg23318 Obj
 		if reg23314 == True {
-			reg23315 := __e.Call(__defun__shen_4incinfs)
+			reg23315 := Call(__e, __defun__shen_4incinfs)
 			_ = reg23315
-			reg23316 := __e.Call(__defun__unify_b, V2922, V2921, V2923, V2924)
+			reg23316 := Call(__e, __defun__unify_b, V2922, V2921, V2923, V2924)
 			reg23318 = reg23316
 		} else {
 			reg23317 := False
@@ -8327,7 +8327,7 @@ func init() {
 		reg23319 := False
 		reg23320 := PrimEqual(Case, reg23319)
 		if reg23320 == True {
-			reg23321 := __e.Call(__defun__shen_4lazyderef, V2920, V2923)
+			reg23321 := Call(__e, __defun__shen_4lazyderef, V2920, V2923)
 			V2428 := reg23321
 			_ = V2428
 			reg23322 := PrimIsPair(V2428)
@@ -8338,13 +8338,13 @@ func init() {
 				reg23324 := PrimTail(V2428)
 				Vs := reg23324
 				_ = Vs
-				reg23325 := __e.Call(__defun__shen_4lazyderef, V2922, V2923)
+				reg23325 := Call(__e, __defun__shen_4lazyderef, V2922, V2923)
 				V2429 := reg23325
 				_ = V2429
 				reg23326 := PrimIsPair(V2429)
 				if reg23326 == True {
 					reg23327 := PrimHead(V2429)
-					reg23328 := __e.Call(__defun__shen_4lazyderef, reg23327, V2923)
+					reg23328 := Call(__e, __defun__shen_4lazyderef, reg23327, V2923)
 					V2430 := reg23328
 					_ = V2430
 					reg23329 := PrimIsPair(V2430)
@@ -8353,20 +8353,20 @@ func init() {
 						V := reg23330
 						_ = V
 						reg23331 := PrimTail(V2430)
-						reg23332 := __e.Call(__defun__shen_4lazyderef, reg23331, V2923)
+						reg23332 := Call(__e, __defun__shen_4lazyderef, reg23331, V2923)
 						V2431 := reg23332
 						_ = V2431
 						reg23333 := PrimIsPair(V2431)
 						if reg23333 == True {
 							reg23334 := PrimHead(V2431)
-							reg23335 := __e.Call(__defun__shen_4lazyderef, reg23334, V2923)
+							reg23335 := Call(__e, __defun__shen_4lazyderef, reg23334, V2923)
 							V2432 := reg23335
 							_ = V2432
 							reg23336 := MakeSymbol(":")
 							reg23337 := PrimEqual(reg23336, V2432)
 							if reg23337 == True {
 								reg23338 := PrimTail(V2431)
-								reg23339 := __e.Call(__defun__shen_4lazyderef, reg23338, V2923)
+								reg23339 := Call(__e, __defun__shen_4lazyderef, reg23338, V2923)
 								V2433 := reg23339
 								_ = V2433
 								reg23340 := PrimIsPair(V2433)
@@ -8375,7 +8375,7 @@ func init() {
 									A := reg23341
 									_ = A
 									reg23342 := PrimTail(V2433)
-									reg23343 := __e.Call(__defun__shen_4lazyderef, reg23342, V2923)
+									reg23343 := Call(__e, __defun__shen_4lazyderef, reg23342, V2923)
 									V2434 := reg23343
 									_ = V2434
 									reg23344 := Nil
@@ -8384,82 +8384,82 @@ func init() {
 										reg23346 := PrimTail(V2429)
 										NewHyp := reg23346
 										_ = NewHyp
-										reg23347 := __e.Call(__defun__shen_4incinfs)
+										reg23347 := Call(__e, __defun__shen_4incinfs)
 										_ = reg23347
-										reg23348 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-											__ctx.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
+										reg23348 := MakeNative(func(__e Evaluator, __args ...Obj) {
+											__e.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
 											return
 										}, 0)
-										__ctx.TailApply(__defun__unify_b, V, V2423, V2923, reg23348)
+										__e.TailApply(__defun__unify_b, V, V2423, V2923, reg23348)
 										return
 									} else {
-										reg23351 := __e.Call(__defun__shen_4pvar_2, V2434)
+										reg23351 := Call(__e, __defun__shen_4pvar_2, V2434)
 										if reg23351 == True {
 											reg23352 := Nil
-											reg23353 := __e.Call(__defun__shen_4bindv, V2434, reg23352, V2923)
+											reg23353 := Call(__e, __defun__shen_4bindv, V2434, reg23352, V2923)
 											_ = reg23353
 											reg23354 := PrimTail(V2429)
 											NewHyp := reg23354
 											_ = NewHyp
-											reg23355 := __e.Call(__defun__shen_4incinfs)
+											reg23355 := Call(__e, __defun__shen_4incinfs)
 											_ = reg23355
-											reg23356 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-												__ctx.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
+											reg23356 := MakeNative(func(__e Evaluator, __args ...Obj) {
+												__e.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
 												return
 											}, 0)
-											reg23358 := __e.Call(__defun__unify_b, V, V2423, V2923, reg23356)
+											reg23358 := Call(__e, __defun__unify_b, V, V2423, V2923, reg23356)
 											Result := reg23358
 											_ = Result
-											reg23359 := __e.Call(__defun__shen_4unbindv, V2434, V2923)
+											reg23359 := Call(__e, __defun__shen_4unbindv, V2434, V2923)
 											_ = reg23359
-											__ctx.Return(Result)
+											__e.Return(Result)
 											return
 										} else {
 											reg23360 := False
-											__ctx.Return(reg23360)
+											__e.Return(reg23360)
 											return
 										}
 									}
 								} else {
-									reg23361 := __e.Call(__defun__shen_4pvar_2, V2433)
+									reg23361 := Call(__e, __defun__shen_4pvar_2, V2433)
 									if reg23361 == True {
-										reg23362 := __e.Call(__defun__shen_4newpv, V2923)
+										reg23362 := Call(__e, __defun__shen_4newpv, V2923)
 										A := reg23362
 										_ = A
 										reg23363 := Nil
 										reg23364 := PrimCons(A, reg23363)
-										reg23365 := __e.Call(__defun__shen_4bindv, V2433, reg23364, V2923)
+										reg23365 := Call(__e, __defun__shen_4bindv, V2433, reg23364, V2923)
 										_ = reg23365
 										reg23366 := PrimTail(V2429)
 										NewHyp := reg23366
 										_ = NewHyp
-										reg23367 := __e.Call(__defun__shen_4incinfs)
+										reg23367 := Call(__e, __defun__shen_4incinfs)
 										_ = reg23367
-										reg23368 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-											__ctx.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
+										reg23368 := MakeNative(func(__e Evaluator, __args ...Obj) {
+											__e.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
 											return
 										}, 0)
-										reg23370 := __e.Call(__defun__unify_b, V, V2423, V2923, reg23368)
+										reg23370 := Call(__e, __defun__unify_b, V, V2423, V2923, reg23368)
 										Result := reg23370
 										_ = Result
-										reg23371 := __e.Call(__defun__shen_4unbindv, V2433, V2923)
+										reg23371 := Call(__e, __defun__shen_4unbindv, V2433, V2923)
 										_ = reg23371
-										__ctx.Return(Result)
+										__e.Return(Result)
 										return
 									} else {
 										reg23372 := False
-										__ctx.Return(reg23372)
+										__e.Return(reg23372)
 										return
 									}
 								}
 							} else {
-								reg23373 := __e.Call(__defun__shen_4pvar_2, V2432)
+								reg23373 := Call(__e, __defun__shen_4pvar_2, V2432)
 								if reg23373 == True {
 									reg23374 := MakeSymbol(":")
-									reg23375 := __e.Call(__defun__shen_4bindv, V2432, reg23374, V2923)
+									reg23375 := Call(__e, __defun__shen_4bindv, V2432, reg23374, V2923)
 									_ = reg23375
 									reg23376 := PrimTail(V2431)
-									reg23377 := __e.Call(__defun__shen_4lazyderef, reg23376, V2923)
+									reg23377 := Call(__e, __defun__shen_4lazyderef, reg23376, V2923)
 									V2435 := reg23377
 									_ = V2435
 									reg23378 := PrimIsPair(V2435)
@@ -8469,7 +8469,7 @@ func init() {
 										A := reg23379
 										_ = A
 										reg23380 := PrimTail(V2435)
-										reg23381 := __e.Call(__defun__shen_4lazyderef, reg23380, V2923)
+										reg23381 := Call(__e, __defun__shen_4lazyderef, reg23380, V2923)
 										V2436 := reg23381
 										_ = V2436
 										reg23382 := Nil
@@ -8479,34 +8479,34 @@ func init() {
 											reg23384 := PrimTail(V2429)
 											NewHyp := reg23384
 											_ = NewHyp
-											reg23385 := __e.Call(__defun__shen_4incinfs)
+											reg23385 := Call(__e, __defun__shen_4incinfs)
 											_ = reg23385
-											reg23386 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-												__ctx.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
+											reg23386 := MakeNative(func(__e Evaluator, __args ...Obj) {
+												__e.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
 												return
 											}, 0)
-											reg23388 := __e.Call(__defun__unify_b, V, V2423, V2923, reg23386)
+											reg23388 := Call(__e, __defun__unify_b, V, V2423, V2923, reg23386)
 											reg23400 = reg23388
 										} else {
-											reg23389 := __e.Call(__defun__shen_4pvar_2, V2436)
+											reg23389 := Call(__e, __defun__shen_4pvar_2, V2436)
 											var reg23399 Obj
 											if reg23389 == True {
 												reg23390 := Nil
-												reg23391 := __e.Call(__defun__shen_4bindv, V2436, reg23390, V2923)
+												reg23391 := Call(__e, __defun__shen_4bindv, V2436, reg23390, V2923)
 												_ = reg23391
 												reg23392 := PrimTail(V2429)
 												NewHyp := reg23392
 												_ = NewHyp
-												reg23393 := __e.Call(__defun__shen_4incinfs)
+												reg23393 := Call(__e, __defun__shen_4incinfs)
 												_ = reg23393
-												reg23394 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-													__ctx.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
+												reg23394 := MakeNative(func(__e Evaluator, __args ...Obj) {
+													__e.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
 													return
 												}, 0)
-												reg23396 := __e.Call(__defun__unify_b, V, V2423, V2923, reg23394)
+												reg23396 := Call(__e, __defun__unify_b, V, V2423, V2923, reg23394)
 												Result := reg23396
 												_ = Result
-												reg23397 := __e.Call(__defun__shen_4unbindv, V2436, V2923)
+												reg23397 := Call(__e, __defun__shen_4unbindv, V2436, V2923)
 												_ = reg23397
 												reg23399 = Result
 											} else {
@@ -8517,29 +8517,29 @@ func init() {
 										}
 										reg23414 = reg23400
 									} else {
-										reg23401 := __e.Call(__defun__shen_4pvar_2, V2435)
+										reg23401 := Call(__e, __defun__shen_4pvar_2, V2435)
 										var reg23413 Obj
 										if reg23401 == True {
-											reg23402 := __e.Call(__defun__shen_4newpv, V2923)
+											reg23402 := Call(__e, __defun__shen_4newpv, V2923)
 											A := reg23402
 											_ = A
 											reg23403 := Nil
 											reg23404 := PrimCons(A, reg23403)
-											reg23405 := __e.Call(__defun__shen_4bindv, V2435, reg23404, V2923)
+											reg23405 := Call(__e, __defun__shen_4bindv, V2435, reg23404, V2923)
 											_ = reg23405
 											reg23406 := PrimTail(V2429)
 											NewHyp := reg23406
 											_ = NewHyp
-											reg23407 := __e.Call(__defun__shen_4incinfs)
+											reg23407 := Call(__e, __defun__shen_4incinfs)
 											_ = reg23407
-											reg23408 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-												__ctx.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
+											reg23408 := MakeNative(func(__e Evaluator, __args ...Obj) {
+												__e.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
 												return
 											}, 0)
-											reg23410 := __e.Call(__defun__unify_b, V, V2423, V2923, reg23408)
+											reg23410 := Call(__e, __defun__unify_b, V, V2423, V2923, reg23408)
 											Result := reg23410
 											_ = Result
-											reg23411 := __e.Call(__defun__shen_4unbindv, V2435, V2923)
+											reg23411 := Call(__e, __defun__shen_4unbindv, V2435, V2923)
 											_ = reg23411
 											reg23413 = Result
 										} else {
@@ -8550,57 +8550,57 @@ func init() {
 									}
 									Result := reg23414
 									_ = Result
-									reg23415 := __e.Call(__defun__shen_4unbindv, V2432, V2923)
+									reg23415 := Call(__e, __defun__shen_4unbindv, V2432, V2923)
 									_ = reg23415
-									__ctx.Return(Result)
+									__e.Return(Result)
 									return
 								} else {
 									reg23416 := False
-									__ctx.Return(reg23416)
+									__e.Return(reg23416)
 									return
 								}
 							}
 						} else {
-							reg23417 := __e.Call(__defun__shen_4pvar_2, V2431)
+							reg23417 := Call(__e, __defun__shen_4pvar_2, V2431)
 							if reg23417 == True {
-								reg23418 := __e.Call(__defun__shen_4newpv, V2923)
+								reg23418 := Call(__e, __defun__shen_4newpv, V2923)
 								A := reg23418
 								_ = A
 								reg23419 := MakeSymbol(":")
 								reg23420 := Nil
 								reg23421 := PrimCons(A, reg23420)
 								reg23422 := PrimCons(reg23419, reg23421)
-								reg23423 := __e.Call(__defun__shen_4bindv, V2431, reg23422, V2923)
+								reg23423 := Call(__e, __defun__shen_4bindv, V2431, reg23422, V2923)
 								_ = reg23423
 								reg23424 := PrimTail(V2429)
 								NewHyp := reg23424
 								_ = NewHyp
-								reg23425 := __e.Call(__defun__shen_4incinfs)
+								reg23425 := Call(__e, __defun__shen_4incinfs)
 								_ = reg23425
-								reg23426 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-									__ctx.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
+								reg23426 := MakeNative(func(__e Evaluator, __args ...Obj) {
+									__e.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
 									return
 								}, 0)
-								reg23428 := __e.Call(__defun__unify_b, V, V2423, V2923, reg23426)
+								reg23428 := Call(__e, __defun__unify_b, V, V2423, V2923, reg23426)
 								Result := reg23428
 								_ = Result
-								reg23429 := __e.Call(__defun__shen_4unbindv, V2431, V2923)
+								reg23429 := Call(__e, __defun__shen_4unbindv, V2431, V2923)
 								_ = reg23429
-								__ctx.Return(Result)
+								__e.Return(Result)
 								return
 							} else {
 								reg23430 := False
-								__ctx.Return(reg23430)
+								__e.Return(reg23430)
 								return
 							}
 						}
 					} else {
-						reg23431 := __e.Call(__defun__shen_4pvar_2, V2430)
+						reg23431 := Call(__e, __defun__shen_4pvar_2, V2430)
 						if reg23431 == True {
-							reg23432 := __e.Call(__defun__shen_4newpv, V2923)
+							reg23432 := Call(__e, __defun__shen_4newpv, V2923)
 							V := reg23432
 							_ = V
-							reg23433 := __e.Call(__defun__shen_4newpv, V2923)
+							reg23433 := Call(__e, __defun__shen_4newpv, V2923)
 							A := reg23433
 							_ = A
 							reg23434 := MakeSymbol(":")
@@ -8608,40 +8608,40 @@ func init() {
 							reg23436 := PrimCons(A, reg23435)
 							reg23437 := PrimCons(reg23434, reg23436)
 							reg23438 := PrimCons(V, reg23437)
-							reg23439 := __e.Call(__defun__shen_4bindv, V2430, reg23438, V2923)
+							reg23439 := Call(__e, __defun__shen_4bindv, V2430, reg23438, V2923)
 							_ = reg23439
 							reg23440 := PrimTail(V2429)
 							NewHyp := reg23440
 							_ = NewHyp
-							reg23441 := __e.Call(__defun__shen_4incinfs)
+							reg23441 := Call(__e, __defun__shen_4incinfs)
 							_ = reg23441
-							reg23442 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-								__ctx.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
+							reg23442 := MakeNative(func(__e Evaluator, __args ...Obj) {
+								__e.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
 								return
 							}, 0)
-							reg23444 := __e.Call(__defun__unify_b, V, V2423, V2923, reg23442)
+							reg23444 := Call(__e, __defun__unify_b, V, V2423, V2923, reg23442)
 							Result := reg23444
 							_ = Result
-							reg23445 := __e.Call(__defun__shen_4unbindv, V2430, V2923)
+							reg23445 := Call(__e, __defun__shen_4unbindv, V2430, V2923)
 							_ = reg23445
-							__ctx.Return(Result)
+							__e.Return(Result)
 							return
 						} else {
 							reg23446 := False
-							__ctx.Return(reg23446)
+							__e.Return(reg23446)
 							return
 						}
 					}
 				} else {
-					reg23447 := __e.Call(__defun__shen_4pvar_2, V2429)
+					reg23447 := Call(__e, __defun__shen_4pvar_2, V2429)
 					if reg23447 == True {
-						reg23448 := __e.Call(__defun__shen_4newpv, V2923)
+						reg23448 := Call(__e, __defun__shen_4newpv, V2923)
 						V := reg23448
 						_ = V
-						reg23449 := __e.Call(__defun__shen_4newpv, V2923)
+						reg23449 := Call(__e, __defun__shen_4newpv, V2923)
 						A := reg23449
 						_ = A
-						reg23450 := __e.Call(__defun__shen_4newpv, V2923)
+						reg23450 := Call(__e, __defun__shen_4newpv, V2923)
 						NewHyp := reg23450
 						_ = NewHyp
 						reg23451 := MakeSymbol(":")
@@ -8650,40 +8650,40 @@ func init() {
 						reg23454 := PrimCons(reg23451, reg23453)
 						reg23455 := PrimCons(V, reg23454)
 						reg23456 := PrimCons(reg23455, NewHyp)
-						reg23457 := __e.Call(__defun__shen_4bindv, V2429, reg23456, V2923)
+						reg23457 := Call(__e, __defun__shen_4bindv, V2429, reg23456, V2923)
 						_ = reg23457
-						reg23458 := __e.Call(__defun__shen_4incinfs)
+						reg23458 := Call(__e, __defun__shen_4incinfs)
 						_ = reg23458
-						reg23459 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-							__ctx.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
+						reg23459 := MakeNative(func(__e Evaluator, __args ...Obj) {
+							__e.TailApply(__defun__shen_4newhyps, Vs, V2921, NewHyp, V2923, V2924)
 							return
 						}, 0)
-						reg23461 := __e.Call(__defun__unify_b, V, V2423, V2923, reg23459)
+						reg23461 := Call(__e, __defun__unify_b, V, V2423, V2923, reg23459)
 						Result := reg23461
 						_ = Result
-						reg23462 := __e.Call(__defun__shen_4unbindv, V2429, V2923)
+						reg23462 := Call(__e, __defun__shen_4unbindv, V2429, V2923)
 						_ = reg23462
-						__ctx.Return(Result)
+						__e.Return(Result)
 						return
 					} else {
 						reg23463 := False
-						__ctx.Return(reg23463)
+						__e.Return(reg23463)
 						return
 					}
 				}
 			} else {
 				reg23464 := False
-				__ctx.Return(reg23464)
+				__e.Return(reg23464)
 				return
 			}
 		} else {
-			__ctx.Return(Case)
+			__e.Return(Case)
 			return
 		}
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.newhyps", value: __defun__shen_4newhyps})
 
-	__defun__shen_4patthyps = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4patthyps = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2930 := __args[0]
 		_ = V2930
 		V2931 := __args[1]
@@ -8693,7 +8693,7 @@ func init() {
 		reg23465 := Nil
 		reg23466 := PrimEqual(reg23465, V2930)
 		if reg23466 == True {
-			__ctx.Return(V2932)
+			__e.Return(V2932)
 			return
 		} else {
 			reg23467 := PrimIsPair(V2930)
@@ -8799,19 +8799,19 @@ func init() {
 				reg23516 := PrimTail(V2931)
 				reg23517 := PrimTail(reg23516)
 				reg23518 := PrimHead(reg23517)
-				reg23519 := __e.Call(__defun__shen_4patthyps, reg23515, reg23518, V2932)
-				__ctx.TailApply(__defun__adjoin, reg23514, reg23519)
+				reg23519 := Call(__e, __defun__shen_4patthyps, reg23515, reg23518, V2932)
+				__e.TailApply(__defun__adjoin, reg23514, reg23519)
 				return
 			} else {
 				reg23521 := MakeSymbol("shen.patthyps")
-				__ctx.TailApply(__defun__shen_4f__error, reg23521)
+				__e.TailApply(__defun__shen_4f__error, reg23521)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.patthyps", value: __defun__shen_4patthyps})
 
-	__defun__shen_4result_1type = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4result_1type = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2939 := __args[0]
 		_ = V2939
 		V2940 := __args[1]
@@ -8891,13 +8891,13 @@ func init() {
 		if reg23554 == True {
 			reg23555 := PrimTail(V2940)
 			reg23556 := PrimHead(reg23555)
-			__ctx.Return(reg23556)
+			__e.Return(reg23556)
 			return
 		} else {
 			reg23557 := Nil
 			reg23558 := PrimEqual(reg23557, V2939)
 			if reg23558 == True {
-				__ctx.Return(V2940)
+				__e.Return(V2940)
 				return
 			} else {
 				reg23559 := PrimIsPair(V2939)
@@ -8996,11 +8996,11 @@ func init() {
 					reg23601 := PrimTail(V2940)
 					reg23602 := PrimTail(reg23601)
 					reg23603 := PrimHead(reg23602)
-					__ctx.TailApply(__defun__shen_4result_1type, reg23600, reg23603)
+					__e.TailApply(__defun__shen_4result_1type, reg23600, reg23603)
 					return
 				} else {
 					reg23605 := MakeSymbol("shen.result-type")
-					__ctx.TailApply(__defun__shen_4f__error, reg23605)
+					__e.TailApply(__defun__shen_4f__error, reg23605)
 					return
 				}
 			}
@@ -9008,7 +9008,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.result-type", value: __defun__shen_4result_1type})
 
-	__defun__shen_4t_d_1patterns = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4t_d_1patterns = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2946 := __args[0]
 		_ = V2946
 		V2947 := __args[1]
@@ -9019,16 +9019,16 @@ func init() {
 		_ = V2949
 		V2950 := __args[4]
 		_ = V2950
-		reg23607 := __e.Call(__defun__shen_4lazyderef, V2946, V2949)
+		reg23607 := Call(__e, __defun__shen_4lazyderef, V2946, V2949)
 		V2415 := reg23607
 		_ = V2415
 		reg23608 := Nil
 		reg23609 := PrimEqual(reg23608, V2415)
 		var reg23613 Obj
 		if reg23609 == True {
-			reg23610 := __e.Call(__defun__shen_4incinfs)
+			reg23610 := Call(__e, __defun__shen_4incinfs)
 			_ = reg23610
-			reg23611 := __e.Call(__defun__thaw, V2950)
+			reg23611 := Call(__e, __defun__thaw, V2950)
 			reg23613 = reg23611
 		} else {
 			reg23612 := False
@@ -9039,7 +9039,7 @@ func init() {
 		reg23614 := False
 		reg23615 := PrimEqual(Case, reg23614)
 		if reg23615 == True {
-			reg23616 := __e.Call(__defun__shen_4lazyderef, V2946, V2949)
+			reg23616 := Call(__e, __defun__shen_4lazyderef, V2946, V2949)
 			V2416 := reg23616
 			_ = V2416
 			reg23617 := PrimIsPair(V2416)
@@ -9050,7 +9050,7 @@ func init() {
 				reg23619 := PrimTail(V2416)
 				Patterns := reg23619
 				_ = Patterns
-				reg23620 := __e.Call(__defun__shen_4lazyderef, V2947, V2949)
+				reg23620 := Call(__e, __defun__shen_4lazyderef, V2947, V2949)
 				V2417 := reg23620
 				_ = V2417
 				reg23621 := PrimIsPair(V2417)
@@ -9059,20 +9059,20 @@ func init() {
 					A := reg23622
 					_ = A
 					reg23623 := PrimTail(V2417)
-					reg23624 := __e.Call(__defun__shen_4lazyderef, reg23623, V2949)
+					reg23624 := Call(__e, __defun__shen_4lazyderef, reg23623, V2949)
 					V2418 := reg23624
 					_ = V2418
 					reg23625 := PrimIsPair(V2418)
 					if reg23625 == True {
 						reg23626 := PrimHead(V2418)
-						reg23627 := __e.Call(__defun__shen_4lazyderef, reg23626, V2949)
+						reg23627 := Call(__e, __defun__shen_4lazyderef, reg23626, V2949)
 						V2419 := reg23627
 						_ = V2419
 						reg23628 := MakeSymbol("-->")
 						reg23629 := PrimEqual(reg23628, V2419)
 						if reg23629 == True {
 							reg23630 := PrimTail(V2418)
-							reg23631 := __e.Call(__defun__shen_4lazyderef, reg23630, V2949)
+							reg23631 := Call(__e, __defun__shen_4lazyderef, reg23630, V2949)
 							V2420 := reg23631
 							_ = V2420
 							reg23632 := PrimIsPair(V2420)
@@ -9081,63 +9081,63 @@ func init() {
 								B := reg23633
 								_ = B
 								reg23634 := PrimTail(V2420)
-								reg23635 := __e.Call(__defun__shen_4lazyderef, reg23634, V2949)
+								reg23635 := Call(__e, __defun__shen_4lazyderef, reg23634, V2949)
 								V2421 := reg23635
 								_ = V2421
 								reg23636 := Nil
 								reg23637 := PrimEqual(reg23636, V2421)
 								if reg23637 == True {
-									reg23638 := __e.Call(__defun__shen_4incinfs)
+									reg23638 := Call(__e, __defun__shen_4incinfs)
 									_ = reg23638
 									reg23639 := MakeSymbol(":")
 									reg23640 := Nil
 									reg23641 := PrimCons(A, reg23640)
 									reg23642 := PrimCons(reg23639, reg23641)
 									reg23643 := PrimCons(Pattern, reg23642)
-									reg23644 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-										__ctx.TailApply(__defun__shen_4t_d_1patterns, Patterns, B, V2948, V2949, V2950)
+									reg23644 := MakeNative(func(__e Evaluator, __args ...Obj) {
+										__e.TailApply(__defun__shen_4t_d_1patterns, Patterns, B, V2948, V2949, V2950)
 										return
 									}, 0)
-									__ctx.TailApply(__defun__shen_4t_d, reg23643, V2948, V2949, reg23644)
+									__e.TailApply(__defun__shen_4t_d, reg23643, V2948, V2949, reg23644)
 									return
 								} else {
 									reg23647 := False
-									__ctx.Return(reg23647)
+									__e.Return(reg23647)
 									return
 								}
 							} else {
 								reg23648 := False
-								__ctx.Return(reg23648)
+								__e.Return(reg23648)
 								return
 							}
 						} else {
 							reg23649 := False
-							__ctx.Return(reg23649)
+							__e.Return(reg23649)
 							return
 						}
 					} else {
 						reg23650 := False
-						__ctx.Return(reg23650)
+						__e.Return(reg23650)
 						return
 					}
 				} else {
 					reg23651 := False
-					__ctx.Return(reg23651)
+					__e.Return(reg23651)
 					return
 				}
 			} else {
 				reg23652 := False
-				__ctx.Return(reg23652)
+				__e.Return(reg23652)
 				return
 			}
 		} else {
-			__ctx.Return(Case)
+			__e.Return(Case)
 			return
 		}
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.t*-patterns", value: __defun__shen_4t_d_1patterns})
 
-	__defun__shen_4t_d_1action = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4t_d_1action = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2956 := __args[0]
 		_ = V2956
 		V2957 := __args[1]
@@ -9148,17 +9148,17 @@ func init() {
 		_ = V2959
 		V2960 := __args[4]
 		_ = V2960
-		reg23653 := __e.Call(__defun__shen_4catchpoint)
+		reg23653 := Call(__e, __defun__shen_4catchpoint)
 		Throwcontrol := reg23653
 		_ = Throwcontrol
-		reg23654 := __e.Call(__defun__shen_4lazyderef, V2956, V2959)
+		reg23654 := Call(__e, __defun__shen_4lazyderef, V2956, V2959)
 		V2392 := reg23654
 		_ = V2392
 		reg23655 := PrimIsPair(V2392)
 		var reg23702 Obj
 		if reg23655 == True {
 			reg23656 := PrimHead(V2392)
-			reg23657 := __e.Call(__defun__shen_4lazyderef, reg23656, V2959)
+			reg23657 := Call(__e, __defun__shen_4lazyderef, reg23656, V2959)
 			V2393 := reg23657
 			_ = V2393
 			reg23658 := MakeSymbol("where")
@@ -9166,7 +9166,7 @@ func init() {
 			var reg23700 Obj
 			if reg23659 == True {
 				reg23660 := PrimTail(V2392)
-				reg23661 := __e.Call(__defun__shen_4lazyderef, reg23660, V2959)
+				reg23661 := Call(__e, __defun__shen_4lazyderef, reg23660, V2959)
 				V2394 := reg23661
 				_ = V2394
 				reg23662 := PrimIsPair(V2394)
@@ -9176,7 +9176,7 @@ func init() {
 					P := reg23663
 					_ = P
 					reg23664 := PrimTail(V2394)
-					reg23665 := __e.Call(__defun__shen_4lazyderef, reg23664, V2959)
+					reg23665 := Call(__e, __defun__shen_4lazyderef, reg23664, V2959)
 					V2395 := reg23665
 					_ = V2395
 					reg23666 := PrimIsPair(V2395)
@@ -9186,24 +9186,24 @@ func init() {
 						Action := reg23667
 						_ = Action
 						reg23668 := PrimTail(V2395)
-						reg23669 := __e.Call(__defun__shen_4lazyderef, reg23668, V2959)
+						reg23669 := Call(__e, __defun__shen_4lazyderef, reg23668, V2959)
 						V2396 := reg23669
 						_ = V2396
 						reg23670 := Nil
 						reg23671 := PrimEqual(reg23670, V2396)
 						var reg23694 Obj
 						if reg23671 == True {
-							reg23672 := __e.Call(__defun__shen_4incinfs)
+							reg23672 := Call(__e, __defun__shen_4incinfs)
 							_ = reg23672
-							reg23673 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+							reg23673 := MakeNative(func(__e Evaluator, __args ...Obj) {
 								reg23674 := MakeSymbol(":")
 								reg23675 := MakeSymbol("boolean")
 								reg23676 := Nil
 								reg23677 := PrimCons(reg23675, reg23676)
 								reg23678 := PrimCons(reg23674, reg23677)
 								reg23679 := PrimCons(P, reg23678)
-								reg23680 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-									reg23681 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+								reg23680 := MakeNative(func(__e Evaluator, __args ...Obj) {
+									reg23681 := MakeNative(func(__e Evaluator, __args ...Obj) {
 										reg23682 := MakeSymbol(":")
 										reg23683 := MakeSymbol("verified")
 										reg23684 := Nil
@@ -9211,16 +9211,16 @@ func init() {
 										reg23686 := PrimCons(reg23682, reg23685)
 										reg23687 := PrimCons(P, reg23686)
 										reg23688 := PrimCons(reg23687, V2958)
-										__ctx.TailApply(__defun__shen_4t_d_1action, Action, V2957, reg23688, V2959, V2960)
+										__e.TailApply(__defun__shen_4t_d_1action, Action, V2957, reg23688, V2959, V2960)
 										return
 									}, 0)
-									__ctx.TailApply(__defun__cut, Throwcontrol, V2959, reg23681)
+									__e.TailApply(__defun__cut, Throwcontrol, V2959, reg23681)
 									return
 								}, 0)
-								__ctx.TailApply(__defun__shen_4t_d, reg23679, V2958, V2959, reg23680)
+								__e.TailApply(__defun__shen_4t_d, reg23679, V2958, V2959, reg23680)
 								return
 							}, 0)
-							reg23692 := __e.Call(__defun__cut, Throwcontrol, V2959, reg23673)
+							reg23692 := Call(__e, __defun__cut, Throwcontrol, V2959, reg23673)
 							reg23694 = reg23692
 						} else {
 							reg23693 := False
@@ -9252,14 +9252,14 @@ func init() {
 		reg23704 := PrimEqual(Case, reg23703)
 		var reg23840 Obj
 		if reg23704 == True {
-			reg23705 := __e.Call(__defun__shen_4lazyderef, V2956, V2959)
+			reg23705 := Call(__e, __defun__shen_4lazyderef, V2956, V2959)
 			V2397 := reg23705
 			_ = V2397
 			reg23706 := PrimIsPair(V2397)
 			var reg23781 Obj
 			if reg23706 == True {
 				reg23707 := PrimHead(V2397)
-				reg23708 := __e.Call(__defun__shen_4lazyderef, reg23707, V2959)
+				reg23708 := Call(__e, __defun__shen_4lazyderef, reg23707, V2959)
 				V2398 := reg23708
 				_ = V2398
 				reg23709 := MakeSymbol("shen.choicepoint!")
@@ -9267,28 +9267,28 @@ func init() {
 				var reg23779 Obj
 				if reg23710 == True {
 					reg23711 := PrimTail(V2397)
-					reg23712 := __e.Call(__defun__shen_4lazyderef, reg23711, V2959)
+					reg23712 := Call(__e, __defun__shen_4lazyderef, reg23711, V2959)
 					V2399 := reg23712
 					_ = V2399
 					reg23713 := PrimIsPair(V2399)
 					var reg23777 Obj
 					if reg23713 == True {
 						reg23714 := PrimHead(V2399)
-						reg23715 := __e.Call(__defun__shen_4lazyderef, reg23714, V2959)
+						reg23715 := Call(__e, __defun__shen_4lazyderef, reg23714, V2959)
 						V2400 := reg23715
 						_ = V2400
 						reg23716 := PrimIsPair(V2400)
 						var reg23775 Obj
 						if reg23716 == True {
 							reg23717 := PrimHead(V2400)
-							reg23718 := __e.Call(__defun__shen_4lazyderef, reg23717, V2959)
+							reg23718 := Call(__e, __defun__shen_4lazyderef, reg23717, V2959)
 							V2401 := reg23718
 							_ = V2401
 							reg23719 := PrimIsPair(V2401)
 							var reg23773 Obj
 							if reg23719 == True {
 								reg23720 := PrimHead(V2401)
-								reg23721 := __e.Call(__defun__shen_4lazyderef, reg23720, V2959)
+								reg23721 := Call(__e, __defun__shen_4lazyderef, reg23720, V2959)
 								V2402 := reg23721
 								_ = V2402
 								reg23722 := MakeSymbol("fail-if")
@@ -9296,7 +9296,7 @@ func init() {
 								var reg23771 Obj
 								if reg23723 == True {
 									reg23724 := PrimTail(V2401)
-									reg23725 := __e.Call(__defun__shen_4lazyderef, reg23724, V2959)
+									reg23725 := Call(__e, __defun__shen_4lazyderef, reg23724, V2959)
 									V2403 := reg23725
 									_ = V2403
 									reg23726 := PrimIsPair(V2403)
@@ -9306,7 +9306,7 @@ func init() {
 										F := reg23727
 										_ = F
 										reg23728 := PrimTail(V2403)
-										reg23729 := __e.Call(__defun__shen_4lazyderef, reg23728, V2959)
+										reg23729 := Call(__e, __defun__shen_4lazyderef, reg23728, V2959)
 										V2404 := reg23729
 										_ = V2404
 										reg23730 := Nil
@@ -9314,7 +9314,7 @@ func init() {
 										var reg23767 Obj
 										if reg23731 == True {
 											reg23732 := PrimTail(V2400)
-											reg23733 := __e.Call(__defun__shen_4lazyderef, reg23732, V2959)
+											reg23733 := Call(__e, __defun__shen_4lazyderef, reg23732, V2959)
 											V2405 := reg23733
 											_ = V2405
 											reg23734 := PrimIsPair(V2405)
@@ -9324,7 +9324,7 @@ func init() {
 												Action := reg23735
 												_ = Action
 												reg23736 := PrimTail(V2405)
-												reg23737 := __e.Call(__defun__shen_4lazyderef, reg23736, V2959)
+												reg23737 := Call(__e, __defun__shen_4lazyderef, reg23736, V2959)
 												V2406 := reg23737
 												_ = V2406
 												reg23738 := Nil
@@ -9332,16 +9332,16 @@ func init() {
 												var reg23763 Obj
 												if reg23739 == True {
 													reg23740 := PrimTail(V2399)
-													reg23741 := __e.Call(__defun__shen_4lazyderef, reg23740, V2959)
+													reg23741 := Call(__e, __defun__shen_4lazyderef, reg23740, V2959)
 													V2407 := reg23741
 													_ = V2407
 													reg23742 := Nil
 													reg23743 := PrimEqual(reg23742, V2407)
 													var reg23761 Obj
 													if reg23743 == True {
-														reg23744 := __e.Call(__defun__shen_4incinfs)
+														reg23744 := Call(__e, __defun__shen_4incinfs)
 														_ = reg23744
-														reg23745 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+														reg23745 := MakeNative(func(__e Evaluator, __args ...Obj) {
 															reg23746 := MakeSymbol("where")
 															reg23747 := MakeSymbol("not")
 															reg23748 := Nil
@@ -9354,10 +9354,10 @@ func init() {
 															reg23755 := PrimCons(Action, reg23754)
 															reg23756 := PrimCons(reg23753, reg23755)
 															reg23757 := PrimCons(reg23746, reg23756)
-															__ctx.TailApply(__defun__shen_4t_d_1action, reg23757, V2957, V2958, V2959, V2960)
+															__e.TailApply(__defun__shen_4t_d_1action, reg23757, V2957, V2958, V2959, V2960)
 															return
 														}, 0)
-														reg23759 := __e.Call(__defun__cut, Throwcontrol, V2959, reg23745)
+														reg23759 := Call(__e, __defun__cut, Throwcontrol, V2959, reg23745)
 														reg23761 = reg23759
 													} else {
 														reg23760 := False
@@ -9419,14 +9419,14 @@ func init() {
 			reg23783 := PrimEqual(Case, reg23782)
 			var reg23839 Obj
 			if reg23783 == True {
-				reg23784 := __e.Call(__defun__shen_4lazyderef, V2956, V2959)
+				reg23784 := Call(__e, __defun__shen_4lazyderef, V2956, V2959)
 				V2408 := reg23784
 				_ = V2408
 				reg23785 := PrimIsPair(V2408)
 				var reg23828 Obj
 				if reg23785 == True {
 					reg23786 := PrimHead(V2408)
-					reg23787 := __e.Call(__defun__shen_4lazyderef, reg23786, V2959)
+					reg23787 := Call(__e, __defun__shen_4lazyderef, reg23786, V2959)
 					V2409 := reg23787
 					_ = V2409
 					reg23788 := MakeSymbol("shen.choicepoint!")
@@ -9434,7 +9434,7 @@ func init() {
 					var reg23826 Obj
 					if reg23789 == True {
 						reg23790 := PrimTail(V2408)
-						reg23791 := __e.Call(__defun__shen_4lazyderef, reg23790, V2959)
+						reg23791 := Call(__e, __defun__shen_4lazyderef, reg23790, V2959)
 						V2410 := reg23791
 						_ = V2410
 						reg23792 := PrimIsPair(V2410)
@@ -9444,16 +9444,16 @@ func init() {
 							Action := reg23793
 							_ = Action
 							reg23794 := PrimTail(V2410)
-							reg23795 := __e.Call(__defun__shen_4lazyderef, reg23794, V2959)
+							reg23795 := Call(__e, __defun__shen_4lazyderef, reg23794, V2959)
 							V2411 := reg23795
 							_ = V2411
 							reg23796 := Nil
 							reg23797 := PrimEqual(reg23796, V2411)
 							var reg23822 Obj
 							if reg23797 == True {
-								reg23798 := __e.Call(__defun__shen_4incinfs)
+								reg23798 := Call(__e, __defun__shen_4incinfs)
 								_ = reg23798
-								reg23799 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+								reg23799 := MakeNative(func(__e Evaluator, __args ...Obj) {
 									reg23800 := MakeSymbol("where")
 									reg23801 := MakeSymbol("not")
 									reg23802 := MakeSymbol("=")
@@ -9473,10 +9473,10 @@ func init() {
 									reg23816 := PrimCons(Action, reg23815)
 									reg23817 := PrimCons(reg23814, reg23816)
 									reg23818 := PrimCons(reg23800, reg23817)
-									__ctx.TailApply(__defun__shen_4t_d_1action, reg23818, V2957, V2958, V2959, V2960)
+									__e.TailApply(__defun__shen_4t_d_1action, reg23818, V2957, V2958, V2959, V2960)
 									return
 								}, 0)
-								reg23820 := __e.Call(__defun__cut, Throwcontrol, V2959, reg23799)
+								reg23820 := Call(__e, __defun__cut, Throwcontrol, V2959, reg23799)
 								reg23822 = reg23820
 							} else {
 								reg23821 := False
@@ -9503,14 +9503,14 @@ func init() {
 				reg23830 := PrimEqual(Case, reg23829)
 				var reg23838 Obj
 				if reg23830 == True {
-					reg23831 := __e.Call(__defun__shen_4incinfs)
+					reg23831 := Call(__e, __defun__shen_4incinfs)
 					_ = reg23831
 					reg23832 := MakeSymbol(":")
 					reg23833 := Nil
 					reg23834 := PrimCons(V2957, reg23833)
 					reg23835 := PrimCons(reg23832, reg23834)
 					reg23836 := PrimCons(V2956, reg23835)
-					reg23837 := __e.Call(__defun__shen_4t_d, reg23836, V2958, V2959, V2960)
+					reg23837 := Call(__e, __defun__shen_4t_d, reg23836, V2958, V2959, V2960)
 					reg23838 = reg23837
 				} else {
 					reg23838 = Case
@@ -9523,12 +9523,12 @@ func init() {
 		} else {
 			reg23840 = Case
 		}
-		__ctx.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg23840)
+		__e.TailApply(__defun__shen_4cutpoint, Throwcontrol, reg23840)
 		return
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "shen.t*-action", value: __defun__shen_4t_d_1action})
 
-	__defun__findall = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__findall = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2966 := __args[0]
 		_ = V2966
 		V2967 := __args[1]
@@ -9539,33 +9539,33 @@ func init() {
 		_ = V2969
 		V2970 := __args[4]
 		_ = V2970
-		reg23842 := __e.Call(__defun__shen_4newpv, V2969)
+		reg23842 := Call(__e, __defun__shen_4newpv, V2969)
 		B := reg23842
 		_ = B
-		reg23843 := __e.Call(__defun__shen_4newpv, V2969)
+		reg23843 := Call(__e, __defun__shen_4newpv, V2969)
 		A := reg23843
 		_ = A
-		reg23844 := __e.Call(__defun__shen_4incinfs)
+		reg23844 := Call(__e, __defun__shen_4incinfs)
 		_ = reg23844
 		reg23845 := MakeSymbol("shen.a")
-		reg23846 := __e.Call(__defun__gensym, reg23845)
-		reg23847 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			reg23848 := __e.Call(__defun__shen_4lazyderef, A, V2969)
+		reg23846 := Call(__e, __defun__gensym, reg23845)
+		reg23847 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			reg23848 := Call(__e, __defun__shen_4lazyderef, A, V2969)
 			reg23849 := Nil
 			reg23850 := PrimSet(reg23848, reg23849)
-			reg23851 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-				__ctx.TailApply(__defun__shen_4findallhelp, V2966, V2967, V2968, A, V2969, V2970)
+			reg23851 := MakeNative(func(__e Evaluator, __args ...Obj) {
+				__e.TailApply(__defun__shen_4findallhelp, V2966, V2967, V2968, A, V2969, V2970)
 				return
 			}, 0)
-			__ctx.TailApply(__defun__bind, B, reg23850, V2969, reg23851)
+			__e.TailApply(__defun__bind, B, reg23850, V2969, reg23851)
 			return
 		}, 0)
-		__ctx.TailApply(__defun__bind, A, reg23846, V2969, reg23847)
+		__e.TailApply(__defun__bind, A, reg23846, V2969, reg23847)
 		return
 	}, 5)
 	__initDefs = append(__initDefs, defType{name: "findall", value: __defun__findall})
 
-	__defun__shen_4findallhelp = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4findallhelp = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2977 := __args[0]
 		_ = V2977
 		V2978 := __args[1]
@@ -9578,37 +9578,37 @@ func init() {
 		_ = V2981
 		V2982 := __args[5]
 		_ = V2982
-		reg23855 := __e.Call(__defun__shen_4incinfs)
+		reg23855 := Call(__e, __defun__shen_4incinfs)
 		_ = reg23855
-		reg23856 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			reg23857 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg23856 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			reg23857 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg23858 := False
-				__ctx.TailApply(__defun__fwhen, reg23858, V2981, V2982)
+				__e.TailApply(__defun__fwhen, reg23858, V2981, V2982)
 				return
 			}, 0)
-			__ctx.TailApply(__defun__shen_4remember, V2980, V2977, V2981, reg23857)
+			__e.TailApply(__defun__shen_4remember, V2980, V2977, V2981, reg23857)
 			return
 		}, 0)
-		reg23861 := __e.Call(__defun__call, V2978, V2981, reg23856)
+		reg23861 := Call(__e, __defun__call, V2978, V2981, reg23856)
 		Case := reg23861
 		_ = Case
 		reg23862 := False
 		reg23863 := PrimEqual(Case, reg23862)
 		if reg23863 == True {
-			reg23864 := __e.Call(__defun__shen_4incinfs)
+			reg23864 := Call(__e, __defun__shen_4incinfs)
 			_ = reg23864
-			reg23865 := __e.Call(__defun__shen_4lazyderef, V2980, V2981)
+			reg23865 := Call(__e, __defun__shen_4lazyderef, V2980, V2981)
 			reg23866 := PrimValue(reg23865)
-			__ctx.TailApply(__defun__bind, V2979, reg23866, V2981, V2982)
+			__e.TailApply(__defun__bind, V2979, reg23866, V2981, V2982)
 			return
 		} else {
-			__ctx.Return(Case)
+			__e.Return(Case)
 			return
 		}
 	}, 6)
 	__initDefs = append(__initDefs, defType{name: "shen.findallhelp", value: __defun__shen_4findallhelp})
 
-	__defun__shen_4remember = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4remember = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2987 := __args[0]
 		_ = V2987
 		V2988 := __args[1]
@@ -9617,18 +9617,18 @@ func init() {
 		_ = V2989
 		V2990 := __args[3]
 		_ = V2990
-		reg23868 := __e.Call(__defun__shen_4newpv, V2989)
+		reg23868 := Call(__e, __defun__shen_4newpv, V2989)
 		B := reg23868
 		_ = B
-		reg23869 := __e.Call(__defun__shen_4incinfs)
+		reg23869 := Call(__e, __defun__shen_4incinfs)
 		_ = reg23869
-		reg23870 := __e.Call(__defun__shen_4deref, V2987, V2989)
-		reg23871 := __e.Call(__defun__shen_4deref, V2988, V2989)
-		reg23872 := __e.Call(__defun__shen_4deref, V2987, V2989)
+		reg23870 := Call(__e, __defun__shen_4deref, V2987, V2989)
+		reg23871 := Call(__e, __defun__shen_4deref, V2988, V2989)
+		reg23872 := Call(__e, __defun__shen_4deref, V2987, V2989)
 		reg23873 := PrimValue(reg23872)
 		reg23874 := PrimCons(reg23871, reg23873)
 		reg23875 := PrimSet(reg23870, reg23874)
-		__ctx.TailApply(__defun__bind, B, reg23875, V2989, V2990)
+		__e.TailApply(__defun__bind, B, reg23875, V2989, V2990)
 		return
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.remember", value: __defun__shen_4remember})

--- a/cmd/shen/toplevel.go
+++ b/cmd/shen/toplevel.go
@@ -39,65 +39,65 @@ var __defun__shen_4extract_1pvars Obj                      // shen.extract-pvars
 var __defun__shen_4mult__subst Obj                         // shen.mult_subst
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg64 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg64)
+		__e.Return(reg64)
 		return
 	}, 0))
-	__defun__shen_4repl = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-		reg65 := __e.Call(__defun__shen_4credits)
+	__defun__shen_4repl = MakeNative(func(__e Evaluator, __args ...Obj) {
+		reg65 := Call(__e, __defun__shen_4credits)
 		_ = reg65
-		__ctx.TailApply(__defun__shen_4loop)
+		__e.TailApply(__defun__shen_4loop)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.repl", value: __defun__shen_4repl})
 
-	__defun__shen_4loop = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-		reg67 := __e.Call(__defun__shen_4initialise__environment)
+	__defun__shen_4loop = MakeNative(func(__e Evaluator, __args ...Obj) {
+		reg67 := Call(__e, __defun__shen_4initialise__environment)
 		_ = reg67
-		reg68 := __e.Call(__defun__shen_4prompt)
+		reg68 := Call(__e, __defun__shen_4prompt)
 		_ = reg68
-		reg69 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			__ctx.TailApply(__defun__shen_4read_1evaluate_1print)
+		reg69 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			__e.TailApply(__defun__shen_4read_1evaluate_1print)
 			return
 		}, 0)
-		reg71 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg71 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
-			__ctx.TailApply(__defun__shen_4toplevel_1display_1exception, E)
+			__e.TailApply(__defun__shen_4toplevel_1display_1exception, E)
 			return
 		}, 1)
-		reg73 := __e.Try(reg69).Catch(reg71)
+		reg73 := Try(__e, reg69).Catch(reg71)
 		_ = reg73
-		__ctx.TailApply(__defun__shen_4loop)
+		__e.TailApply(__defun__shen_4loop)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.loop", value: __defun__shen_4loop})
 
-	__defun__shen_4toplevel_1display_1exception = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4toplevel_1display_1exception = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2992 := __args[0]
 		_ = V2992
 		reg75 := PrimErrorToString(V2992)
-		reg76 := __e.Call(__defun__stoutput)
-		__ctx.TailApply(__defun__pr, reg75, reg76)
+		reg76 := Call(__e, __defun__stoutput)
+		__e.TailApply(__defun__pr, reg75, reg76)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.toplevel-display-exception", value: __defun__shen_4toplevel_1display_1exception})
 
-	__defun__shen_4credits = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4credits = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg78 := MakeString("\nShen, copyright (C) 2010-2015 Mark Tarver\n")
-		reg79 := __e.Call(__defun__stoutput)
-		reg80 := __e.Call(__defun__shen_4prhush, reg78, reg79)
+		reg79 := Call(__e, __defun__stoutput)
+		reg80 := Call(__e, __defun__shen_4prhush, reg78, reg79)
 		_ = reg80
 		reg81 := MakeString("www.shenlanguage.org, ")
 		reg82 := MakeSymbol("*version*")
 		reg83 := PrimValue(reg82)
 		reg84 := MakeString("\n")
 		reg85 := MakeSymbol("shen.a")
-		reg86 := __e.Call(__defun__shen_4app, reg83, reg84, reg85)
+		reg86 := Call(__e, __defun__shen_4app, reg83, reg84, reg85)
 		reg87 := PrimStringConcat(reg81, reg86)
-		reg88 := __e.Call(__defun__stoutput)
-		reg89 := __e.Call(__defun__shen_4prhush, reg87, reg88)
+		reg88 := Call(__e, __defun__stoutput)
+		reg89 := Call(__e, __defun__shen_4prhush, reg87, reg88)
 		_ = reg89
 		reg90 := MakeString("running under ")
 		reg91 := MakeSymbol("*language*")
@@ -107,13 +107,13 @@ func init() {
 		reg95 := PrimValue(reg94)
 		reg96 := MakeString("")
 		reg97 := MakeSymbol("shen.a")
-		reg98 := __e.Call(__defun__shen_4app, reg95, reg96, reg97)
+		reg98 := Call(__e, __defun__shen_4app, reg95, reg96, reg97)
 		reg99 := PrimStringConcat(reg93, reg98)
 		reg100 := MakeSymbol("shen.a")
-		reg101 := __e.Call(__defun__shen_4app, reg92, reg99, reg100)
+		reg101 := Call(__e, __defun__shen_4app, reg92, reg99, reg100)
 		reg102 := PrimStringConcat(reg90, reg101)
-		reg103 := __e.Call(__defun__stoutput)
-		reg104 := __e.Call(__defun__shen_4prhush, reg102, reg103)
+		reg103 := Call(__e, __defun__stoutput)
+		reg104 := Call(__e, __defun__shen_4prhush, reg102, reg103)
 		_ = reg104
 		reg105 := MakeString("\nport ")
 		reg106 := MakeSymbol("*port*")
@@ -123,18 +123,18 @@ func init() {
 		reg110 := PrimValue(reg109)
 		reg111 := MakeString("\n")
 		reg112 := MakeSymbol("shen.a")
-		reg113 := __e.Call(__defun__shen_4app, reg110, reg111, reg112)
+		reg113 := Call(__e, __defun__shen_4app, reg110, reg111, reg112)
 		reg114 := PrimStringConcat(reg108, reg113)
 		reg115 := MakeSymbol("shen.a")
-		reg116 := __e.Call(__defun__shen_4app, reg107, reg114, reg115)
+		reg116 := Call(__e, __defun__shen_4app, reg107, reg114, reg115)
 		reg117 := PrimStringConcat(reg105, reg116)
-		reg118 := __e.Call(__defun__stoutput)
-		__ctx.TailApply(__defun__shen_4prhush, reg117, reg118)
+		reg118 := Call(__e, __defun__stoutput)
+		__e.TailApply(__defun__shen_4prhush, reg117, reg118)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.credits", value: __defun__shen_4credits})
 
-	__defun__shen_4initialise__environment = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4initialise__environment = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg120 := MakeSymbol("shen.*call*")
 		reg121 := MakeNumber(0)
 		reg122 := MakeSymbol("shen.*infs*")
@@ -152,19 +152,19 @@ func init() {
 		reg134 := PrimCons(reg122, reg133)
 		reg135 := PrimCons(reg121, reg134)
 		reg136 := PrimCons(reg120, reg135)
-		__ctx.TailApply(__defun__shen_4multiple_1set, reg136)
+		__e.TailApply(__defun__shen_4multiple_1set, reg136)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.initialise_environment", value: __defun__shen_4initialise__environment})
 
-	__defun__shen_4multiple_1set = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4multiple_1set = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2994 := __args[0]
 		_ = V2994
 		reg138 := Nil
 		reg139 := PrimEqual(reg138, V2994)
 		if reg139 == True {
 			reg140 := Nil
-			__ctx.Return(reg140)
+			__e.Return(reg140)
 			return
 		} else {
 			reg141 := PrimIsPair(V2994)
@@ -193,68 +193,68 @@ func init() {
 				_ = reg152
 				reg153 := PrimTail(V2994)
 				reg154 := PrimTail(reg153)
-				__ctx.TailApply(__defun__shen_4multiple_1set, reg154)
+				__e.TailApply(__defun__shen_4multiple_1set, reg154)
 				return
 			} else {
 				reg156 := MakeSymbol("shen.multiple-set")
-				__ctx.TailApply(__defun__shen_4f__error, reg156)
+				__e.TailApply(__defun__shen_4f__error, reg156)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.multiple-set", value: __defun__shen_4multiple_1set})
 
-	__defun__destroy = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__destroy = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V2996 := __args[0]
 		_ = V2996
 		reg158 := MakeSymbol("symbol")
-		__ctx.TailApply(__defun__declare, V2996, reg158)
+		__e.TailApply(__defun__declare, V2996, reg158)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "destroy", value: __defun__destroy})
 
-	__defun__shen_4read_1evaluate_1print = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-		reg160 := __e.Call(__defun__shen_4toplineread)
+	__defun__shen_4read_1evaluate_1print = MakeNative(func(__e Evaluator, __args ...Obj) {
+		reg160 := Call(__e, __defun__shen_4toplineread)
 		Lineread := reg160
 		_ = Lineread
 		reg161 := MakeSymbol("shen.*history*")
 		reg162 := PrimValue(reg161)
 		History := reg162
 		_ = History
-		reg163 := __e.Call(__defun__shen_4retrieve_1from_1history_1if_1needed, Lineread, History)
+		reg163 := Call(__e, __defun__shen_4retrieve_1from_1history_1if_1needed, Lineread, History)
 		NewLineread := reg163
 		_ = NewLineread
-		reg164 := __e.Call(__defun__shen_4update__history, NewLineread, History)
+		reg164 := Call(__e, __defun__shen_4update__history, NewLineread, History)
 		NewHistory := reg164
 		_ = NewHistory
-		reg165 := __e.Call(__defun__fst, NewLineread)
+		reg165 := Call(__e, __defun__fst, NewLineread)
 		Parsed := reg165
 		_ = Parsed
-		__ctx.TailApply(__defun__shen_4toplevel, Parsed)
+		__e.TailApply(__defun__shen_4toplevel, Parsed)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.read-evaluate-print", value: __defun__shen_4read_1evaluate_1print})
 
-	__defun__shen_4retrieve_1from_1history_1if_1needed = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4retrieve_1from_1history_1if_1needed = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3008 := __args[0]
 		_ = V3008
 		V3009 := __args[1]
 		_ = V3009
-		reg167 := __e.Call(__defun__tuple_2, V3008)
+		reg167 := Call(__e, __defun__tuple_2, V3008)
 		var reg187 Obj
 		if reg167 == True {
-			reg168 := __e.Call(__defun__snd, V3008)
+			reg168 := Call(__e, __defun__snd, V3008)
 			reg169 := PrimIsPair(reg168)
 			var reg182 Obj
 			if reg169 == True {
-				reg170 := __e.Call(__defun__snd, V3008)
+				reg170 := Call(__e, __defun__snd, V3008)
 				reg171 := PrimHead(reg170)
-				reg172 := __e.Call(__defun__shen_4space)
-				reg173 := __e.Call(__defun__shen_4newline)
+				reg172 := Call(__e, __defun__shen_4space)
+				reg173 := Call(__e, __defun__shen_4newline)
 				reg174 := Nil
 				reg175 := PrimCons(reg173, reg174)
 				reg176 := PrimCons(reg172, reg175)
-				reg177 := __e.Call(__defun__element_2, reg171, reg176)
+				reg177 := Call(__e, __defun__element_2, reg171, reg176)
 				var reg180 Obj
 				if reg177 == True {
 					reg178 := True
@@ -282,27 +282,27 @@ func init() {
 			reg187 = reg186
 		}
 		if reg187 == True {
-			reg188 := __e.Call(__defun__fst, V3008)
-			reg189 := __e.Call(__defun__snd, V3008)
+			reg188 := Call(__e, __defun__fst, V3008)
+			reg189 := Call(__e, __defun__snd, V3008)
 			reg190 := PrimTail(reg189)
-			reg191 := __e.Call(__defun___8p, reg188, reg190)
-			__ctx.TailApply(__defun__shen_4retrieve_1from_1history_1if_1needed, reg191, V3009)
+			reg191 := Call(__e, __defun___8p, reg188, reg190)
+			__e.TailApply(__defun__shen_4retrieve_1from_1history_1if_1needed, reg191, V3009)
 			return
 		} else {
-			reg193 := __e.Call(__defun__tuple_2, V3008)
+			reg193 := Call(__e, __defun__tuple_2, V3008)
 			var reg243 Obj
 			if reg193 == True {
-				reg194 := __e.Call(__defun__snd, V3008)
+				reg194 := Call(__e, __defun__snd, V3008)
 				reg195 := PrimIsPair(reg194)
 				var reg238 Obj
 				if reg195 == True {
-					reg196 := __e.Call(__defun__snd, V3008)
+					reg196 := Call(__e, __defun__snd, V3008)
 					reg197 := PrimTail(reg196)
 					reg198 := PrimIsPair(reg197)
 					var reg233 Obj
 					if reg198 == True {
 						reg199 := Nil
-						reg200 := __e.Call(__defun__snd, V3008)
+						reg200 := Call(__e, __defun__snd, V3008)
 						reg201 := PrimTail(reg200)
 						reg202 := PrimTail(reg201)
 						reg203 := PrimEqual(reg199, reg202)
@@ -311,16 +311,16 @@ func init() {
 							reg204 := PrimIsPair(V3009)
 							var reg223 Obj
 							if reg204 == True {
-								reg205 := __e.Call(__defun__snd, V3008)
+								reg205 := Call(__e, __defun__snd, V3008)
 								reg206 := PrimHead(reg205)
-								reg207 := __e.Call(__defun__shen_4exclamation)
+								reg207 := Call(__e, __defun__shen_4exclamation)
 								reg208 := PrimEqual(reg206, reg207)
 								var reg218 Obj
 								if reg208 == True {
-									reg209 := __e.Call(__defun__snd, V3008)
+									reg209 := Call(__e, __defun__snd, V3008)
 									reg210 := PrimTail(reg209)
 									reg211 := PrimHead(reg210)
-									reg212 := __e.Call(__defun__shen_4exclamation)
+									reg212 := Call(__e, __defun__shen_4exclamation)
 									reg213 := PrimEqual(reg211, reg212)
 									var reg216 Obj
 									if reg213 == True {
@@ -402,24 +402,24 @@ func init() {
 			}
 			if reg243 == True {
 				reg244 := PrimHead(V3009)
-				reg245 := __e.Call(__defun__snd, reg244)
-				reg246 := __e.Call(__defun__shen_4prbytes, reg245)
+				reg245 := Call(__e, __defun__snd, reg244)
+				reg246 := Call(__e, __defun__shen_4prbytes, reg245)
 				PastPrint := reg246
 				_ = PastPrint
 				reg247 := PrimHead(V3009)
-				__ctx.Return(reg247)
+				__e.Return(reg247)
 				return
 			} else {
-				reg248 := __e.Call(__defun__tuple_2, V3008)
+				reg248 := Call(__e, __defun__tuple_2, V3008)
 				var reg264 Obj
 				if reg248 == True {
-					reg249 := __e.Call(__defun__snd, V3008)
+					reg249 := Call(__e, __defun__snd, V3008)
 					reg250 := PrimIsPair(reg249)
 					var reg259 Obj
 					if reg250 == True {
-						reg251 := __e.Call(__defun__snd, V3008)
+						reg251 := Call(__e, __defun__snd, V3008)
 						reg252 := PrimHead(reg251)
-						reg253 := __e.Call(__defun__shen_4exclamation)
+						reg253 := Call(__e, __defun__shen_4exclamation)
 						reg254 := PrimEqual(reg252, reg253)
 						var reg257 Obj
 						if reg254 == True {
@@ -448,38 +448,38 @@ func init() {
 					reg264 = reg263
 				}
 				if reg264 == True {
-					reg265 := __e.Call(__defun__snd, V3008)
+					reg265 := Call(__e, __defun__snd, V3008)
 					reg266 := PrimTail(reg265)
-					reg267 := __e.Call(__defun__shen_4make_1key, reg266, V3009)
+					reg267 := Call(__e, __defun__shen_4make_1key, reg266, V3009)
 					Key_2 := reg267
 					_ = Key_2
-					reg268 := __e.Call(__defun__shen_4find_1past_1inputs, Key_2, V3009)
-					reg269 := __e.Call(__defun__head, reg268)
+					reg268 := Call(__e, __defun__shen_4find_1past_1inputs, Key_2, V3009)
+					reg269 := Call(__e, __defun__head, reg268)
 					Find := reg269
 					_ = Find
-					reg270 := __e.Call(__defun__snd, Find)
-					reg271 := __e.Call(__defun__shen_4prbytes, reg270)
+					reg270 := Call(__e, __defun__snd, Find)
+					reg271 := Call(__e, __defun__shen_4prbytes, reg270)
 					PastPrint := reg271
 					_ = PastPrint
-					__ctx.Return(Find)
+					__e.Return(Find)
 					return
 				} else {
-					reg272 := __e.Call(__defun__tuple_2, V3008)
+					reg272 := Call(__e, __defun__tuple_2, V3008)
 					var reg297 Obj
 					if reg272 == True {
-						reg273 := __e.Call(__defun__snd, V3008)
+						reg273 := Call(__e, __defun__snd, V3008)
 						reg274 := PrimIsPair(reg273)
 						var reg292 Obj
 						if reg274 == True {
 							reg275 := Nil
-							reg276 := __e.Call(__defun__snd, V3008)
+							reg276 := Call(__e, __defun__snd, V3008)
 							reg277 := PrimTail(reg276)
 							reg278 := PrimEqual(reg275, reg277)
 							var reg287 Obj
 							if reg278 == True {
-								reg279 := __e.Call(__defun__snd, V3008)
+								reg279 := Call(__e, __defun__snd, V3008)
 								reg280 := PrimHead(reg279)
-								reg281 := __e.Call(__defun__shen_4percent)
+								reg281 := Call(__e, __defun__shen_4percent)
 								reg282 := PrimEqual(reg280, reg281)
 								var reg285 Obj
 								if reg282 == True {
@@ -521,30 +521,30 @@ func init() {
 						reg297 = reg296
 					}
 					if reg297 == True {
-						reg298 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+						reg298 := MakeNative(func(__e Evaluator, __args ...Obj) {
 							X := __args[0]
 							_ = X
 							reg299 := True
-							__ctx.Return(reg299)
+							__e.Return(reg299)
 							return
 						}, 1)
-						reg300 := __e.Call(__defun__reverse, V3009)
+						reg300 := Call(__e, __defun__reverse, V3009)
 						reg301 := MakeNumber(0)
-						reg302 := __e.Call(__defun__shen_4print_1past_1inputs, reg298, reg300, reg301)
+						reg302 := Call(__e, __defun__shen_4print_1past_1inputs, reg298, reg300, reg301)
 						_ = reg302
-						__ctx.TailApply(__defun__abort)
+						__e.TailApply(__defun__abort)
 						return
 					} else {
-						reg304 := __e.Call(__defun__tuple_2, V3008)
+						reg304 := Call(__e, __defun__tuple_2, V3008)
 						var reg320 Obj
 						if reg304 == True {
-							reg305 := __e.Call(__defun__snd, V3008)
+							reg305 := Call(__e, __defun__snd, V3008)
 							reg306 := PrimIsPair(reg305)
 							var reg315 Obj
 							if reg306 == True {
-								reg307 := __e.Call(__defun__snd, V3008)
+								reg307 := Call(__e, __defun__snd, V3008)
 								reg308 := PrimHead(reg307)
-								reg309 := __e.Call(__defun__shen_4percent)
+								reg309 := Call(__e, __defun__shen_4percent)
 								reg310 := PrimEqual(reg308, reg309)
 								var reg313 Obj
 								if reg310 == True {
@@ -573,20 +573,20 @@ func init() {
 							reg320 = reg319
 						}
 						if reg320 == True {
-							reg321 := __e.Call(__defun__snd, V3008)
+							reg321 := Call(__e, __defun__snd, V3008)
 							reg322 := PrimTail(reg321)
-							reg323 := __e.Call(__defun__shen_4make_1key, reg322, V3009)
+							reg323 := Call(__e, __defun__shen_4make_1key, reg322, V3009)
 							Key_2 := reg323
 							_ = Key_2
-							reg324 := __e.Call(__defun__reverse, V3009)
+							reg324 := Call(__e, __defun__reverse, V3009)
 							reg325 := MakeNumber(0)
-							reg326 := __e.Call(__defun__shen_4print_1past_1inputs, Key_2, reg324, reg325)
+							reg326 := Call(__e, __defun__shen_4print_1past_1inputs, Key_2, reg324, reg325)
 							Pastprint := reg326
 							_ = Pastprint
-							__ctx.TailApply(__defun__abort)
+							__e.TailApply(__defun__abort)
 							return
 						} else {
-							__ctx.Return(V3008)
+							__e.Return(V3008)
 							return
 						}
 					}
@@ -596,40 +596,40 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.retrieve-from-history-if-needed", value: __defun__shen_4retrieve_1from_1history_1if_1needed})
 
-	__defun__shen_4percent = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4percent = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg328 := MakeNumber(37)
-		__ctx.Return(reg328)
+		__e.Return(reg328)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.percent", value: __defun__shen_4percent})
 
-	__defun__shen_4exclamation = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4exclamation = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg329 := MakeNumber(33)
-		__ctx.Return(reg329)
+		__e.Return(reg329)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.exclamation", value: __defun__shen_4exclamation})
 
-	__defun__shen_4prbytes = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prbytes = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3011 := __args[0]
 		_ = V3011
-		reg330 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg330 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			Byte := __args[0]
 			_ = Byte
 			reg331 := PrimNumberToString(Byte)
-			reg332 := __e.Call(__defun__stoutput)
-			__ctx.TailApply(__defun__pr, reg331, reg332)
+			reg332 := Call(__e, __defun__stoutput)
+			__e.TailApply(__defun__pr, reg331, reg332)
 			return
 		}, 1)
-		reg334 := __e.Call(__defun__shen_4for_1each, reg330, V3011)
+		reg334 := Call(__e, __defun__shen_4for_1each, reg330, V3011)
 		_ = reg334
 		reg335 := MakeNumber(1)
-		__ctx.TailApply(__defun__nl, reg335)
+		__e.TailApply(__defun__nl, reg335)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.prbytes", value: __defun__shen_4prbytes})
 
-	__defun__shen_4update__history = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4update__history = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3014 := __args[0]
 		_ = V3014
 		V3015 := __args[1]
@@ -637,57 +637,57 @@ func init() {
 		reg337 := MakeSymbol("shen.*history*")
 		reg338 := PrimCons(V3014, V3015)
 		reg339 := PrimSet(reg337, reg338)
-		__ctx.Return(reg339)
+		__e.Return(reg339)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.update_history", value: __defun__shen_4update__history})
 
-	__defun__shen_4toplineread = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-		reg340 := __e.Call(__defun__stinput)
-		reg341 := __e.Call(__defun__shen_4read_1char_1code, reg340)
+	__defun__shen_4toplineread = MakeNative(func(__e Evaluator, __args ...Obj) {
+		reg340 := Call(__e, __defun__stinput)
+		reg341 := Call(__e, __defun__shen_4read_1char_1code, reg340)
 		reg342 := Nil
-		__ctx.TailApply(__defun__shen_4toplineread__loop, reg341, reg342)
+		__e.TailApply(__defun__shen_4toplineread__loop, reg341, reg342)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.toplineread", value: __defun__shen_4toplineread})
 
-	__defun__shen_4toplineread__loop = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4toplineread__loop = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3019 := __args[0]
 		_ = V3019
 		V3020 := __args[1]
 		_ = V3020
-		reg344 := __e.Call(__defun__shen_4hat)
+		reg344 := Call(__e, __defun__shen_4hat)
 		reg345 := PrimEqual(V3019, reg344)
 		if reg345 == True {
 			reg346 := MakeString("line read aborted")
 			reg347 := PrimSimpleError(reg346)
-			__ctx.Return(reg347)
+			__e.Return(reg347)
 			return
 		} else {
-			reg348 := __e.Call(__defun__shen_4newline)
-			reg349 := __e.Call(__defun__shen_4carriage_1return)
+			reg348 := Call(__e, __defun__shen_4newline)
+			reg349 := Call(__e, __defun__shen_4carriage_1return)
 			reg350 := Nil
 			reg351 := PrimCons(reg349, reg350)
 			reg352 := PrimCons(reg348, reg351)
-			reg353 := __e.Call(__defun__element_2, V3019, reg352)
+			reg353 := Call(__e, __defun__element_2, V3019, reg352)
 			if reg353 == True {
-				reg354 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg354 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					X := __args[0]
 					_ = X
-					__ctx.TailApply(__defun__shen_4_5st__input_6, X)
+					__e.TailApply(__defun__shen_4_5st__input_6, X)
 					return
 				}, 1)
-				reg356 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg356 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					E := __args[0]
 					_ = E
 					reg357 := MakeSymbol("shen.nextline")
-					__ctx.Return(reg357)
+					__e.Return(reg357)
 					return
 				}, 1)
-				reg358 := __e.Call(__defun__compile, reg354, V3020, reg356)
+				reg358 := Call(__e, __defun__compile, reg354, V3020, reg356)
 				Line := reg358
 				_ = Line
-				reg359 := __e.Call(__defun__shen_4record_1it, V3020)
+				reg359 := Call(__e, __defun__shen_4record_1it, V3020)
 				It := reg359
 				_ = It
 				reg360 := MakeSymbol("shen.nextline")
@@ -697,7 +697,7 @@ func init() {
 					reg362 := True
 					reg367 = reg362
 				} else {
-					reg363 := __e.Call(__defun__empty_2, Line)
+					reg363 := Call(__e, __defun__empty_2, Line)
 					var reg366 Obj
 					if reg363 == True {
 						reg364 := True
@@ -709,20 +709,20 @@ func init() {
 					reg367 = reg366
 				}
 				if reg367 == True {
-					reg368 := __e.Call(__defun__stinput)
-					reg369 := __e.Call(__defun__shen_4read_1char_1code, reg368)
+					reg368 := Call(__e, __defun__stinput)
+					reg369 := Call(__e, __defun__shen_4read_1char_1code, reg368)
 					reg370 := Nil
 					reg371 := PrimCons(V3019, reg370)
-					reg372 := __e.Call(__defun__append, V3020, reg371)
-					__ctx.TailApply(__defun__shen_4toplineread__loop, reg369, reg372)
+					reg372 := Call(__e, __defun__append, V3020, reg371)
+					__e.TailApply(__defun__shen_4toplineread__loop, reg369, reg372)
 					return
 				} else {
-					__ctx.TailApply(__defun___8p, Line, V3020)
+					__e.TailApply(__defun___8p, Line, V3020)
 					return
 				}
 			} else {
-				reg375 := __e.Call(__defun__stinput)
-				reg376 := __e.Call(__defun__shen_4read_1char_1code, reg375)
+				reg375 := Call(__e, __defun__stinput)
+				reg376 := Call(__e, __defun__shen_4read_1char_1code, reg375)
 				reg377 := MakeNumber(-1)
 				reg378 := PrimEqual(V3019, reg377)
 				var reg382 Obj
@@ -731,38 +731,38 @@ func init() {
 				} else {
 					reg379 := Nil
 					reg380 := PrimCons(V3019, reg379)
-					reg381 := __e.Call(__defun__append, V3020, reg380)
+					reg381 := Call(__e, __defun__append, V3020, reg380)
 					reg382 = reg381
 				}
-				__ctx.TailApply(__defun__shen_4toplineread__loop, reg376, reg382)
+				__e.TailApply(__defun__shen_4toplineread__loop, reg376, reg382)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.toplineread_loop", value: __defun__shen_4toplineread__loop})
 
-	__defun__shen_4hat = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4hat = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg384 := MakeNumber(94)
-		__ctx.Return(reg384)
+		__e.Return(reg384)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.hat", value: __defun__shen_4hat})
 
-	__defun__shen_4newline = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4newline = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg385 := MakeNumber(10)
-		__ctx.Return(reg385)
+		__e.Return(reg385)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.newline", value: __defun__shen_4newline})
 
-	__defun__shen_4carriage_1return = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4carriage_1return = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg386 := MakeNumber(13)
-		__ctx.Return(reg386)
+		__e.Return(reg386)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.carriage-return", value: __defun__shen_4carriage_1return})
 
-	__defun__tc = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__tc = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3026 := __args[0]
 		_ = V3026
 		reg387 := MakeSymbol("+")
@@ -771,7 +771,7 @@ func init() {
 			reg389 := MakeSymbol("shen.*tc*")
 			reg390 := True
 			reg391 := PrimSet(reg389, reg390)
-			__ctx.Return(reg391)
+			__e.Return(reg391)
 			return
 		} else {
 			reg392 := MakeSymbol("-")
@@ -780,92 +780,92 @@ func init() {
 				reg394 := MakeSymbol("shen.*tc*")
 				reg395 := False
 				reg396 := PrimSet(reg394, reg395)
-				__ctx.Return(reg396)
+				__e.Return(reg396)
 				return
 			} else {
 				reg397 := MakeString("tc expects a + or -")
 				reg398 := PrimSimpleError(reg397)
-				__ctx.Return(reg398)
+				__e.Return(reg398)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "tc", value: __defun__tc})
 
-	__defun__shen_4prompt = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prompt = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg399 := MakeSymbol("shen.*tc*")
 		reg400 := PrimValue(reg399)
 		if reg400 == True {
 			reg401 := MakeString("\n\n(")
 			reg402 := MakeSymbol("shen.*history*")
 			reg403 := PrimValue(reg402)
-			reg404 := __e.Call(__defun__length, reg403)
+			reg404 := Call(__e, __defun__length, reg403)
 			reg405 := MakeString("+) ")
 			reg406 := MakeSymbol("shen.a")
-			reg407 := __e.Call(__defun__shen_4app, reg404, reg405, reg406)
+			reg407 := Call(__e, __defun__shen_4app, reg404, reg405, reg406)
 			reg408 := PrimStringConcat(reg401, reg407)
-			reg409 := __e.Call(__defun__stoutput)
-			__ctx.TailApply(__defun__shen_4prhush, reg408, reg409)
+			reg409 := Call(__e, __defun__stoutput)
+			__e.TailApply(__defun__shen_4prhush, reg408, reg409)
 			return
 		} else {
 			reg411 := MakeString("\n\n(")
 			reg412 := MakeSymbol("shen.*history*")
 			reg413 := PrimValue(reg412)
-			reg414 := __e.Call(__defun__length, reg413)
+			reg414 := Call(__e, __defun__length, reg413)
 			reg415 := MakeString("-) ")
 			reg416 := MakeSymbol("shen.a")
-			reg417 := __e.Call(__defun__shen_4app, reg414, reg415, reg416)
+			reg417 := Call(__e, __defun__shen_4app, reg414, reg415, reg416)
 			reg418 := PrimStringConcat(reg411, reg417)
-			reg419 := __e.Call(__defun__stoutput)
-			__ctx.TailApply(__defun__shen_4prhush, reg418, reg419)
+			reg419 := Call(__e, __defun__stoutput)
+			__e.TailApply(__defun__shen_4prhush, reg418, reg419)
 			return
 		}
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.prompt", value: __defun__shen_4prompt})
 
-	__defun__shen_4toplevel = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4toplevel = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3028 := __args[0]
 		_ = V3028
 		reg421 := MakeSymbol("shen.*tc*")
 		reg422 := PrimValue(reg421)
-		__ctx.TailApply(__defun__shen_4toplevel__evaluate, V3028, reg422)
+		__e.TailApply(__defun__shen_4toplevel__evaluate, V3028, reg422)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.toplevel", value: __defun__shen_4toplevel})
 
-	__defun__shen_4find_1past_1inputs = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4find_1past_1inputs = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3031 := __args[0]
 		_ = V3031
 		V3032 := __args[1]
 		_ = V3032
-		reg424 := __e.Call(__defun__shen_4find, V3031, V3032)
+		reg424 := Call(__e, __defun__shen_4find, V3031, V3032)
 		F := reg424
 		_ = F
-		reg425 := __e.Call(__defun__empty_2, F)
+		reg425 := Call(__e, __defun__empty_2, F)
 		if reg425 == True {
 			reg426 := MakeString("input not found\n")
 			reg427 := PrimSimpleError(reg426)
-			__ctx.Return(reg427)
+			__e.Return(reg427)
 			return
 		} else {
-			__ctx.Return(F)
+			__e.Return(F)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.find-past-inputs", value: __defun__shen_4find_1past_1inputs})
 
-	__defun__shen_4make_1key = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4make_1key = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3035 := __args[0]
 		_ = V3035
 		V3036 := __args[1]
 		_ = V3036
-		reg428 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg428 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4_5st__input_6, X)
+			__e.TailApply(__defun__shen_4_5st__input_6, X)
 			return
 		}, 1)
-		reg430 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg430 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg431 := PrimIsPair(E)
@@ -873,60 +873,60 @@ func init() {
 				reg432 := MakeString("parse error here: ")
 				reg433 := MakeString("\n")
 				reg434 := MakeSymbol("shen.s")
-				reg435 := __e.Call(__defun__shen_4app, E, reg433, reg434)
+				reg435 := Call(__e, __defun__shen_4app, E, reg433, reg434)
 				reg436 := PrimStringConcat(reg432, reg435)
 				reg437 := PrimSimpleError(reg436)
-				__ctx.Return(reg437)
+				__e.Return(reg437)
 				return
 			} else {
 				reg438 := MakeString("parse error\n")
 				reg439 := PrimSimpleError(reg438)
-				__ctx.Return(reg439)
+				__e.Return(reg439)
 				return
 			}
 		}, 1)
-		reg440 := __e.Call(__defun__compile, reg428, V3035, reg430)
+		reg440 := Call(__e, __defun__compile, reg428, V3035, reg430)
 		reg441 := PrimHead(reg440)
 		Atom := reg441
 		_ = Atom
 		reg442 := PrimIsInteger(Atom)
 		if reg442 == True {
-			reg443 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg443 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
 				reg444 := MakeNumber(1)
 				reg445 := PrimNumberAdd(Atom, reg444)
-				reg446 := __e.Call(__defun__reverse, V3036)
-				reg447 := __e.Call(__defun__nth, reg445, reg446)
+				reg446 := Call(__e, __defun__reverse, V3036)
+				reg447 := Call(__e, __defun__nth, reg445, reg446)
 				reg448 := PrimEqual(X, reg447)
-				__ctx.Return(reg448)
+				__e.Return(reg448)
 				return
 			}, 1)
-			__ctx.Return(reg443)
+			__e.Return(reg443)
 			return
 		} else {
-			reg449 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg449 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
-				reg450 := __e.Call(__defun__snd, X)
-				reg451 := __e.Call(__defun__shen_4trim_1gubbins, reg450)
-				__ctx.TailApply(__defun__shen_4prefix_2, V3035, reg451)
+				reg450 := Call(__e, __defun__snd, X)
+				reg451 := Call(__e, __defun__shen_4trim_1gubbins, reg450)
+				__e.TailApply(__defun__shen_4prefix_2, V3035, reg451)
 				return
 			}, 1)
-			__ctx.Return(reg449)
+			__e.Return(reg449)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.make-key", value: __defun__shen_4make_1key})
 
-	__defun__shen_4trim_1gubbins = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4trim_1gubbins = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3038 := __args[0]
 		_ = V3038
 		reg453 := PrimIsPair(V3038)
 		var reg461 Obj
 		if reg453 == True {
 			reg454 := PrimHead(V3038)
-			reg455 := __e.Call(__defun__shen_4space)
+			reg455 := Call(__e, __defun__shen_4space)
 			reg456 := PrimEqual(reg454, reg455)
 			var reg459 Obj
 			if reg456 == True {
@@ -943,14 +943,14 @@ func init() {
 		}
 		if reg461 == True {
 			reg462 := PrimTail(V3038)
-			__ctx.TailApply(__defun__shen_4trim_1gubbins, reg462)
+			__e.TailApply(__defun__shen_4trim_1gubbins, reg462)
 			return
 		} else {
 			reg464 := PrimIsPair(V3038)
 			var reg472 Obj
 			if reg464 == True {
 				reg465 := PrimHead(V3038)
-				reg466 := __e.Call(__defun__shen_4newline)
+				reg466 := Call(__e, __defun__shen_4newline)
 				reg467 := PrimEqual(reg465, reg466)
 				var reg470 Obj
 				if reg467 == True {
@@ -967,14 +967,14 @@ func init() {
 			}
 			if reg472 == True {
 				reg473 := PrimTail(V3038)
-				__ctx.TailApply(__defun__shen_4trim_1gubbins, reg473)
+				__e.TailApply(__defun__shen_4trim_1gubbins, reg473)
 				return
 			} else {
 				reg475 := PrimIsPair(V3038)
 				var reg483 Obj
 				if reg475 == True {
 					reg476 := PrimHead(V3038)
-					reg477 := __e.Call(__defun__shen_4carriage_1return)
+					reg477 := Call(__e, __defun__shen_4carriage_1return)
 					reg478 := PrimEqual(reg476, reg477)
 					var reg481 Obj
 					if reg478 == True {
@@ -991,14 +991,14 @@ func init() {
 				}
 				if reg483 == True {
 					reg484 := PrimTail(V3038)
-					__ctx.TailApply(__defun__shen_4trim_1gubbins, reg484)
+					__e.TailApply(__defun__shen_4trim_1gubbins, reg484)
 					return
 				} else {
 					reg486 := PrimIsPair(V3038)
 					var reg494 Obj
 					if reg486 == True {
 						reg487 := PrimHead(V3038)
-						reg488 := __e.Call(__defun__shen_4tab)
+						reg488 := Call(__e, __defun__shen_4tab)
 						reg489 := PrimEqual(reg487, reg488)
 						var reg492 Obj
 						if reg489 == True {
@@ -1015,14 +1015,14 @@ func init() {
 					}
 					if reg494 == True {
 						reg495 := PrimTail(V3038)
-						__ctx.TailApply(__defun__shen_4trim_1gubbins, reg495)
+						__e.TailApply(__defun__shen_4trim_1gubbins, reg495)
 						return
 					} else {
 						reg497 := PrimIsPair(V3038)
 						var reg505 Obj
 						if reg497 == True {
 							reg498 := PrimHead(V3038)
-							reg499 := __e.Call(__defun__shen_4left_1round)
+							reg499 := Call(__e, __defun__shen_4left_1round)
 							reg500 := PrimEqual(reg498, reg499)
 							var reg503 Obj
 							if reg500 == True {
@@ -1039,10 +1039,10 @@ func init() {
 						}
 						if reg505 == True {
 							reg506 := PrimTail(V3038)
-							__ctx.TailApply(__defun__shen_4trim_1gubbins, reg506)
+							__e.TailApply(__defun__shen_4trim_1gubbins, reg506)
 							return
 						} else {
-							__ctx.Return(V3038)
+							__e.Return(V3038)
 							return
 						}
 					}
@@ -1052,28 +1052,28 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.trim-gubbins", value: __defun__shen_4trim_1gubbins})
 
-	__defun__shen_4space = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4space = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg508 := MakeNumber(32)
-		__ctx.Return(reg508)
+		__e.Return(reg508)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.space", value: __defun__shen_4space})
 
-	__defun__shen_4tab = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4tab = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg509 := MakeNumber(9)
-		__ctx.Return(reg509)
+		__e.Return(reg509)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.tab", value: __defun__shen_4tab})
 
-	__defun__shen_4left_1round = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4left_1round = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg510 := MakeNumber(40)
-		__ctx.Return(reg510)
+		__e.Return(reg510)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.left-round", value: __defun__shen_4left_1round})
 
-	__defun__shen_4find = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4find = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3047 := __args[0]
 		_ = V3047
 		V3048 := __args[1]
@@ -1082,14 +1082,14 @@ func init() {
 		reg512 := PrimEqual(reg511, V3048)
 		if reg512 == True {
 			reg513 := Nil
-			__ctx.Return(reg513)
+			__e.Return(reg513)
 			return
 		} else {
 			reg514 := PrimIsPair(V3048)
 			var reg521 Obj
 			if reg514 == True {
 				reg515 := PrimHead(V3048)
-				reg516 := __e.Call(V3047, reg515)
+				reg516 := Call(__e, V3047, reg515)
 				var reg519 Obj
 				if reg516 == True {
 					reg517 := True
@@ -1106,19 +1106,19 @@ func init() {
 			if reg521 == True {
 				reg522 := PrimHead(V3048)
 				reg523 := PrimTail(V3048)
-				reg524 := __e.Call(__defun__shen_4find, V3047, reg523)
+				reg524 := Call(__e, __defun__shen_4find, V3047, reg523)
 				reg525 := PrimCons(reg522, reg524)
-				__ctx.Return(reg525)
+				__e.Return(reg525)
 				return
 			} else {
 				reg526 := PrimIsPair(V3048)
 				if reg526 == True {
 					reg527 := PrimTail(V3048)
-					__ctx.TailApply(__defun__shen_4find, V3047, reg527)
+					__e.TailApply(__defun__shen_4find, V3047, reg527)
 					return
 				} else {
 					reg529 := MakeSymbol("shen.find")
-					__ctx.TailApply(__defun__shen_4f__error, reg529)
+					__e.TailApply(__defun__shen_4f__error, reg529)
 					return
 				}
 			}
@@ -1126,7 +1126,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.find", value: __defun__shen_4find})
 
-	__defun__shen_4prefix_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prefix_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3062 := __args[0]
 		_ = V3062
 		V3063 := __args[1]
@@ -1135,7 +1135,7 @@ func init() {
 		reg532 := PrimEqual(reg531, V3062)
 		if reg532 == True {
 			reg533 := True
-			__ctx.Return(reg533)
+			__e.Return(reg533)
 			return
 		} else {
 			reg534 := PrimIsPair(V3062)
@@ -1176,18 +1176,18 @@ func init() {
 			if reg548 == True {
 				reg549 := PrimTail(V3062)
 				reg550 := PrimTail(V3063)
-				__ctx.TailApply(__defun__shen_4prefix_2, reg549, reg550)
+				__e.TailApply(__defun__shen_4prefix_2, reg549, reg550)
 				return
 			} else {
 				reg552 := False
-				__ctx.Return(reg552)
+				__e.Return(reg552)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.prefix?", value: __defun__shen_4prefix_2})
 
-	__defun__shen_4print_1past_1inputs = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4print_1past_1inputs = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3075 := __args[0]
 		_ = V3075
 		V3076 := __args[1]
@@ -1198,14 +1198,14 @@ func init() {
 		reg554 := PrimEqual(reg553, V3076)
 		if reg554 == True {
 			reg555 := MakeSymbol("_")
-			__ctx.Return(reg555)
+			__e.Return(reg555)
 			return
 		} else {
 			reg556 := PrimIsPair(V3076)
 			var reg564 Obj
 			if reg556 == True {
 				reg557 := PrimHead(V3076)
-				reg558 := __e.Call(V3075, reg557)
+				reg558 := Call(__e, V3075, reg557)
 				reg559 := PrimNot(reg558)
 				var reg562 Obj
 				if reg559 == True {
@@ -1224,14 +1224,14 @@ func init() {
 				reg565 := PrimTail(V3076)
 				reg566 := MakeNumber(1)
 				reg567 := PrimNumberAdd(V3077, reg566)
-				__ctx.TailApply(__defun__shen_4print_1past_1inputs, V3075, reg565, reg567)
+				__e.TailApply(__defun__shen_4print_1past_1inputs, V3075, reg565, reg567)
 				return
 			} else {
 				reg569 := PrimIsPair(V3076)
 				var reg576 Obj
 				if reg569 == True {
 					reg570 := PrimHead(V3076)
-					reg571 := __e.Call(__defun__tuple_2, reg570)
+					reg571 := Call(__e, __defun__tuple_2, reg570)
 					var reg574 Obj
 					if reg571 == True {
 						reg572 := True
@@ -1248,22 +1248,22 @@ func init() {
 				if reg576 == True {
 					reg577 := MakeString(". ")
 					reg578 := MakeSymbol("shen.a")
-					reg579 := __e.Call(__defun__shen_4app, V3077, reg577, reg578)
-					reg580 := __e.Call(__defun__stoutput)
-					reg581 := __e.Call(__defun__shen_4prhush, reg579, reg580)
+					reg579 := Call(__e, __defun__shen_4app, V3077, reg577, reg578)
+					reg580 := Call(__e, __defun__stoutput)
+					reg581 := Call(__e, __defun__shen_4prhush, reg579, reg580)
 					_ = reg581
 					reg582 := PrimHead(V3076)
-					reg583 := __e.Call(__defun__snd, reg582)
-					reg584 := __e.Call(__defun__shen_4prbytes, reg583)
+					reg583 := Call(__e, __defun__snd, reg582)
+					reg584 := Call(__e, __defun__shen_4prbytes, reg583)
 					_ = reg584
 					reg585 := PrimTail(V3076)
 					reg586 := MakeNumber(1)
 					reg587 := PrimNumberAdd(V3077, reg586)
-					__ctx.TailApply(__defun__shen_4print_1past_1inputs, V3075, reg585, reg587)
+					__e.TailApply(__defun__shen_4print_1past_1inputs, V3075, reg585, reg587)
 					return
 				} else {
 					reg589 := MakeSymbol("shen.print-past-inputs")
-					__ctx.TailApply(__defun__shen_4f__error, reg589)
+					__e.TailApply(__defun__shen_4f__error, reg589)
 					return
 				}
 			}
@@ -1271,7 +1271,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.print-past-inputs", value: __defun__shen_4print_1past_1inputs})
 
-	__defun__shen_4toplevel__evaluate = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4toplevel__evaluate = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3080 := __args[0]
 		_ = V3080
 		V3081 := __args[1]
@@ -1374,7 +1374,7 @@ func init() {
 			reg634 := PrimTail(V3080)
 			reg635 := PrimTail(reg634)
 			reg636 := PrimHead(reg635)
-			__ctx.TailApply(__defun__shen_4typecheck_1and_1evaluate, reg633, reg636)
+			__e.TailApply(__defun__shen_4typecheck_1and_1evaluate, reg633, reg636)
 			return
 		} else {
 			reg638 := PrimIsPair(V3080)
@@ -1399,13 +1399,13 @@ func init() {
 				reg646 := PrimHead(V3080)
 				reg647 := Nil
 				reg648 := PrimCons(reg646, reg647)
-				reg649 := __e.Call(__defun__shen_4toplevel__evaluate, reg648, V3081)
+				reg649 := Call(__e, __defun__shen_4toplevel__evaluate, reg648, V3081)
 				_ = reg649
 				reg650 := MakeNumber(1)
-				reg651 := __e.Call(__defun__nl, reg650)
+				reg651 := Call(__e, __defun__nl, reg650)
 				_ = reg651
 				reg652 := PrimTail(V3080)
-				__ctx.TailApply(__defun__shen_4toplevel__evaluate, reg652, V3081)
+				__e.TailApply(__defun__shen_4toplevel__evaluate, reg652, V3081)
 				return
 			} else {
 				reg654 := PrimIsPair(V3080)
@@ -1447,8 +1447,8 @@ func init() {
 				if reg669 == True {
 					reg670 := PrimHead(V3080)
 					reg671 := MakeSymbol("A")
-					reg672 := __e.Call(__defun__gensym, reg671)
-					__ctx.TailApply(__defun__shen_4typecheck_1and_1evaluate, reg670, reg672)
+					reg672 := Call(__e, __defun__gensym, reg671)
+					__e.TailApply(__defun__shen_4typecheck_1and_1evaluate, reg670, reg672)
 					return
 				} else {
 					reg674 := PrimIsPair(V3080)
@@ -1489,14 +1489,14 @@ func init() {
 					}
 					if reg689 == True {
 						reg690 := PrimHead(V3080)
-						reg691 := __e.Call(__defun__shen_4eval_1without_1macros, reg690)
+						reg691 := Call(__e, __defun__shen_4eval_1without_1macros, reg690)
 						Eval := reg691
 						_ = Eval
-						__ctx.TailApply(__defun__print, Eval)
+						__e.TailApply(__defun__print, Eval)
 						return
 					} else {
 						reg693 := MakeSymbol("shen.toplevel_evaluate")
-						__ctx.TailApply(__defun__shen_4f__error, reg693)
+						__e.TailApply(__defun__shen_4f__error, reg693)
 						return
 					}
 				}
@@ -1505,12 +1505,12 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.toplevel_evaluate", value: __defun__shen_4toplevel__evaluate})
 
-	__defun__shen_4typecheck_1and_1evaluate = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4typecheck_1and_1evaluate = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3084 := __args[0]
 		_ = V3084
 		V3085 := __args[1]
 		_ = V3085
-		reg695 := __e.Call(__defun__shen_4typecheck, V3084, V3085)
+		reg695 := Call(__e, __defun__shen_4typecheck, V3084, V3085)
 		Typecheck := reg695
 		_ = Typecheck
 		reg696 := False
@@ -1518,68 +1518,68 @@ func init() {
 		if reg697 == True {
 			reg698 := MakeString("type error\n")
 			reg699 := PrimSimpleError(reg698)
-			__ctx.Return(reg699)
+			__e.Return(reg699)
 			return
 		} else {
-			reg700 := __e.Call(__defun__shen_4eval_1without_1macros, V3084)
+			reg700 := Call(__e, __defun__shen_4eval_1without_1macros, V3084)
 			Eval := reg700
 			_ = Eval
-			reg701 := __e.Call(__defun__shen_4pretty_1type, Typecheck)
+			reg701 := Call(__e, __defun__shen_4pretty_1type, Typecheck)
 			Type := reg701
 			_ = Type
 			reg702 := MakeString(" : ")
 			reg703 := MakeString("")
 			reg704 := MakeSymbol("shen.r")
-			reg705 := __e.Call(__defun__shen_4app, Type, reg703, reg704)
+			reg705 := Call(__e, __defun__shen_4app, Type, reg703, reg704)
 			reg706 := PrimStringConcat(reg702, reg705)
 			reg707 := MakeSymbol("shen.s")
-			reg708 := __e.Call(__defun__shen_4app, Eval, reg706, reg707)
-			reg709 := __e.Call(__defun__stoutput)
-			__ctx.TailApply(__defun__shen_4prhush, reg708, reg709)
+			reg708 := Call(__e, __defun__shen_4app, Eval, reg706, reg707)
+			reg709 := Call(__e, __defun__stoutput)
+			__e.TailApply(__defun__shen_4prhush, reg708, reg709)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.typecheck-and-evaluate", value: __defun__shen_4typecheck_1and_1evaluate})
 
-	__defun__shen_4pretty_1type = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4pretty_1type = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3087 := __args[0]
 		_ = V3087
 		reg711 := MakeSymbol("shen.*alphabet*")
 		reg712 := PrimValue(reg711)
-		reg713 := __e.Call(__defun__shen_4extract_1pvars, V3087)
-		__ctx.TailApply(__defun__shen_4mult__subst, reg712, reg713, V3087)
+		reg713 := Call(__e, __defun__shen_4extract_1pvars, V3087)
+		__e.TailApply(__defun__shen_4mult__subst, reg712, reg713, V3087)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.pretty-type", value: __defun__shen_4pretty_1type})
 
-	__defun__shen_4extract_1pvars = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4extract_1pvars = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3093 := __args[0]
 		_ = V3093
-		reg715 := __e.Call(__defun__shen_4pvar_2, V3093)
+		reg715 := Call(__e, __defun__shen_4pvar_2, V3093)
 		if reg715 == True {
 			reg716 := Nil
 			reg717 := PrimCons(V3093, reg716)
-			__ctx.Return(reg717)
+			__e.Return(reg717)
 			return
 		} else {
 			reg718 := PrimIsPair(V3093)
 			if reg718 == True {
 				reg719 := PrimHead(V3093)
-				reg720 := __e.Call(__defun__shen_4extract_1pvars, reg719)
+				reg720 := Call(__e, __defun__shen_4extract_1pvars, reg719)
 				reg721 := PrimTail(V3093)
-				reg722 := __e.Call(__defun__shen_4extract_1pvars, reg721)
-				__ctx.TailApply(__defun__union, reg720, reg722)
+				reg722 := Call(__e, __defun__shen_4extract_1pvars, reg721)
+				__e.TailApply(__defun__union, reg720, reg722)
 				return
 			} else {
 				reg724 := Nil
-				__ctx.Return(reg724)
+				__e.Return(reg724)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.extract-pvars", value: __defun__shen_4extract_1pvars})
 
-	__defun__shen_4mult__subst = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4mult__subst = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3101 := __args[0]
 		_ = V3101
 		V3102 := __args[1]
@@ -1589,13 +1589,13 @@ func init() {
 		reg725 := Nil
 		reg726 := PrimEqual(reg725, V3101)
 		if reg726 == True {
-			__ctx.Return(V3103)
+			__e.Return(V3103)
 			return
 		} else {
 			reg727 := Nil
 			reg728 := PrimEqual(reg727, V3102)
 			if reg728 == True {
-				__ctx.Return(V3103)
+				__e.Return(V3103)
 				return
 			} else {
 				reg729 := PrimIsPair(V3101)
@@ -1620,12 +1620,12 @@ func init() {
 					reg737 := PrimTail(V3102)
 					reg738 := PrimHead(V3101)
 					reg739 := PrimHead(V3102)
-					reg740 := __e.Call(__defun__subst, reg738, reg739, V3103)
-					__ctx.TailApply(__defun__shen_4mult__subst, reg736, reg737, reg740)
+					reg740 := Call(__e, __defun__subst, reg738, reg739, V3103)
+					__e.TailApply(__defun__shen_4mult__subst, reg736, reg737, reg740)
 					return
 				} else {
 					reg742 := MakeSymbol("shen.mult_subst")
-					__ctx.TailApply(__defun__shen_4f__error, reg742)
+					__e.TailApply(__defun__shen_4f__error, reg742)
 					return
 				}
 			}

--- a/cmd/shen/track.go
+++ b/cmd/shen/track.go
@@ -25,32 +25,32 @@ var __defun__shen_4get_1profile Obj           // shen.get-profile
 var __defun__shen_4put_1profile Obj           // shen.put-profile
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg15974 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg15974)
+		__e.Return(reg15974)
 		return
 	}, 0))
-	__defun__shen_4f__error = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4f__error = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3105 := __args[0]
 		_ = V3105
 		reg15975 := MakeString("partial function ")
 		reg15976 := MakeString(";\n")
 		reg15977 := MakeSymbol("shen.a")
-		reg15978 := __e.Call(__defun__shen_4app, V3105, reg15976, reg15977)
+		reg15978 := Call(__e, __defun__shen_4app, V3105, reg15976, reg15977)
 		reg15979 := PrimStringConcat(reg15975, reg15978)
-		reg15980 := __e.Call(__defun__stoutput)
-		reg15981 := __e.Call(__defun__shen_4prhush, reg15979, reg15980)
+		reg15980 := Call(__e, __defun__stoutput)
+		reg15981 := Call(__e, __defun__shen_4prhush, reg15979, reg15980)
 		_ = reg15981
-		reg15982 := __e.Call(__defun__shen_4tracked_2, V3105)
+		reg15982 := Call(__e, __defun__shen_4tracked_2, V3105)
 		reg15983 := PrimNot(reg15982)
 		var reg15994 Obj
 		if reg15983 == True {
 			reg15984 := MakeString("track ")
 			reg15985 := MakeString("? ")
 			reg15986 := MakeSymbol("shen.a")
-			reg15987 := __e.Call(__defun__shen_4app, V3105, reg15985, reg15986)
+			reg15987 := Call(__e, __defun__shen_4app, V3105, reg15985, reg15986)
 			reg15988 := PrimStringConcat(reg15984, reg15987)
-			reg15989 := __e.Call(__defun__y_1or_1n_2, reg15988)
+			reg15989 := Call(__e, __defun__y_1or_1n_2, reg15988)
 			var reg15992 Obj
 			if reg15989 == True {
 				reg15990 := True
@@ -66,8 +66,8 @@ func init() {
 		}
 		var reg15998 Obj
 		if reg15994 == True {
-			reg15995 := __e.Call(__defun__ps, V3105)
-			reg15996 := __e.Call(__defun__shen_4track_1function, reg15995)
+			reg15995 := Call(__e, __defun__ps, V3105)
+			reg15996 := Call(__e, __defun__shen_4track_1function, reg15995)
 			reg15998 = reg15996
 		} else {
 			reg15997 := MakeSymbol("shen.ok")
@@ -76,33 +76,33 @@ func init() {
 		_ = reg15998
 		reg15999 := MakeString("aborted")
 		reg16000 := PrimSimpleError(reg15999)
-		__ctx.Return(reg16000)
+		__e.Return(reg16000)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.f_error", value: __defun__shen_4f__error})
 
-	__defun__shen_4tracked_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4tracked_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3107 := __args[0]
 		_ = V3107
 		reg16001 := MakeSymbol("shen.*tracking*")
 		reg16002 := PrimValue(reg16001)
-		__ctx.TailApply(__defun__element_2, V3107, reg16002)
+		__e.TailApply(__defun__element_2, V3107, reg16002)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.tracked?", value: __defun__shen_4tracked_2})
 
-	__defun__track = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__track = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3109 := __args[0]
 		_ = V3109
-		reg16004 := __e.Call(__defun__ps, V3109)
+		reg16004 := Call(__e, __defun__ps, V3109)
 		Source := reg16004
 		_ = Source
-		__ctx.TailApply(__defun__shen_4track_1function, Source)
+		__e.TailApply(__defun__shen_4track_1function, Source)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "track", value: __defun__track})
 
-	__defun__shen_4track_1function = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4track_1function = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3111 := __args[0]
 		_ = V3111
 		reg16006 := PrimIsPair(V3111)
@@ -215,7 +215,7 @@ func init() {
 			reg16062 := PrimTail(reg16061)
 			reg16063 := PrimTail(reg16062)
 			reg16064 := PrimHead(reg16063)
-			reg16065 := __e.Call(__defun__shen_4insert_1tracking_1code, reg16057, reg16060, reg16064)
+			reg16065 := Call(__e, __defun__shen_4insert_1tracking_1code, reg16057, reg16060, reg16064)
 			reg16066 := Nil
 			reg16067 := PrimCons(reg16065, reg16066)
 			reg16068 := PrimCons(reg16055, reg16067)
@@ -233,17 +233,17 @@ func init() {
 			reg16076 := PrimSet(reg16072, reg16075)
 			Tr := reg16076
 			_ = Tr
-			__ctx.Return(Ob)
+			__e.Return(Ob)
 			return
 		} else {
 			reg16077 := MakeSymbol("shen.track-function")
-			__ctx.TailApply(__defun__shen_4f__error, reg16077)
+			__e.TailApply(__defun__shen_4f__error, reg16077)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.track-function", value: __defun__shen_4track_1function})
 
-	__defun__shen_4insert_1tracking_1code = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert_1tracking_1code = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3115 := __args[0]
 		_ = V3115
 		V3116 := __args[1]
@@ -275,7 +275,7 @@ func init() {
 		reg16101 := Nil
 		reg16102 := PrimCons(reg16100, reg16101)
 		reg16103 := PrimCons(reg16099, reg16102)
-		reg16104 := __e.Call(__defun__shen_4cons__form, V3116)
+		reg16104 := Call(__e, __defun__shen_4cons__form, V3116)
 		reg16105 := Nil
 		reg16106 := PrimCons(reg16104, reg16105)
 		reg16107 := PrimCons(V3115, reg16106)
@@ -352,12 +352,12 @@ func init() {
 		reg16178 := PrimCons(reg16176, reg16177)
 		reg16179 := PrimCons(reg16096, reg16178)
 		reg16180 := PrimCons(reg16079, reg16179)
-		__ctx.Return(reg16180)
+		__e.Return(reg16180)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.insert-tracking-code", value: __defun__shen_4insert_1tracking_1code})
 
-	__defun__step = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__step = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3123 := __args[0]
 		_ = V3123
 		reg16181 := MakeSymbol("+")
@@ -366,7 +366,7 @@ func init() {
 			reg16183 := MakeSymbol("shen.*step*")
 			reg16184 := True
 			reg16185 := PrimSet(reg16183, reg16184)
-			__ctx.Return(reg16185)
+			__e.Return(reg16185)
 			return
 		} else {
 			reg16186 := MakeSymbol("-")
@@ -375,19 +375,19 @@ func init() {
 				reg16188 := MakeSymbol("shen.*step*")
 				reg16189 := False
 				reg16190 := PrimSet(reg16188, reg16189)
-				__ctx.Return(reg16190)
+				__e.Return(reg16190)
 				return
 			} else {
 				reg16191 := MakeString("step expects a + or a -.\n")
 				reg16192 := PrimSimpleError(reg16191)
-				__ctx.Return(reg16192)
+				__e.Return(reg16192)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "step", value: __defun__step})
 
-	__defun__spy = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__spy = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3129 := __args[0]
 		_ = V3129
 		reg16193 := MakeSymbol("+")
@@ -396,7 +396,7 @@ func init() {
 			reg16195 := MakeSymbol("shen.*spy*")
 			reg16196 := True
 			reg16197 := PrimSet(reg16195, reg16196)
-			__ctx.Return(reg16197)
+			__e.Return(reg16197)
 			return
 		} else {
 			reg16198 := MakeSymbol("-")
@@ -405,54 +405,54 @@ func init() {
 				reg16200 := MakeSymbol("shen.*spy*")
 				reg16201 := False
 				reg16202 := PrimSet(reg16200, reg16201)
-				__ctx.Return(reg16202)
+				__e.Return(reg16202)
 				return
 			} else {
 				reg16203 := MakeString("spy expects a + or a -.\n")
 				reg16204 := PrimSimpleError(reg16203)
-				__ctx.Return(reg16204)
+				__e.Return(reg16204)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "spy", value: __defun__spy})
 
-	__defun__shen_4terpri_1or_1read_1char = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4terpri_1or_1read_1char = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg16205 := MakeSymbol("shen.*step*")
 		reg16206 := PrimValue(reg16205)
 		if reg16206 == True {
 			reg16207 := MakeSymbol("*stinput*")
 			reg16208 := PrimValue(reg16207)
 			reg16209 := PrimReadByte(reg16208)
-			__ctx.TailApply(__defun__shen_4check_1byte, reg16209)
+			__e.TailApply(__defun__shen_4check_1byte, reg16209)
 			return
 		} else {
 			reg16211 := MakeNumber(1)
-			__ctx.TailApply(__defun__nl, reg16211)
+			__e.TailApply(__defun__nl, reg16211)
 			return
 		}
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.terpri-or-read-char", value: __defun__shen_4terpri_1or_1read_1char})
 
-	__defun__shen_4check_1byte = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4check_1byte = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3135 := __args[0]
 		_ = V3135
-		reg16213 := __e.Call(__defun__shen_4hat)
+		reg16213 := Call(__e, __defun__shen_4hat)
 		reg16214 := PrimEqual(V3135, reg16213)
 		if reg16214 == True {
 			reg16215 := MakeString("aborted")
 			reg16216 := PrimSimpleError(reg16215)
-			__ctx.Return(reg16216)
+			__e.Return(reg16216)
 			return
 		} else {
 			reg16217 := True
-			__ctx.Return(reg16217)
+			__e.Return(reg16217)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.check-byte", value: __defun__shen_4check_1byte})
 
-	__defun__shen_4input_1track = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4input_1track = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3139 := __args[0]
 		_ = V3139
 		V3140 := __args[1]
@@ -460,86 +460,86 @@ func init() {
 		V3141 := __args[2]
 		_ = V3141
 		reg16218 := MakeString("\n")
-		reg16219 := __e.Call(__defun__shen_4spaces, V3139)
+		reg16219 := Call(__e, __defun__shen_4spaces, V3139)
 		reg16220 := MakeString("<")
 		reg16221 := MakeString("> Inputs to ")
 		reg16222 := MakeString(" \n")
-		reg16223 := __e.Call(__defun__shen_4spaces, V3139)
+		reg16223 := Call(__e, __defun__shen_4spaces, V3139)
 		reg16224 := MakeString("")
 		reg16225 := MakeSymbol("shen.a")
-		reg16226 := __e.Call(__defun__shen_4app, reg16223, reg16224, reg16225)
+		reg16226 := Call(__e, __defun__shen_4app, reg16223, reg16224, reg16225)
 		reg16227 := PrimStringConcat(reg16222, reg16226)
 		reg16228 := MakeSymbol("shen.a")
-		reg16229 := __e.Call(__defun__shen_4app, V3140, reg16227, reg16228)
+		reg16229 := Call(__e, __defun__shen_4app, V3140, reg16227, reg16228)
 		reg16230 := PrimStringConcat(reg16221, reg16229)
 		reg16231 := MakeSymbol("shen.a")
-		reg16232 := __e.Call(__defun__shen_4app, V3139, reg16230, reg16231)
+		reg16232 := Call(__e, __defun__shen_4app, V3139, reg16230, reg16231)
 		reg16233 := PrimStringConcat(reg16220, reg16232)
 		reg16234 := MakeSymbol("shen.a")
-		reg16235 := __e.Call(__defun__shen_4app, reg16219, reg16233, reg16234)
+		reg16235 := Call(__e, __defun__shen_4app, reg16219, reg16233, reg16234)
 		reg16236 := PrimStringConcat(reg16218, reg16235)
-		reg16237 := __e.Call(__defun__stoutput)
-		reg16238 := __e.Call(__defun__shen_4prhush, reg16236, reg16237)
+		reg16237 := Call(__e, __defun__stoutput)
+		reg16238 := Call(__e, __defun__shen_4prhush, reg16236, reg16237)
 		_ = reg16238
-		__ctx.TailApply(__defun__shen_4recursively_1print, V3141)
+		__e.TailApply(__defun__shen_4recursively_1print, V3141)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.input-track", value: __defun__shen_4input_1track})
 
-	__defun__shen_4recursively_1print = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4recursively_1print = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3143 := __args[0]
 		_ = V3143
 		reg16240 := Nil
 		reg16241 := PrimEqual(reg16240, V3143)
 		if reg16241 == True {
 			reg16242 := MakeString(" ==>")
-			reg16243 := __e.Call(__defun__stoutput)
-			__ctx.TailApply(__defun__shen_4prhush, reg16242, reg16243)
+			reg16243 := Call(__e, __defun__stoutput)
+			__e.TailApply(__defun__shen_4prhush, reg16242, reg16243)
 			return
 		} else {
 			reg16245 := PrimIsPair(V3143)
 			if reg16245 == True {
 				reg16246 := PrimHead(V3143)
-				reg16247 := __e.Call(__defun__print, reg16246)
+				reg16247 := Call(__e, __defun__print, reg16246)
 				_ = reg16247
 				reg16248 := MakeString(", ")
-				reg16249 := __e.Call(__defun__stoutput)
-				reg16250 := __e.Call(__defun__shen_4prhush, reg16248, reg16249)
+				reg16249 := Call(__e, __defun__stoutput)
+				reg16250 := Call(__e, __defun__shen_4prhush, reg16248, reg16249)
 				_ = reg16250
 				reg16251 := PrimTail(V3143)
-				__ctx.TailApply(__defun__shen_4recursively_1print, reg16251)
+				__e.TailApply(__defun__shen_4recursively_1print, reg16251)
 				return
 			} else {
 				reg16253 := MakeSymbol("shen.recursively-print")
-				__ctx.TailApply(__defun__shen_4f__error, reg16253)
+				__e.TailApply(__defun__shen_4f__error, reg16253)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.recursively-print", value: __defun__shen_4recursively_1print})
 
-	__defun__shen_4spaces = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4spaces = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3145 := __args[0]
 		_ = V3145
 		reg16255 := MakeNumber(0)
 		reg16256 := PrimEqual(reg16255, V3145)
 		if reg16256 == True {
 			reg16257 := MakeString("")
-			__ctx.Return(reg16257)
+			__e.Return(reg16257)
 			return
 		} else {
 			reg16258 := MakeString(" ")
 			reg16259 := MakeNumber(1)
 			reg16260 := PrimNumberSubtract(V3145, reg16259)
-			reg16261 := __e.Call(__defun__shen_4spaces, reg16260)
+			reg16261 := Call(__e, __defun__shen_4spaces, reg16260)
 			reg16262 := PrimStringConcat(reg16258, reg16261)
-			__ctx.Return(reg16262)
+			__e.Return(reg16262)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.spaces", value: __defun__shen_4spaces})
 
-	__defun__shen_4output_1track = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4output_1track = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3149 := __args[0]
 		_ = V3149
 		V3150 := __args[1]
@@ -547,35 +547,35 @@ func init() {
 		V3151 := __args[2]
 		_ = V3151
 		reg16263 := MakeString("\n")
-		reg16264 := __e.Call(__defun__shen_4spaces, V3149)
+		reg16264 := Call(__e, __defun__shen_4spaces, V3149)
 		reg16265 := MakeString("<")
 		reg16266 := MakeString("> Output from ")
 		reg16267 := MakeString(" \n")
-		reg16268 := __e.Call(__defun__shen_4spaces, V3149)
+		reg16268 := Call(__e, __defun__shen_4spaces, V3149)
 		reg16269 := MakeString("==> ")
 		reg16270 := MakeString("")
 		reg16271 := MakeSymbol("shen.s")
-		reg16272 := __e.Call(__defun__shen_4app, V3151, reg16270, reg16271)
+		reg16272 := Call(__e, __defun__shen_4app, V3151, reg16270, reg16271)
 		reg16273 := PrimStringConcat(reg16269, reg16272)
 		reg16274 := MakeSymbol("shen.a")
-		reg16275 := __e.Call(__defun__shen_4app, reg16268, reg16273, reg16274)
+		reg16275 := Call(__e, __defun__shen_4app, reg16268, reg16273, reg16274)
 		reg16276 := PrimStringConcat(reg16267, reg16275)
 		reg16277 := MakeSymbol("shen.a")
-		reg16278 := __e.Call(__defun__shen_4app, V3150, reg16276, reg16277)
+		reg16278 := Call(__e, __defun__shen_4app, V3150, reg16276, reg16277)
 		reg16279 := PrimStringConcat(reg16266, reg16278)
 		reg16280 := MakeSymbol("shen.a")
-		reg16281 := __e.Call(__defun__shen_4app, V3149, reg16279, reg16280)
+		reg16281 := Call(__e, __defun__shen_4app, V3149, reg16279, reg16280)
 		reg16282 := PrimStringConcat(reg16265, reg16281)
 		reg16283 := MakeSymbol("shen.a")
-		reg16284 := __e.Call(__defun__shen_4app, reg16264, reg16282, reg16283)
+		reg16284 := Call(__e, __defun__shen_4app, reg16264, reg16282, reg16283)
 		reg16285 := PrimStringConcat(reg16263, reg16284)
-		reg16286 := __e.Call(__defun__stoutput)
-		__ctx.TailApply(__defun__shen_4prhush, reg16285, reg16286)
+		reg16286 := Call(__e, __defun__stoutput)
+		__e.TailApply(__defun__shen_4prhush, reg16285, reg16286)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.output-track", value: __defun__shen_4output_1track})
 
-	__defun__untrack = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__untrack = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3153 := __args[0]
 		_ = V3153
 		reg16288 := MakeSymbol("shen.*tracking*")
@@ -583,26 +583,26 @@ func init() {
 		Tracking := reg16289
 		_ = Tracking
 		reg16290 := MakeSymbol("shen.*tracking*")
-		reg16291 := __e.Call(__defun__remove, V3153, Tracking)
+		reg16291 := Call(__e, __defun__remove, V3153, Tracking)
 		reg16292 := PrimSet(reg16290, reg16291)
 		Tracking = reg16292
 		_ = Tracking
-		reg16293 := __e.Call(__defun__ps, V3153)
-		__ctx.TailApply(__defun__eval, reg16293)
+		reg16293 := Call(__e, __defun__ps, V3153)
+		__e.TailApply(__defun__eval, reg16293)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "untrack", value: __defun__untrack})
 
-	__defun__profile = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__profile = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3155 := __args[0]
 		_ = V3155
-		reg16295 := __e.Call(__defun__ps, V3155)
-		__ctx.TailApply(__defun__shen_4profile_1help, reg16295)
+		reg16295 := Call(__e, __defun__ps, V3155)
+		__e.TailApply(__defun__shen_4profile_1help, reg16295)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "profile", value: __defun__profile})
 
-	__defun__shen_4profile_1help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4profile_1help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3161 := __args[0]
 		_ = V3161
 		reg16297 := PrimIsPair(V3161)
@@ -701,7 +701,7 @@ func init() {
 		}
 		if reg16340 == True {
 			reg16341 := MakeSymbol("shen.f")
-			reg16342 := __e.Call(__defun__gensym, reg16341)
+			reg16342 := Call(__e, __defun__gensym, reg16341)
 			G := reg16342
 			_ = G
 			reg16343 := MakeSymbol("defun")
@@ -719,7 +719,7 @@ func init() {
 			reg16355 := PrimTail(reg16354)
 			reg16356 := PrimHead(reg16355)
 			reg16357 := PrimCons(G, reg16356)
-			reg16358 := __e.Call(__defun__shen_4profile_1func, reg16350, reg16353, reg16357)
+			reg16358 := Call(__e, __defun__shen_4profile_1func, reg16350, reg16353, reg16357)
 			reg16359 := Nil
 			reg16360 := PrimCons(reg16358, reg16359)
 			reg16361 := PrimCons(reg16348, reg16360)
@@ -737,7 +737,7 @@ func init() {
 			reg16371 := PrimTail(reg16370)
 			reg16372 := PrimTail(reg16371)
 			reg16373 := PrimHead(reg16372)
-			reg16374 := __e.Call(__defun__subst, G, reg16369, reg16373)
+			reg16374 := Call(__e, __defun__subst, G, reg16369, reg16373)
 			reg16375 := Nil
 			reg16376 := PrimCons(reg16374, reg16375)
 			reg16377 := PrimCons(reg16367, reg16376)
@@ -745,34 +745,34 @@ func init() {
 			reg16379 := PrimCons(reg16364, reg16378)
 			Def := reg16379
 			_ = Def
-			reg16380 := __e.Call(__defun__shen_4eval_1without_1macros, Profile)
+			reg16380 := Call(__e, __defun__shen_4eval_1without_1macros, Profile)
 			CompileProfile := reg16380
 			_ = CompileProfile
-			reg16381 := __e.Call(__defun__shen_4eval_1without_1macros, Def)
+			reg16381 := Call(__e, __defun__shen_4eval_1without_1macros, Def)
 			CompileG := reg16381
 			_ = CompileG
 			reg16382 := PrimTail(V3161)
 			reg16383 := PrimHead(reg16382)
-			__ctx.Return(reg16383)
+			__e.Return(reg16383)
 			return
 		} else {
 			reg16384 := MakeString("Cannot profile.\n")
 			reg16385 := PrimSimpleError(reg16384)
-			__ctx.Return(reg16385)
+			__e.Return(reg16385)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.profile-help", value: __defun__shen_4profile_1help})
 
-	__defun__unprofile = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__unprofile = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3163 := __args[0]
 		_ = V3163
-		__ctx.TailApply(__defun__untrack, V3163)
+		__e.TailApply(__defun__untrack, V3163)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "unprofile", value: __defun__unprofile})
 
-	__defun__shen_4profile_1func = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4profile_1func = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3167 := __args[0]
 		_ = V3167
 		V3168 := __args[1]
@@ -839,50 +839,50 @@ func init() {
 		reg16444 := PrimCons(reg16393, reg16443)
 		reg16445 := PrimCons(reg16388, reg16444)
 		reg16446 := PrimCons(reg16387, reg16445)
-		__ctx.Return(reg16446)
+		__e.Return(reg16446)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.profile-func", value: __defun__shen_4profile_1func})
 
-	__defun__profile_1results = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__profile_1results = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3171 := __args[0]
 		_ = V3171
-		reg16447 := __e.Call(__defun__shen_4get_1profile, V3171)
+		reg16447 := Call(__e, __defun__shen_4get_1profile, V3171)
 		Results := reg16447
 		_ = Results
 		reg16448 := MakeNumber(0)
-		reg16449 := __e.Call(__defun__shen_4put_1profile, V3171, reg16448)
+		reg16449 := Call(__e, __defun__shen_4put_1profile, V3171, reg16448)
 		Initialise := reg16449
 		_ = Initialise
-		__ctx.TailApply(__defun___8p, V3171, Results)
+		__e.TailApply(__defun___8p, V3171, Results)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "profile-results", value: __defun__profile_1results})
 
-	__defun__shen_4get_1profile = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4get_1profile = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3173 := __args[0]
 		_ = V3173
-		reg16451 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg16451 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg16452 := MakeSymbol("profile")
 			reg16453 := MakeSymbol("*property-vector*")
 			reg16454 := PrimValue(reg16453)
-			__ctx.TailApply(__defun__get, V3173, reg16452, reg16454)
+			__e.TailApply(__defun__get, V3173, reg16452, reg16454)
 			return
 		}, 0)
-		reg16456 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg16456 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg16457 := MakeNumber(0)
-			__ctx.Return(reg16457)
+			__e.Return(reg16457)
 			return
 		}, 1)
-		reg16458 := __e.Try(reg16451).Catch(reg16456)
-		__ctx.Return(reg16458)
+		reg16458 := Try(__e, reg16451).Catch(reg16456)
+		__e.Return(reg16458)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.get-profile", value: __defun__shen_4get_1profile})
 
-	__defun__shen_4put_1profile = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4put_1profile = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3176 := __args[0]
 		_ = V3176
 		V3177 := __args[1]
@@ -890,7 +890,7 @@ func init() {
 		reg16459 := MakeSymbol("profile")
 		reg16460 := MakeSymbol("*property-vector*")
 		reg16461 := PrimValue(reg16460)
-		__ctx.TailApply(__defun__put, V3176, reg16459, V3177, reg16461)
+		__e.TailApply(__defun__put, V3176, reg16459, V3177, reg16461)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.put-profile", value: __defun__shen_4put_1profile})

--- a/cmd/shen/types.go
+++ b/cmd/shen/types.go
@@ -144,12 +144,12 @@ var __defun__shen_4type_1signature_1of_1_d Obj                       // shen.typ
 var __defun__shen_4type_1signature_1of_1_a_a Obj                     // shen.type-signature-of-==
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg23877 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg23877)
+		__e.Return(reg23877)
 		return
 	}, 0))
-	__defun__declare = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__declare = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3180 := __args[0]
 		_ = V3180
 		V3181 := __args[1]
@@ -162,30 +162,30 @@ func init() {
 		reg23883 := PrimSet(reg23878, reg23882)
 		Record := reg23883
 		_ = Record
-		reg23884 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			__ctx.TailApply(__defun__shen_4variancy_1test, V3180, V3181)
+		reg23884 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			__e.TailApply(__defun__shen_4variancy_1test, V3180, V3181)
 			return
 		}, 0)
-		reg23886 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg23886 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg23887 := MakeSymbol("shen.skip")
-			__ctx.Return(reg23887)
+			__e.Return(reg23887)
 			return
 		}, 1)
-		reg23888 := __e.Try(reg23884).Catch(reg23886)
+		reg23888 := Try(__e, reg23884).Catch(reg23886)
 		Variancy := reg23888
 		_ = Variancy
-		reg23889 := __e.Call(__defun__shen_4demodulate, V3181)
-		reg23890 := __e.Call(__defun__shen_4rcons__form, reg23889)
+		reg23889 := Call(__e, __defun__shen_4demodulate, V3181)
+		reg23890 := Call(__e, __defun__shen_4rcons__form, reg23889)
 		Type := reg23890
 		_ = Type
 		reg23891 := MakeSymbol("shen.type-signature-of-")
-		reg23892 := __e.Call(__defun__concat, reg23891, V3180)
+		reg23892 := Call(__e, __defun__concat, reg23891, V3180)
 		F_d := reg23892
 		_ = F_d
 		reg23893 := MakeNumber(1)
-		reg23894 := __e.Call(__defun__shen_4parameters, reg23893)
+		reg23894 := Call(__e, __defun__shen_4parameters, reg23893)
 		Parameters := reg23894
 		_ = Parameters
 		reg23895 := MakeSymbol("X")
@@ -207,10 +207,10 @@ func init() {
 		reg23911 := PrimCons(reg23898, reg23910)
 		Clause := reg23911
 		_ = Clause
-		reg23912 := __e.Call(__defun__shen_4aum, Clause, Parameters)
+		reg23912 := Call(__e, __defun__shen_4aum, Clause, Parameters)
 		AUM__instruction := reg23912
 		_ = AUM__instruction
-		reg23913 := __e.Call(__defun__shen_4aum__to__shen, AUM__instruction)
+		reg23913 := Call(__e, __defun__shen_4aum__to__shen, AUM__instruction)
 		Code := reg23913
 		_ = Code
 		reg23914 := MakeSymbol("define")
@@ -223,46 +223,46 @@ func init() {
 		reg23921 := Nil
 		reg23922 := PrimCons(Code, reg23921)
 		reg23923 := PrimCons(reg23920, reg23922)
-		reg23924 := __e.Call(__defun__append, reg23919, reg23923)
-		reg23925 := __e.Call(__defun__append, Parameters, reg23924)
+		reg23924 := Call(__e, __defun__append, reg23919, reg23923)
+		reg23925 := Call(__e, __defun__append, Parameters, reg23924)
 		reg23926 := PrimCons(F_d, reg23925)
 		reg23927 := PrimCons(reg23914, reg23926)
 		ShenDef := reg23927
 		_ = ShenDef
-		reg23928 := __e.Call(__defun__shen_4eval_1without_1macros, ShenDef)
+		reg23928 := Call(__e, __defun__shen_4eval_1without_1macros, ShenDef)
 		Eval := reg23928
 		_ = Eval
-		__ctx.Return(V3180)
+		__e.Return(V3180)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "declare", value: __defun__declare})
 
-	__defun__shen_4demodulate = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4demodulate = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3183 := __args[0]
 		_ = V3183
 		reg23929 := MakeSymbol("shen.*demodulation-function*")
 		reg23930 := PrimValue(reg23929)
-		reg23931 := __e.Call(__defun__shen_4walk, reg23930, V3183)
+		reg23931 := Call(__e, __defun__shen_4walk, reg23930, V3183)
 		Demod := reg23931
 		_ = Demod
 		reg23932 := PrimEqual(Demod, V3183)
 		if reg23932 == True {
-			__ctx.Return(V3183)
+			__e.Return(V3183)
 			return
 		} else {
-			__ctx.TailApply(__defun__shen_4demodulate, Demod)
+			__e.TailApply(__defun__shen_4demodulate, Demod)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.demodulate", value: __defun__shen_4demodulate})
 
-	__defun__shen_4variancy_1test = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4variancy_1test = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3186 := __args[0]
 		_ = V3186
 		V3187 := __args[1]
 		_ = V3187
 		reg23934 := MakeSymbol("B")
-		reg23935 := __e.Call(__defun__shen_4typecheck, V3186, reg23934)
+		reg23935 := Call(__e, __defun__shen_4typecheck, V3186, reg23934)
 		TypeF := reg23935
 		_ = TypeF
 		reg23936 := MakeSymbol("symbol")
@@ -272,7 +272,7 @@ func init() {
 			reg23938 := MakeSymbol("shen.skip")
 			reg23949 = reg23938
 		} else {
-			reg23939 := __e.Call(__defun__shen_4variant_2, TypeF, V3187)
+			reg23939 := Call(__e, __defun__shen_4variant_2, TypeF, V3187)
 			var reg23948 Obj
 			if reg23939 == True {
 				reg23940 := MakeSymbol("shen.skip")
@@ -281,10 +281,10 @@ func init() {
 				reg23941 := MakeString("warning: changing the type of ")
 				reg23942 := MakeString(" may create errors\n")
 				reg23943 := MakeSymbol("shen.a")
-				reg23944 := __e.Call(__defun__shen_4app, V3186, reg23942, reg23943)
+				reg23944 := Call(__e, __defun__shen_4app, V3186, reg23942, reg23943)
 				reg23945 := PrimStringConcat(reg23941, reg23944)
-				reg23946 := __e.Call(__defun__stoutput)
-				reg23947 := __e.Call(__defun__shen_4prhush, reg23945, reg23946)
+				reg23946 := Call(__e, __defun__stoutput)
+				reg23947 := Call(__e, __defun__shen_4prhush, reg23945, reg23946)
 				reg23948 = reg23947
 			}
 			reg23949 = reg23948
@@ -292,12 +292,12 @@ func init() {
 		Check := reg23949
 		_ = Check
 		reg23950 := MakeSymbol("shen.skip")
-		__ctx.Return(reg23950)
+		__e.Return(reg23950)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.variancy-test", value: __defun__shen_4variancy_1test})
 
-	__defun__shen_4variant_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4variant_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3200 := __args[0]
 		_ = V3200
 		V3201 := __args[1]
@@ -305,7 +305,7 @@ func init() {
 		reg23951 := PrimEqual(V3201, V3200)
 		if reg23951 == True {
 			reg23952 := True
-			__ctx.Return(reg23952)
+			__e.Return(reg23952)
 			return
 		} else {
 			reg23953 := PrimIsPair(V3200)
@@ -346,7 +346,7 @@ func init() {
 			if reg23967 == True {
 				reg23968 := PrimTail(V3200)
 				reg23969 := PrimTail(V3201)
-				__ctx.TailApply(__defun__shen_4variant_2, reg23968, reg23969)
+				__e.TailApply(__defun__shen_4variant_2, reg23968, reg23969)
 				return
 			} else {
 				reg23971 := PrimIsPair(V3200)
@@ -356,7 +356,7 @@ func init() {
 					var reg23986 Obj
 					if reg23972 == True {
 						reg23973 := PrimHead(V3200)
-						reg23974 := __e.Call(__defun__shen_4pvar_2, reg23973)
+						reg23974 := Call(__e, __defun__shen_4pvar_2, reg23973)
 						var reg23981 Obj
 						if reg23974 == True {
 							reg23975 := PrimHead(V3201)
@@ -404,12 +404,12 @@ func init() {
 					reg23992 := MakeSymbol("shen.a")
 					reg23993 := PrimHead(V3200)
 					reg23994 := PrimTail(V3200)
-					reg23995 := __e.Call(__defun__subst, reg23992, reg23993, reg23994)
+					reg23995 := Call(__e, __defun__subst, reg23992, reg23993, reg23994)
 					reg23996 := MakeSymbol("shen.a")
 					reg23997 := PrimHead(V3201)
 					reg23998 := PrimTail(V3201)
-					reg23999 := __e.Call(__defun__subst, reg23996, reg23997, reg23998)
-					__ctx.TailApply(__defun__shen_4variant_2, reg23995, reg23999)
+					reg23999 := Call(__e, __defun__subst, reg23996, reg23997, reg23998)
+					__e.TailApply(__defun__shen_4variant_2, reg23995, reg23999)
 					return
 				} else {
 					reg24001 := PrimIsPair(V3200)
@@ -466,15 +466,15 @@ func init() {
 					if reg24021 == True {
 						reg24022 := PrimHead(V3200)
 						reg24023 := PrimTail(V3200)
-						reg24024 := __e.Call(__defun__append, reg24022, reg24023)
+						reg24024 := Call(__e, __defun__append, reg24022, reg24023)
 						reg24025 := PrimHead(V3201)
 						reg24026 := PrimTail(V3201)
-						reg24027 := __e.Call(__defun__append, reg24025, reg24026)
-						__ctx.TailApply(__defun__shen_4variant_2, reg24024, reg24027)
+						reg24027 := Call(__e, __defun__append, reg24025, reg24026)
+						__e.TailApply(__defun__shen_4variant_2, reg24024, reg24027)
 						return
 					} else {
 						reg24029 := False
-						__ctx.Return(reg24029)
+						__e.Return(reg24029)
 						return
 					}
 				}
@@ -483,17 +483,17 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.variant?", value: __defun__shen_4variant_2})
 
-	__defun__shen_4type_1signature_1of_1absvector_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1absvector_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4556 := __args[0]
 		_ = V4556
 		V4557 := __args[1]
 		_ = V4557
 		V4558 := __args[2]
 		_ = V4558
-		reg24030 := __e.Call(__defun__shen_4newpv, V4557)
+		reg24030 := Call(__e, __defun__shen_4newpv, V4557)
 		A := reg24030
 		_ = A
-		reg24031 := __e.Call(__defun__shen_4incinfs)
+		reg24031 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24031
 		reg24032 := MakeSymbol("-->")
 		reg24033 := MakeSymbol("boolean")
@@ -501,22 +501,22 @@ func init() {
 		reg24035 := PrimCons(reg24033, reg24034)
 		reg24036 := PrimCons(reg24032, reg24035)
 		reg24037 := PrimCons(A, reg24036)
-		__ctx.TailApply(__defun__unify_b, V4556, reg24037, V4557, V4558)
+		__e.TailApply(__defun__unify_b, V4556, reg24037, V4557, V4558)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-absvector?", value: __defun__shen_4type_1signature_1of_1absvector_2})
 
-	__defun__shen_4type_1signature_1of_1adjoin = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1adjoin = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4546 := __args[0]
 		_ = V4546
 		V4547 := __args[1]
 		_ = V4547
 		V4548 := __args[2]
 		_ = V4548
-		reg24039 := __e.Call(__defun__shen_4newpv, V4547)
+		reg24039 := Call(__e, __defun__shen_4newpv, V4547)
 		A := reg24039
 		_ = A
-		reg24040 := __e.Call(__defun__shen_4incinfs)
+		reg24040 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24040
 		reg24041 := MakeSymbol("-->")
 		reg24042 := MakeSymbol("list")
@@ -536,19 +536,19 @@ func init() {
 		reg24056 := PrimCons(reg24054, reg24055)
 		reg24057 := PrimCons(reg24041, reg24056)
 		reg24058 := PrimCons(A, reg24057)
-		__ctx.TailApply(__defun__unify_b, V4546, reg24058, V4547, V4548)
+		__e.TailApply(__defun__unify_b, V4546, reg24058, V4547, V4548)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-adjoin", value: __defun__shen_4type_1signature_1of_1adjoin})
 
-	__defun__shen_4type_1signature_1of_1and = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1and = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4536 := __args[0]
 		_ = V4536
 		V4537 := __args[1]
 		_ = V4537
 		V4538 := __args[2]
 		_ = V4538
-		reg24060 := __e.Call(__defun__shen_4incinfs)
+		reg24060 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24060
 		reg24061 := MakeSymbol("boolean")
 		reg24062 := MakeSymbol("-->")
@@ -563,22 +563,22 @@ func init() {
 		reg24071 := PrimCons(reg24069, reg24070)
 		reg24072 := PrimCons(reg24062, reg24071)
 		reg24073 := PrimCons(reg24061, reg24072)
-		__ctx.TailApply(__defun__unify_b, V4536, reg24073, V4537, V4538)
+		__e.TailApply(__defun__unify_b, V4536, reg24073, V4537, V4538)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-and", value: __defun__shen_4type_1signature_1of_1and})
 
-	__defun__shen_4type_1signature_1of_1shen_4app = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1shen_4app = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4526 := __args[0]
 		_ = V4526
 		V4527 := __args[1]
 		_ = V4527
 		V4528 := __args[2]
 		_ = V4528
-		reg24075 := __e.Call(__defun__shen_4newpv, V4527)
+		reg24075 := Call(__e, __defun__shen_4newpv, V4527)
 		A := reg24075
 		_ = A
-		reg24076 := __e.Call(__defun__shen_4incinfs)
+		reg24076 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24076
 		reg24077 := MakeSymbol("-->")
 		reg24078 := MakeSymbol("string")
@@ -598,22 +598,22 @@ func init() {
 		reg24092 := PrimCons(reg24090, reg24091)
 		reg24093 := PrimCons(reg24077, reg24092)
 		reg24094 := PrimCons(A, reg24093)
-		__ctx.TailApply(__defun__unify_b, V4526, reg24094, V4527, V4528)
+		__e.TailApply(__defun__unify_b, V4526, reg24094, V4527, V4528)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-shen.app", value: __defun__shen_4type_1signature_1of_1shen_4app})
 
-	__defun__shen_4type_1signature_1of_1append = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1append = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4516 := __args[0]
 		_ = V4516
 		V4517 := __args[1]
 		_ = V4517
 		V4518 := __args[2]
 		_ = V4518
-		reg24096 := __e.Call(__defun__shen_4newpv, V4517)
+		reg24096 := Call(__e, __defun__shen_4newpv, V4517)
 		A := reg24096
 		_ = A
-		reg24097 := __e.Call(__defun__shen_4incinfs)
+		reg24097 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24097
 		reg24098 := MakeSymbol("list")
 		reg24099 := Nil
@@ -637,22 +637,22 @@ func init() {
 		reg24117 := PrimCons(reg24115, reg24116)
 		reg24118 := PrimCons(reg24102, reg24117)
 		reg24119 := PrimCons(reg24101, reg24118)
-		__ctx.TailApply(__defun__unify_b, V4516, reg24119, V4517, V4518)
+		__e.TailApply(__defun__unify_b, V4516, reg24119, V4517, V4518)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-append", value: __defun__shen_4type_1signature_1of_1append})
 
-	__defun__shen_4type_1signature_1of_1arity = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1arity = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4506 := __args[0]
 		_ = V4506
 		V4507 := __args[1]
 		_ = V4507
 		V4508 := __args[2]
 		_ = V4508
-		reg24121 := __e.Call(__defun__shen_4newpv, V4507)
+		reg24121 := Call(__e, __defun__shen_4newpv, V4507)
 		A := reg24121
 		_ = A
-		reg24122 := __e.Call(__defun__shen_4incinfs)
+		reg24122 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24122
 		reg24123 := MakeSymbol("-->")
 		reg24124 := MakeSymbol("number")
@@ -660,22 +660,22 @@ func init() {
 		reg24126 := PrimCons(reg24124, reg24125)
 		reg24127 := PrimCons(reg24123, reg24126)
 		reg24128 := PrimCons(A, reg24127)
-		__ctx.TailApply(__defun__unify_b, V4506, reg24128, V4507, V4508)
+		__e.TailApply(__defun__unify_b, V4506, reg24128, V4507, V4508)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-arity", value: __defun__shen_4type_1signature_1of_1arity})
 
-	__defun__shen_4type_1signature_1of_1assoc = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1assoc = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4496 := __args[0]
 		_ = V4496
 		V4497 := __args[1]
 		_ = V4497
 		V4498 := __args[2]
 		_ = V4498
-		reg24130 := __e.Call(__defun__shen_4newpv, V4497)
+		reg24130 := Call(__e, __defun__shen_4newpv, V4497)
 		A := reg24130
 		_ = A
-		reg24131 := __e.Call(__defun__shen_4incinfs)
+		reg24131 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24131
 		reg24132 := MakeSymbol("-->")
 		reg24133 := MakeSymbol("list")
@@ -699,22 +699,22 @@ func init() {
 		reg24151 := PrimCons(reg24149, reg24150)
 		reg24152 := PrimCons(reg24132, reg24151)
 		reg24153 := PrimCons(A, reg24152)
-		__ctx.TailApply(__defun__unify_b, V4496, reg24153, V4497, V4498)
+		__e.TailApply(__defun__unify_b, V4496, reg24153, V4497, V4498)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-assoc", value: __defun__shen_4type_1signature_1of_1assoc})
 
-	__defun__shen_4type_1signature_1of_1boolean_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1boolean_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4486 := __args[0]
 		_ = V4486
 		V4487 := __args[1]
 		_ = V4487
 		V4488 := __args[2]
 		_ = V4488
-		reg24155 := __e.Call(__defun__shen_4newpv, V4487)
+		reg24155 := Call(__e, __defun__shen_4newpv, V4487)
 		A := reg24155
 		_ = A
-		reg24156 := __e.Call(__defun__shen_4incinfs)
+		reg24156 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24156
 		reg24157 := MakeSymbol("-->")
 		reg24158 := MakeSymbol("boolean")
@@ -722,19 +722,19 @@ func init() {
 		reg24160 := PrimCons(reg24158, reg24159)
 		reg24161 := PrimCons(reg24157, reg24160)
 		reg24162 := PrimCons(A, reg24161)
-		__ctx.TailApply(__defun__unify_b, V4486, reg24162, V4487, V4488)
+		__e.TailApply(__defun__unify_b, V4486, reg24162, V4487, V4488)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-boolean?", value: __defun__shen_4type_1signature_1of_1boolean_2})
 
-	__defun__shen_4type_1signature_1of_1bound_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1bound_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4476 := __args[0]
 		_ = V4476
 		V4477 := __args[1]
 		_ = V4477
 		V4478 := __args[2]
 		_ = V4478
-		reg24164 := __e.Call(__defun__shen_4incinfs)
+		reg24164 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24164
 		reg24165 := MakeSymbol("symbol")
 		reg24166 := MakeSymbol("-->")
@@ -743,19 +743,19 @@ func init() {
 		reg24169 := PrimCons(reg24167, reg24168)
 		reg24170 := PrimCons(reg24166, reg24169)
 		reg24171 := PrimCons(reg24165, reg24170)
-		__ctx.TailApply(__defun__unify_b, V4476, reg24171, V4477, V4478)
+		__e.TailApply(__defun__unify_b, V4476, reg24171, V4477, V4478)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-bound?", value: __defun__shen_4type_1signature_1of_1bound_2})
 
-	__defun__shen_4type_1signature_1of_1cd = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1cd = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4466 := __args[0]
 		_ = V4466
 		V4467 := __args[1]
 		_ = V4467
 		V4468 := __args[2]
 		_ = V4468
-		reg24173 := __e.Call(__defun__shen_4incinfs)
+		reg24173 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24173
 		reg24174 := MakeSymbol("string")
 		reg24175 := MakeSymbol("-->")
@@ -764,25 +764,25 @@ func init() {
 		reg24178 := PrimCons(reg24176, reg24177)
 		reg24179 := PrimCons(reg24175, reg24178)
 		reg24180 := PrimCons(reg24174, reg24179)
-		__ctx.TailApply(__defun__unify_b, V4466, reg24180, V4467, V4468)
+		__e.TailApply(__defun__unify_b, V4466, reg24180, V4467, V4468)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-cd", value: __defun__shen_4type_1signature_1of_1cd})
 
-	__defun__shen_4type_1signature_1of_1close = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1close = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4456 := __args[0]
 		_ = V4456
 		V4457 := __args[1]
 		_ = V4457
 		V4458 := __args[2]
 		_ = V4458
-		reg24182 := __e.Call(__defun__shen_4newpv, V4457)
+		reg24182 := Call(__e, __defun__shen_4newpv, V4457)
 		A := reg24182
 		_ = A
-		reg24183 := __e.Call(__defun__shen_4newpv, V4457)
+		reg24183 := Call(__e, __defun__shen_4newpv, V4457)
 		B := reg24183
 		_ = B
-		reg24184 := __e.Call(__defun__shen_4incinfs)
+		reg24184 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24184
 		reg24185 := MakeSymbol("stream")
 		reg24186 := Nil
@@ -797,19 +797,19 @@ func init() {
 		reg24195 := PrimCons(reg24193, reg24194)
 		reg24196 := PrimCons(reg24189, reg24195)
 		reg24197 := PrimCons(reg24188, reg24196)
-		__ctx.TailApply(__defun__unify_b, V4456, reg24197, V4457, V4458)
+		__e.TailApply(__defun__unify_b, V4456, reg24197, V4457, V4458)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-close", value: __defun__shen_4type_1signature_1of_1close})
 
-	__defun__shen_4type_1signature_1of_1cn = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1cn = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4446 := __args[0]
 		_ = V4446
 		V4447 := __args[1]
 		_ = V4447
 		V4448 := __args[2]
 		_ = V4448
-		reg24199 := __e.Call(__defun__shen_4incinfs)
+		reg24199 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24199
 		reg24200 := MakeSymbol("string")
 		reg24201 := MakeSymbol("-->")
@@ -824,25 +824,25 @@ func init() {
 		reg24210 := PrimCons(reg24208, reg24209)
 		reg24211 := PrimCons(reg24201, reg24210)
 		reg24212 := PrimCons(reg24200, reg24211)
-		__ctx.TailApply(__defun__unify_b, V4446, reg24212, V4447, V4448)
+		__e.TailApply(__defun__unify_b, V4446, reg24212, V4447, V4448)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-cn", value: __defun__shen_4type_1signature_1of_1cn})
 
-	__defun__shen_4type_1signature_1of_1compile = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1compile = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4436 := __args[0]
 		_ = V4436
 		V4437 := __args[1]
 		_ = V4437
 		V4438 := __args[2]
 		_ = V4438
-		reg24214 := __e.Call(__defun__shen_4newpv, V4437)
+		reg24214 := Call(__e, __defun__shen_4newpv, V4437)
 		A := reg24214
 		_ = A
-		reg24215 := __e.Call(__defun__shen_4newpv, V4437)
+		reg24215 := Call(__e, __defun__shen_4newpv, V4437)
 		B := reg24215
 		_ = B
-		reg24216 := __e.Call(__defun__shen_4incinfs)
+		reg24216 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24216
 		reg24217 := MakeSymbol("shen.==>")
 		reg24218 := Nil
@@ -869,22 +869,22 @@ func init() {
 		reg24239 := PrimCons(reg24237, reg24238)
 		reg24240 := PrimCons(reg24222, reg24239)
 		reg24241 := PrimCons(reg24221, reg24240)
-		__ctx.TailApply(__defun__unify_b, V4436, reg24241, V4437, V4438)
+		__e.TailApply(__defun__unify_b, V4436, reg24241, V4437, V4438)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-compile", value: __defun__shen_4type_1signature_1of_1compile})
 
-	__defun__shen_4type_1signature_1of_1cons_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1cons_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4426 := __args[0]
 		_ = V4426
 		V4427 := __args[1]
 		_ = V4427
 		V4428 := __args[2]
 		_ = V4428
-		reg24243 := __e.Call(__defun__shen_4newpv, V4427)
+		reg24243 := Call(__e, __defun__shen_4newpv, V4427)
 		A := reg24243
 		_ = A
-		reg24244 := __e.Call(__defun__shen_4incinfs)
+		reg24244 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24244
 		reg24245 := MakeSymbol("-->")
 		reg24246 := MakeSymbol("boolean")
@@ -892,25 +892,25 @@ func init() {
 		reg24248 := PrimCons(reg24246, reg24247)
 		reg24249 := PrimCons(reg24245, reg24248)
 		reg24250 := PrimCons(A, reg24249)
-		__ctx.TailApply(__defun__unify_b, V4426, reg24250, V4427, V4428)
+		__e.TailApply(__defun__unify_b, V4426, reg24250, V4427, V4428)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-cons?", value: __defun__shen_4type_1signature_1of_1cons_2})
 
-	__defun__shen_4type_1signature_1of_1destroy = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1destroy = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4416 := __args[0]
 		_ = V4416
 		V4417 := __args[1]
 		_ = V4417
 		V4418 := __args[2]
 		_ = V4418
-		reg24252 := __e.Call(__defun__shen_4newpv, V4417)
+		reg24252 := Call(__e, __defun__shen_4newpv, V4417)
 		A := reg24252
 		_ = A
-		reg24253 := __e.Call(__defun__shen_4newpv, V4417)
+		reg24253 := Call(__e, __defun__shen_4newpv, V4417)
 		B := reg24253
 		_ = B
-		reg24254 := __e.Call(__defun__shen_4incinfs)
+		reg24254 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24254
 		reg24255 := MakeSymbol("-->")
 		reg24256 := Nil
@@ -923,22 +923,22 @@ func init() {
 		reg24263 := PrimCons(reg24261, reg24262)
 		reg24264 := PrimCons(reg24260, reg24263)
 		reg24265 := PrimCons(reg24259, reg24264)
-		__ctx.TailApply(__defun__unify_b, V4416, reg24265, V4417, V4418)
+		__e.TailApply(__defun__unify_b, V4416, reg24265, V4417, V4418)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-destroy", value: __defun__shen_4type_1signature_1of_1destroy})
 
-	__defun__shen_4type_1signature_1of_1difference = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1difference = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4406 := __args[0]
 		_ = V4406
 		V4407 := __args[1]
 		_ = V4407
 		V4408 := __args[2]
 		_ = V4408
-		reg24267 := __e.Call(__defun__shen_4newpv, V4407)
+		reg24267 := Call(__e, __defun__shen_4newpv, V4407)
 		A := reg24267
 		_ = A
-		reg24268 := __e.Call(__defun__shen_4incinfs)
+		reg24268 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24268
 		reg24269 := MakeSymbol("list")
 		reg24270 := Nil
@@ -962,25 +962,25 @@ func init() {
 		reg24288 := PrimCons(reg24286, reg24287)
 		reg24289 := PrimCons(reg24273, reg24288)
 		reg24290 := PrimCons(reg24272, reg24289)
-		__ctx.TailApply(__defun__unify_b, V4406, reg24290, V4407, V4408)
+		__e.TailApply(__defun__unify_b, V4406, reg24290, V4407, V4408)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-difference", value: __defun__shen_4type_1signature_1of_1difference})
 
-	__defun__shen_4type_1signature_1of_1do = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1do = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4396 := __args[0]
 		_ = V4396
 		V4397 := __args[1]
 		_ = V4397
 		V4398 := __args[2]
 		_ = V4398
-		reg24292 := __e.Call(__defun__shen_4newpv, V4397)
+		reg24292 := Call(__e, __defun__shen_4newpv, V4397)
 		A := reg24292
 		_ = A
-		reg24293 := __e.Call(__defun__shen_4newpv, V4397)
+		reg24293 := Call(__e, __defun__shen_4newpv, V4397)
 		B := reg24293
 		_ = B
-		reg24294 := __e.Call(__defun__shen_4incinfs)
+		reg24294 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24294
 		reg24295 := MakeSymbol("-->")
 		reg24296 := MakeSymbol("-->")
@@ -992,25 +992,25 @@ func init() {
 		reg24302 := PrimCons(reg24300, reg24301)
 		reg24303 := PrimCons(reg24295, reg24302)
 		reg24304 := PrimCons(A, reg24303)
-		__ctx.TailApply(__defun__unify_b, V4396, reg24304, V4397, V4398)
+		__e.TailApply(__defun__unify_b, V4396, reg24304, V4397, V4398)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-do", value: __defun__shen_4type_1signature_1of_1do})
 
-	__defun__shen_4type_1signature_1of_1_5e_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_5e_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4386 := __args[0]
 		_ = V4386
 		V4387 := __args[1]
 		_ = V4387
 		V4388 := __args[2]
 		_ = V4388
-		reg24306 := __e.Call(__defun__shen_4newpv, V4387)
+		reg24306 := Call(__e, __defun__shen_4newpv, V4387)
 		A := reg24306
 		_ = A
-		reg24307 := __e.Call(__defun__shen_4newpv, V4387)
+		reg24307 := Call(__e, __defun__shen_4newpv, V4387)
 		B := reg24307
 		_ = B
-		reg24308 := __e.Call(__defun__shen_4incinfs)
+		reg24308 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24308
 		reg24309 := MakeSymbol("list")
 		reg24310 := Nil
@@ -1025,22 +1025,22 @@ func init() {
 		reg24319 := PrimCons(reg24317, reg24318)
 		reg24320 := PrimCons(reg24313, reg24319)
 		reg24321 := PrimCons(reg24312, reg24320)
-		__ctx.TailApply(__defun__unify_b, V4386, reg24321, V4387, V4388)
+		__e.TailApply(__defun__unify_b, V4386, reg24321, V4387, V4388)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-<e>", value: __defun__shen_4type_1signature_1of_1_5e_6})
 
-	__defun__shen_4type_1signature_1of_1_5_b_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_5_b_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4376 := __args[0]
 		_ = V4376
 		V4377 := __args[1]
 		_ = V4377
 		V4378 := __args[2]
 		_ = V4378
-		reg24323 := __e.Call(__defun__shen_4newpv, V4377)
+		reg24323 := Call(__e, __defun__shen_4newpv, V4377)
 		A := reg24323
 		_ = A
-		reg24324 := __e.Call(__defun__shen_4incinfs)
+		reg24324 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24324
 		reg24325 := MakeSymbol("list")
 		reg24326 := Nil
@@ -1055,22 +1055,22 @@ func init() {
 		reg24335 := PrimCons(reg24333, reg24334)
 		reg24336 := PrimCons(reg24329, reg24335)
 		reg24337 := PrimCons(reg24328, reg24336)
-		__ctx.TailApply(__defun__unify_b, V4376, reg24337, V4377, V4378)
+		__e.TailApply(__defun__unify_b, V4376, reg24337, V4377, V4378)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-<!>", value: __defun__shen_4type_1signature_1of_1_5_b_6})
 
-	__defun__shen_4type_1signature_1of_1element_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1element_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4366 := __args[0]
 		_ = V4366
 		V4367 := __args[1]
 		_ = V4367
 		V4368 := __args[2]
 		_ = V4368
-		reg24339 := __e.Call(__defun__shen_4newpv, V4367)
+		reg24339 := Call(__e, __defun__shen_4newpv, V4367)
 		A := reg24339
 		_ = A
-		reg24340 := __e.Call(__defun__shen_4incinfs)
+		reg24340 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24340
 		reg24341 := MakeSymbol("-->")
 		reg24342 := MakeSymbol("list")
@@ -1087,22 +1087,22 @@ func init() {
 		reg24353 := PrimCons(reg24351, reg24352)
 		reg24354 := PrimCons(reg24341, reg24353)
 		reg24355 := PrimCons(A, reg24354)
-		__ctx.TailApply(__defun__unify_b, V4366, reg24355, V4367, V4368)
+		__e.TailApply(__defun__unify_b, V4366, reg24355, V4367, V4368)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-element?", value: __defun__shen_4type_1signature_1of_1element_2})
 
-	__defun__shen_4type_1signature_1of_1empty_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1empty_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4356 := __args[0]
 		_ = V4356
 		V4357 := __args[1]
 		_ = V4357
 		V4358 := __args[2]
 		_ = V4358
-		reg24357 := __e.Call(__defun__shen_4newpv, V4357)
+		reg24357 := Call(__e, __defun__shen_4newpv, V4357)
 		A := reg24357
 		_ = A
-		reg24358 := __e.Call(__defun__shen_4incinfs)
+		reg24358 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24358
 		reg24359 := MakeSymbol("-->")
 		reg24360 := MakeSymbol("boolean")
@@ -1110,19 +1110,19 @@ func init() {
 		reg24362 := PrimCons(reg24360, reg24361)
 		reg24363 := PrimCons(reg24359, reg24362)
 		reg24364 := PrimCons(A, reg24363)
-		__ctx.TailApply(__defun__unify_b, V4356, reg24364, V4357, V4358)
+		__e.TailApply(__defun__unify_b, V4356, reg24364, V4357, V4358)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-empty?", value: __defun__shen_4type_1signature_1of_1empty_2})
 
-	__defun__shen_4type_1signature_1of_1enable_1type_1theory = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1enable_1type_1theory = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4346 := __args[0]
 		_ = V4346
 		V4347 := __args[1]
 		_ = V4347
 		V4348 := __args[2]
 		_ = V4348
-		reg24366 := __e.Call(__defun__shen_4incinfs)
+		reg24366 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24366
 		reg24367 := MakeSymbol("symbol")
 		reg24368 := MakeSymbol("-->")
@@ -1131,19 +1131,19 @@ func init() {
 		reg24371 := PrimCons(reg24369, reg24370)
 		reg24372 := PrimCons(reg24368, reg24371)
 		reg24373 := PrimCons(reg24367, reg24372)
-		__ctx.TailApply(__defun__unify_b, V4346, reg24373, V4347, V4348)
+		__e.TailApply(__defun__unify_b, V4346, reg24373, V4347, V4348)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-enable-type-theory", value: __defun__shen_4type_1signature_1of_1enable_1type_1theory})
 
-	__defun__shen_4type_1signature_1of_1external = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1external = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4336 := __args[0]
 		_ = V4336
 		V4337 := __args[1]
 		_ = V4337
 		V4338 := __args[2]
 		_ = V4338
-		reg24375 := __e.Call(__defun__shen_4incinfs)
+		reg24375 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24375
 		reg24376 := MakeSymbol("symbol")
 		reg24377 := MakeSymbol("-->")
@@ -1156,19 +1156,19 @@ func init() {
 		reg24384 := PrimCons(reg24382, reg24383)
 		reg24385 := PrimCons(reg24377, reg24384)
 		reg24386 := PrimCons(reg24376, reg24385)
-		__ctx.TailApply(__defun__unify_b, V4336, reg24386, V4337, V4338)
+		__e.TailApply(__defun__unify_b, V4336, reg24386, V4337, V4338)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-external", value: __defun__shen_4type_1signature_1of_1external})
 
-	__defun__shen_4type_1signature_1of_1error_1to_1string = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1error_1to_1string = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4326 := __args[0]
 		_ = V4326
 		V4327 := __args[1]
 		_ = V4327
 		V4328 := __args[2]
 		_ = V4328
-		reg24388 := __e.Call(__defun__shen_4incinfs)
+		reg24388 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24388
 		reg24389 := MakeSymbol("exception")
 		reg24390 := MakeSymbol("-->")
@@ -1177,22 +1177,22 @@ func init() {
 		reg24393 := PrimCons(reg24391, reg24392)
 		reg24394 := PrimCons(reg24390, reg24393)
 		reg24395 := PrimCons(reg24389, reg24394)
-		__ctx.TailApply(__defun__unify_b, V4326, reg24395, V4327, V4328)
+		__e.TailApply(__defun__unify_b, V4326, reg24395, V4327, V4328)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-error-to-string", value: __defun__shen_4type_1signature_1of_1error_1to_1string})
 
-	__defun__shen_4type_1signature_1of_1explode = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1explode = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4316 := __args[0]
 		_ = V4316
 		V4317 := __args[1]
 		_ = V4317
 		V4318 := __args[2]
 		_ = V4318
-		reg24397 := __e.Call(__defun__shen_4newpv, V4317)
+		reg24397 := Call(__e, __defun__shen_4newpv, V4317)
 		A := reg24397
 		_ = A
-		reg24398 := __e.Call(__defun__shen_4incinfs)
+		reg24398 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24398
 		reg24399 := MakeSymbol("-->")
 		reg24400 := MakeSymbol("list")
@@ -1204,38 +1204,38 @@ func init() {
 		reg24406 := PrimCons(reg24404, reg24405)
 		reg24407 := PrimCons(reg24399, reg24406)
 		reg24408 := PrimCons(A, reg24407)
-		__ctx.TailApply(__defun__unify_b, V4316, reg24408, V4317, V4318)
+		__e.TailApply(__defun__unify_b, V4316, reg24408, V4317, V4318)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-explode", value: __defun__shen_4type_1signature_1of_1explode})
 
-	__defun__shen_4type_1signature_1of_1fail = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1fail = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4306 := __args[0]
 		_ = V4306
 		V4307 := __args[1]
 		_ = V4307
 		V4308 := __args[2]
 		_ = V4308
-		reg24410 := __e.Call(__defun__shen_4incinfs)
+		reg24410 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24410
 		reg24411 := MakeSymbol("-->")
 		reg24412 := MakeSymbol("symbol")
 		reg24413 := Nil
 		reg24414 := PrimCons(reg24412, reg24413)
 		reg24415 := PrimCons(reg24411, reg24414)
-		__ctx.TailApply(__defun__unify_b, V4306, reg24415, V4307, V4308)
+		__e.TailApply(__defun__unify_b, V4306, reg24415, V4307, V4308)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-fail", value: __defun__shen_4type_1signature_1of_1fail})
 
-	__defun__shen_4type_1signature_1of_1fail_1if = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1fail_1if = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4296 := __args[0]
 		_ = V4296
 		V4297 := __args[1]
 		_ = V4297
 		V4298 := __args[2]
 		_ = V4298
-		reg24417 := __e.Call(__defun__shen_4incinfs)
+		reg24417 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24417
 		reg24418 := MakeSymbol("symbol")
 		reg24419 := MakeSymbol("-->")
@@ -1256,22 +1256,22 @@ func init() {
 		reg24434 := PrimCons(reg24432, reg24433)
 		reg24435 := PrimCons(reg24425, reg24434)
 		reg24436 := PrimCons(reg24424, reg24435)
-		__ctx.TailApply(__defun__unify_b, V4296, reg24436, V4297, V4298)
+		__e.TailApply(__defun__unify_b, V4296, reg24436, V4297, V4298)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-fail-if", value: __defun__shen_4type_1signature_1of_1fail_1if})
 
-	__defun__shen_4type_1signature_1of_1fix = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1fix = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4286 := __args[0]
 		_ = V4286
 		V4287 := __args[1]
 		_ = V4287
 		V4288 := __args[2]
 		_ = V4288
-		reg24438 := __e.Call(__defun__shen_4newpv, V4287)
+		reg24438 := Call(__e, __defun__shen_4newpv, V4287)
 		A := reg24438
 		_ = A
-		reg24439 := __e.Call(__defun__shen_4incinfs)
+		reg24439 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24439
 		reg24440 := MakeSymbol("-->")
 		reg24441 := Nil
@@ -1288,22 +1288,22 @@ func init() {
 		reg24452 := PrimCons(reg24450, reg24451)
 		reg24453 := PrimCons(reg24445, reg24452)
 		reg24454 := PrimCons(reg24444, reg24453)
-		__ctx.TailApply(__defun__unify_b, V4286, reg24454, V4287, V4288)
+		__e.TailApply(__defun__unify_b, V4286, reg24454, V4287, V4288)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-fix", value: __defun__shen_4type_1signature_1of_1fix})
 
-	__defun__shen_4type_1signature_1of_1freeze = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1freeze = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4276 := __args[0]
 		_ = V4276
 		V4277 := __args[1]
 		_ = V4277
 		V4278 := __args[2]
 		_ = V4278
-		reg24456 := __e.Call(__defun__shen_4newpv, V4277)
+		reg24456 := Call(__e, __defun__shen_4newpv, V4277)
 		A := reg24456
 		_ = A
-		reg24457 := __e.Call(__defun__shen_4incinfs)
+		reg24457 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24457
 		reg24458 := MakeSymbol("-->")
 		reg24459 := MakeSymbol("lazy")
@@ -1314,25 +1314,25 @@ func init() {
 		reg24464 := PrimCons(reg24462, reg24463)
 		reg24465 := PrimCons(reg24458, reg24464)
 		reg24466 := PrimCons(A, reg24465)
-		__ctx.TailApply(__defun__unify_b, V4276, reg24466, V4277, V4278)
+		__e.TailApply(__defun__unify_b, V4276, reg24466, V4277, V4278)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-freeze", value: __defun__shen_4type_1signature_1of_1freeze})
 
-	__defun__shen_4type_1signature_1of_1fst = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1fst = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4266 := __args[0]
 		_ = V4266
 		V4267 := __args[1]
 		_ = V4267
 		V4268 := __args[2]
 		_ = V4268
-		reg24468 := __e.Call(__defun__shen_4newpv, V4267)
+		reg24468 := Call(__e, __defun__shen_4newpv, V4267)
 		B := reg24468
 		_ = B
-		reg24469 := __e.Call(__defun__shen_4newpv, V4267)
+		reg24469 := Call(__e, __defun__shen_4newpv, V4267)
 		A := reg24469
 		_ = A
-		reg24470 := __e.Call(__defun__shen_4incinfs)
+		reg24470 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24470
 		reg24471 := MakeSymbol("*")
 		reg24472 := Nil
@@ -1344,25 +1344,25 @@ func init() {
 		reg24478 := PrimCons(A, reg24477)
 		reg24479 := PrimCons(reg24476, reg24478)
 		reg24480 := PrimCons(reg24475, reg24479)
-		__ctx.TailApply(__defun__unify_b, V4266, reg24480, V4267, V4268)
+		__e.TailApply(__defun__unify_b, V4266, reg24480, V4267, V4268)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-fst", value: __defun__shen_4type_1signature_1of_1fst})
 
-	__defun__shen_4type_1signature_1of_1function = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1function = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4256 := __args[0]
 		_ = V4256
 		V4257 := __args[1]
 		_ = V4257
 		V4258 := __args[2]
 		_ = V4258
-		reg24482 := __e.Call(__defun__shen_4newpv, V4257)
+		reg24482 := Call(__e, __defun__shen_4newpv, V4257)
 		A := reg24482
 		_ = A
-		reg24483 := __e.Call(__defun__shen_4newpv, V4257)
+		reg24483 := Call(__e, __defun__shen_4newpv, V4257)
 		B := reg24483
 		_ = B
-		reg24484 := __e.Call(__defun__shen_4incinfs)
+		reg24484 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24484
 		reg24485 := MakeSymbol("-->")
 		reg24486 := Nil
@@ -1379,19 +1379,19 @@ func init() {
 		reg24497 := PrimCons(reg24495, reg24496)
 		reg24498 := PrimCons(reg24490, reg24497)
 		reg24499 := PrimCons(reg24489, reg24498)
-		__ctx.TailApply(__defun__unify_b, V4256, reg24499, V4257, V4258)
+		__e.TailApply(__defun__unify_b, V4256, reg24499, V4257, V4258)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-function", value: __defun__shen_4type_1signature_1of_1function})
 
-	__defun__shen_4type_1signature_1of_1gensym = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1gensym = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4246 := __args[0]
 		_ = V4246
 		V4247 := __args[1]
 		_ = V4247
 		V4248 := __args[2]
 		_ = V4248
-		reg24501 := __e.Call(__defun__shen_4incinfs)
+		reg24501 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24501
 		reg24502 := MakeSymbol("symbol")
 		reg24503 := MakeSymbol("-->")
@@ -1400,22 +1400,22 @@ func init() {
 		reg24506 := PrimCons(reg24504, reg24505)
 		reg24507 := PrimCons(reg24503, reg24506)
 		reg24508 := PrimCons(reg24502, reg24507)
-		__ctx.TailApply(__defun__unify_b, V4246, reg24508, V4247, V4248)
+		__e.TailApply(__defun__unify_b, V4246, reg24508, V4247, V4248)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-gensym", value: __defun__shen_4type_1signature_1of_1gensym})
 
-	__defun__shen_4type_1signature_1of_1_5_1vector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_5_1vector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4236 := __args[0]
 		_ = V4236
 		V4237 := __args[1]
 		_ = V4237
 		V4238 := __args[2]
 		_ = V4238
-		reg24510 := __e.Call(__defun__shen_4newpv, V4237)
+		reg24510 := Call(__e, __defun__shen_4newpv, V4237)
 		A := reg24510
 		_ = A
-		reg24511 := __e.Call(__defun__shen_4incinfs)
+		reg24511 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24511
 		reg24512 := MakeSymbol("vector")
 		reg24513 := Nil
@@ -1432,22 +1432,22 @@ func init() {
 		reg24524 := PrimCons(reg24522, reg24523)
 		reg24525 := PrimCons(reg24516, reg24524)
 		reg24526 := PrimCons(reg24515, reg24525)
-		__ctx.TailApply(__defun__unify_b, V4236, reg24526, V4237, V4238)
+		__e.TailApply(__defun__unify_b, V4236, reg24526, V4237, V4238)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-<-vector", value: __defun__shen_4type_1signature_1of_1_5_1vector})
 
-	__defun__shen_4type_1signature_1of_1vector_1_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1vector_1_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4226 := __args[0]
 		_ = V4226
 		V4227 := __args[1]
 		_ = V4227
 		V4228 := __args[2]
 		_ = V4228
-		reg24528 := __e.Call(__defun__shen_4newpv, V4227)
+		reg24528 := Call(__e, __defun__shen_4newpv, V4227)
 		A := reg24528
 		_ = A
-		reg24529 := __e.Call(__defun__shen_4incinfs)
+		reg24529 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24529
 		reg24530 := MakeSymbol("vector")
 		reg24531 := Nil
@@ -1473,22 +1473,22 @@ func init() {
 		reg24551 := PrimCons(reg24549, reg24550)
 		reg24552 := PrimCons(reg24534, reg24551)
 		reg24553 := PrimCons(reg24533, reg24552)
-		__ctx.TailApply(__defun__unify_b, V4226, reg24553, V4227, V4228)
+		__e.TailApply(__defun__unify_b, V4226, reg24553, V4227, V4228)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-vector->", value: __defun__shen_4type_1signature_1of_1vector_1_6})
 
-	__defun__shen_4type_1signature_1of_1vector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1vector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4216 := __args[0]
 		_ = V4216
 		V4217 := __args[1]
 		_ = V4217
 		V4218 := __args[2]
 		_ = V4218
-		reg24555 := __e.Call(__defun__shen_4newpv, V4217)
+		reg24555 := Call(__e, __defun__shen_4newpv, V4217)
 		A := reg24555
 		_ = A
-		reg24556 := __e.Call(__defun__shen_4incinfs)
+		reg24556 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24556
 		reg24557 := MakeSymbol("number")
 		reg24558 := MakeSymbol("-->")
@@ -1500,19 +1500,19 @@ func init() {
 		reg24564 := PrimCons(reg24562, reg24563)
 		reg24565 := PrimCons(reg24558, reg24564)
 		reg24566 := PrimCons(reg24557, reg24565)
-		__ctx.TailApply(__defun__unify_b, V4216, reg24566, V4217, V4218)
+		__e.TailApply(__defun__unify_b, V4216, reg24566, V4217, V4218)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-vector", value: __defun__shen_4type_1signature_1of_1vector})
 
-	__defun__shen_4type_1signature_1of_1get_1time = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1get_1time = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4206 := __args[0]
 		_ = V4206
 		V4207 := __args[1]
 		_ = V4207
 		V4208 := __args[2]
 		_ = V4208
-		reg24568 := __e.Call(__defun__shen_4incinfs)
+		reg24568 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24568
 		reg24569 := MakeSymbol("symbol")
 		reg24570 := MakeSymbol("-->")
@@ -1521,22 +1521,22 @@ func init() {
 		reg24573 := PrimCons(reg24571, reg24572)
 		reg24574 := PrimCons(reg24570, reg24573)
 		reg24575 := PrimCons(reg24569, reg24574)
-		__ctx.TailApply(__defun__unify_b, V4206, reg24575, V4207, V4208)
+		__e.TailApply(__defun__unify_b, V4206, reg24575, V4207, V4208)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-get-time", value: __defun__shen_4type_1signature_1of_1get_1time})
 
-	__defun__shen_4type_1signature_1of_1hash = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1hash = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4196 := __args[0]
 		_ = V4196
 		V4197 := __args[1]
 		_ = V4197
 		V4198 := __args[2]
 		_ = V4198
-		reg24577 := __e.Call(__defun__shen_4newpv, V4197)
+		reg24577 := Call(__e, __defun__shen_4newpv, V4197)
 		A := reg24577
 		_ = A
-		reg24578 := __e.Call(__defun__shen_4incinfs)
+		reg24578 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24578
 		reg24579 := MakeSymbol("-->")
 		reg24580 := MakeSymbol("number")
@@ -1550,22 +1550,22 @@ func init() {
 		reg24588 := PrimCons(reg24586, reg24587)
 		reg24589 := PrimCons(reg24579, reg24588)
 		reg24590 := PrimCons(A, reg24589)
-		__ctx.TailApply(__defun__unify_b, V4196, reg24590, V4197, V4198)
+		__e.TailApply(__defun__unify_b, V4196, reg24590, V4197, V4198)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-hash", value: __defun__shen_4type_1signature_1of_1hash})
 
-	__defun__shen_4type_1signature_1of_1head = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1head = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4186 := __args[0]
 		_ = V4186
 		V4187 := __args[1]
 		_ = V4187
 		V4188 := __args[2]
 		_ = V4188
-		reg24592 := __e.Call(__defun__shen_4newpv, V4187)
+		reg24592 := Call(__e, __defun__shen_4newpv, V4187)
 		A := reg24592
 		_ = A
-		reg24593 := __e.Call(__defun__shen_4incinfs)
+		reg24593 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24593
 		reg24594 := MakeSymbol("list")
 		reg24595 := Nil
@@ -1576,22 +1576,22 @@ func init() {
 		reg24600 := PrimCons(A, reg24599)
 		reg24601 := PrimCons(reg24598, reg24600)
 		reg24602 := PrimCons(reg24597, reg24601)
-		__ctx.TailApply(__defun__unify_b, V4186, reg24602, V4187, V4188)
+		__e.TailApply(__defun__unify_b, V4186, reg24602, V4187, V4188)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-head", value: __defun__shen_4type_1signature_1of_1head})
 
-	__defun__shen_4type_1signature_1of_1hdv = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1hdv = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4176 := __args[0]
 		_ = V4176
 		V4177 := __args[1]
 		_ = V4177
 		V4178 := __args[2]
 		_ = V4178
-		reg24604 := __e.Call(__defun__shen_4newpv, V4177)
+		reg24604 := Call(__e, __defun__shen_4newpv, V4177)
 		A := reg24604
 		_ = A
-		reg24605 := __e.Call(__defun__shen_4incinfs)
+		reg24605 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24605
 		reg24606 := MakeSymbol("vector")
 		reg24607 := Nil
@@ -1602,19 +1602,19 @@ func init() {
 		reg24612 := PrimCons(A, reg24611)
 		reg24613 := PrimCons(reg24610, reg24612)
 		reg24614 := PrimCons(reg24609, reg24613)
-		__ctx.TailApply(__defun__unify_b, V4176, reg24614, V4177, V4178)
+		__e.TailApply(__defun__unify_b, V4176, reg24614, V4177, V4178)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-hdv", value: __defun__shen_4type_1signature_1of_1hdv})
 
-	__defun__shen_4type_1signature_1of_1hdstr = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1hdstr = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4166 := __args[0]
 		_ = V4166
 		V4167 := __args[1]
 		_ = V4167
 		V4168 := __args[2]
 		_ = V4168
-		reg24616 := __e.Call(__defun__shen_4incinfs)
+		reg24616 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24616
 		reg24617 := MakeSymbol("string")
 		reg24618 := MakeSymbol("-->")
@@ -1623,22 +1623,22 @@ func init() {
 		reg24621 := PrimCons(reg24619, reg24620)
 		reg24622 := PrimCons(reg24618, reg24621)
 		reg24623 := PrimCons(reg24617, reg24622)
-		__ctx.TailApply(__defun__unify_b, V4166, reg24623, V4167, V4168)
+		__e.TailApply(__defun__unify_b, V4166, reg24623, V4167, V4168)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-hdstr", value: __defun__shen_4type_1signature_1of_1hdstr})
 
-	__defun__shen_4type_1signature_1of_1if = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1if = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4156 := __args[0]
 		_ = V4156
 		V4157 := __args[1]
 		_ = V4157
 		V4158 := __args[2]
 		_ = V4158
-		reg24625 := __e.Call(__defun__shen_4newpv, V4157)
+		reg24625 := Call(__e, __defun__shen_4newpv, V4157)
 		A := reg24625
 		_ = A
-		reg24626 := __e.Call(__defun__shen_4incinfs)
+		reg24626 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24626
 		reg24627 := MakeSymbol("boolean")
 		reg24628 := MakeSymbol("-->")
@@ -1656,57 +1656,57 @@ func init() {
 		reg24640 := PrimCons(reg24638, reg24639)
 		reg24641 := PrimCons(reg24628, reg24640)
 		reg24642 := PrimCons(reg24627, reg24641)
-		__ctx.TailApply(__defun__unify_b, V4156, reg24642, V4157, V4158)
+		__e.TailApply(__defun__unify_b, V4156, reg24642, V4157, V4158)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-if", value: __defun__shen_4type_1signature_1of_1if})
 
-	__defun__shen_4type_1signature_1of_1it = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1it = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4146 := __args[0]
 		_ = V4146
 		V4147 := __args[1]
 		_ = V4147
 		V4148 := __args[2]
 		_ = V4148
-		reg24644 := __e.Call(__defun__shen_4incinfs)
+		reg24644 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24644
 		reg24645 := MakeSymbol("-->")
 		reg24646 := MakeSymbol("string")
 		reg24647 := Nil
 		reg24648 := PrimCons(reg24646, reg24647)
 		reg24649 := PrimCons(reg24645, reg24648)
-		__ctx.TailApply(__defun__unify_b, V4146, reg24649, V4147, V4148)
+		__e.TailApply(__defun__unify_b, V4146, reg24649, V4147, V4148)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-it", value: __defun__shen_4type_1signature_1of_1it})
 
-	__defun__shen_4type_1signature_1of_1implementation = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1implementation = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4136 := __args[0]
 		_ = V4136
 		V4137 := __args[1]
 		_ = V4137
 		V4138 := __args[2]
 		_ = V4138
-		reg24651 := __e.Call(__defun__shen_4incinfs)
+		reg24651 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24651
 		reg24652 := MakeSymbol("-->")
 		reg24653 := MakeSymbol("string")
 		reg24654 := Nil
 		reg24655 := PrimCons(reg24653, reg24654)
 		reg24656 := PrimCons(reg24652, reg24655)
-		__ctx.TailApply(__defun__unify_b, V4136, reg24656, V4137, V4138)
+		__e.TailApply(__defun__unify_b, V4136, reg24656, V4137, V4138)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-implementation", value: __defun__shen_4type_1signature_1of_1implementation})
 
-	__defun__shen_4type_1signature_1of_1include = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1include = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4126 := __args[0]
 		_ = V4126
 		V4127 := __args[1]
 		_ = V4127
 		V4128 := __args[2]
 		_ = V4128
-		reg24658 := __e.Call(__defun__shen_4incinfs)
+		reg24658 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24658
 		reg24659 := MakeSymbol("list")
 		reg24660 := MakeSymbol("symbol")
@@ -1723,19 +1723,19 @@ func init() {
 		reg24671 := PrimCons(reg24669, reg24670)
 		reg24672 := PrimCons(reg24664, reg24671)
 		reg24673 := PrimCons(reg24663, reg24672)
-		__ctx.TailApply(__defun__unify_b, V4126, reg24673, V4127, V4128)
+		__e.TailApply(__defun__unify_b, V4126, reg24673, V4127, V4128)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-include", value: __defun__shen_4type_1signature_1of_1include})
 
-	__defun__shen_4type_1signature_1of_1include_1all_1but = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1include_1all_1but = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4116 := __args[0]
 		_ = V4116
 		V4117 := __args[1]
 		_ = V4117
 		V4118 := __args[2]
 		_ = V4118
-		reg24675 := __e.Call(__defun__shen_4incinfs)
+		reg24675 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24675
 		reg24676 := MakeSymbol("list")
 		reg24677 := MakeSymbol("symbol")
@@ -1752,41 +1752,41 @@ func init() {
 		reg24688 := PrimCons(reg24686, reg24687)
 		reg24689 := PrimCons(reg24681, reg24688)
 		reg24690 := PrimCons(reg24680, reg24689)
-		__ctx.TailApply(__defun__unify_b, V4116, reg24690, V4117, V4118)
+		__e.TailApply(__defun__unify_b, V4116, reg24690, V4117, V4118)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-include-all-but", value: __defun__shen_4type_1signature_1of_1include_1all_1but})
 
-	__defun__shen_4type_1signature_1of_1inferences = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1inferences = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4106 := __args[0]
 		_ = V4106
 		V4107 := __args[1]
 		_ = V4107
 		V4108 := __args[2]
 		_ = V4108
-		reg24692 := __e.Call(__defun__shen_4incinfs)
+		reg24692 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24692
 		reg24693 := MakeSymbol("-->")
 		reg24694 := MakeSymbol("number")
 		reg24695 := Nil
 		reg24696 := PrimCons(reg24694, reg24695)
 		reg24697 := PrimCons(reg24693, reg24696)
-		__ctx.TailApply(__defun__unify_b, V4106, reg24697, V4107, V4108)
+		__e.TailApply(__defun__unify_b, V4106, reg24697, V4107, V4108)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-inferences", value: __defun__shen_4type_1signature_1of_1inferences})
 
-	__defun__shen_4type_1signature_1of_1shen_4insert = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1shen_4insert = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4096 := __args[0]
 		_ = V4096
 		V4097 := __args[1]
 		_ = V4097
 		V4098 := __args[2]
 		_ = V4098
-		reg24699 := __e.Call(__defun__shen_4newpv, V4097)
+		reg24699 := Call(__e, __defun__shen_4newpv, V4097)
 		A := reg24699
 		_ = A
-		reg24700 := __e.Call(__defun__shen_4incinfs)
+		reg24700 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24700
 		reg24701 := MakeSymbol("-->")
 		reg24702 := MakeSymbol("string")
@@ -1800,22 +1800,22 @@ func init() {
 		reg24710 := PrimCons(reg24708, reg24709)
 		reg24711 := PrimCons(reg24701, reg24710)
 		reg24712 := PrimCons(A, reg24711)
-		__ctx.TailApply(__defun__unify_b, V4096, reg24712, V4097, V4098)
+		__e.TailApply(__defun__unify_b, V4096, reg24712, V4097, V4098)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-shen.insert", value: __defun__shen_4type_1signature_1of_1shen_4insert})
 
-	__defun__shen_4type_1signature_1of_1integer_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1integer_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4086 := __args[0]
 		_ = V4086
 		V4087 := __args[1]
 		_ = V4087
 		V4088 := __args[2]
 		_ = V4088
-		reg24714 := __e.Call(__defun__shen_4newpv, V4087)
+		reg24714 := Call(__e, __defun__shen_4newpv, V4087)
 		A := reg24714
 		_ = A
-		reg24715 := __e.Call(__defun__shen_4incinfs)
+		reg24715 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24715
 		reg24716 := MakeSymbol("-->")
 		reg24717 := MakeSymbol("boolean")
@@ -1823,19 +1823,19 @@ func init() {
 		reg24719 := PrimCons(reg24717, reg24718)
 		reg24720 := PrimCons(reg24716, reg24719)
 		reg24721 := PrimCons(A, reg24720)
-		__ctx.TailApply(__defun__unify_b, V4086, reg24721, V4087, V4088)
+		__e.TailApply(__defun__unify_b, V4086, reg24721, V4087, V4088)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-integer?", value: __defun__shen_4type_1signature_1of_1integer_2})
 
-	__defun__shen_4type_1signature_1of_1internal = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1internal = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4076 := __args[0]
 		_ = V4076
 		V4077 := __args[1]
 		_ = V4077
 		V4078 := __args[2]
 		_ = V4078
-		reg24723 := __e.Call(__defun__shen_4incinfs)
+		reg24723 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24723
 		reg24724 := MakeSymbol("symbol")
 		reg24725 := MakeSymbol("-->")
@@ -1848,22 +1848,22 @@ func init() {
 		reg24732 := PrimCons(reg24730, reg24731)
 		reg24733 := PrimCons(reg24725, reg24732)
 		reg24734 := PrimCons(reg24724, reg24733)
-		__ctx.TailApply(__defun__unify_b, V4076, reg24734, V4077, V4078)
+		__e.TailApply(__defun__unify_b, V4076, reg24734, V4077, V4078)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-internal", value: __defun__shen_4type_1signature_1of_1internal})
 
-	__defun__shen_4type_1signature_1of_1intersection = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1intersection = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4066 := __args[0]
 		_ = V4066
 		V4067 := __args[1]
 		_ = V4067
 		V4068 := __args[2]
 		_ = V4068
-		reg24736 := __e.Call(__defun__shen_4newpv, V4067)
+		reg24736 := Call(__e, __defun__shen_4newpv, V4067)
 		A := reg24736
 		_ = A
-		reg24737 := __e.Call(__defun__shen_4incinfs)
+		reg24737 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24737
 		reg24738 := MakeSymbol("list")
 		reg24739 := Nil
@@ -1887,62 +1887,62 @@ func init() {
 		reg24757 := PrimCons(reg24755, reg24756)
 		reg24758 := PrimCons(reg24742, reg24757)
 		reg24759 := PrimCons(reg24741, reg24758)
-		__ctx.TailApply(__defun__unify_b, V4066, reg24759, V4067, V4068)
+		__e.TailApply(__defun__unify_b, V4066, reg24759, V4067, V4068)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-intersection", value: __defun__shen_4type_1signature_1of_1intersection})
 
-	__defun__shen_4type_1signature_1of_1kill = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1kill = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4056 := __args[0]
 		_ = V4056
 		V4057 := __args[1]
 		_ = V4057
 		V4058 := __args[2]
 		_ = V4058
-		reg24761 := __e.Call(__defun__shen_4newpv, V4057)
+		reg24761 := Call(__e, __defun__shen_4newpv, V4057)
 		A := reg24761
 		_ = A
-		reg24762 := __e.Call(__defun__shen_4incinfs)
+		reg24762 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24762
 		reg24763 := MakeSymbol("-->")
 		reg24764 := Nil
 		reg24765 := PrimCons(A, reg24764)
 		reg24766 := PrimCons(reg24763, reg24765)
-		__ctx.TailApply(__defun__unify_b, V4056, reg24766, V4057, V4058)
+		__e.TailApply(__defun__unify_b, V4056, reg24766, V4057, V4058)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-kill", value: __defun__shen_4type_1signature_1of_1kill})
 
-	__defun__shen_4type_1signature_1of_1language = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1language = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4046 := __args[0]
 		_ = V4046
 		V4047 := __args[1]
 		_ = V4047
 		V4048 := __args[2]
 		_ = V4048
-		reg24768 := __e.Call(__defun__shen_4incinfs)
+		reg24768 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24768
 		reg24769 := MakeSymbol("-->")
 		reg24770 := MakeSymbol("string")
 		reg24771 := Nil
 		reg24772 := PrimCons(reg24770, reg24771)
 		reg24773 := PrimCons(reg24769, reg24772)
-		__ctx.TailApply(__defun__unify_b, V4046, reg24773, V4047, V4048)
+		__e.TailApply(__defun__unify_b, V4046, reg24773, V4047, V4048)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-language", value: __defun__shen_4type_1signature_1of_1language})
 
-	__defun__shen_4type_1signature_1of_1length = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1length = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4036 := __args[0]
 		_ = V4036
 		V4037 := __args[1]
 		_ = V4037
 		V4038 := __args[2]
 		_ = V4038
-		reg24775 := __e.Call(__defun__shen_4newpv, V4037)
+		reg24775 := Call(__e, __defun__shen_4newpv, V4037)
 		A := reg24775
 		_ = A
-		reg24776 := __e.Call(__defun__shen_4incinfs)
+		reg24776 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24776
 		reg24777 := MakeSymbol("list")
 		reg24778 := Nil
@@ -1954,22 +1954,22 @@ func init() {
 		reg24784 := PrimCons(reg24782, reg24783)
 		reg24785 := PrimCons(reg24781, reg24784)
 		reg24786 := PrimCons(reg24780, reg24785)
-		__ctx.TailApply(__defun__unify_b, V4036, reg24786, V4037, V4038)
+		__e.TailApply(__defun__unify_b, V4036, reg24786, V4037, V4038)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-length", value: __defun__shen_4type_1signature_1of_1length})
 
-	__defun__shen_4type_1signature_1of_1limit = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1limit = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4026 := __args[0]
 		_ = V4026
 		V4027 := __args[1]
 		_ = V4027
 		V4028 := __args[2]
 		_ = V4028
-		reg24788 := __e.Call(__defun__shen_4newpv, V4027)
+		reg24788 := Call(__e, __defun__shen_4newpv, V4027)
 		A := reg24788
 		_ = A
-		reg24789 := __e.Call(__defun__shen_4incinfs)
+		reg24789 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24789
 		reg24790 := MakeSymbol("vector")
 		reg24791 := Nil
@@ -1981,19 +1981,19 @@ func init() {
 		reg24797 := PrimCons(reg24795, reg24796)
 		reg24798 := PrimCons(reg24794, reg24797)
 		reg24799 := PrimCons(reg24793, reg24798)
-		__ctx.TailApply(__defun__unify_b, V4026, reg24799, V4027, V4028)
+		__e.TailApply(__defun__unify_b, V4026, reg24799, V4027, V4028)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-limit", value: __defun__shen_4type_1signature_1of_1limit})
 
-	__defun__shen_4type_1signature_1of_1load = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1load = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4016 := __args[0]
 		_ = V4016
 		V4017 := __args[1]
 		_ = V4017
 		V4018 := __args[2]
 		_ = V4018
-		reg24801 := __e.Call(__defun__shen_4incinfs)
+		reg24801 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24801
 		reg24802 := MakeSymbol("string")
 		reg24803 := MakeSymbol("-->")
@@ -2002,25 +2002,25 @@ func init() {
 		reg24806 := PrimCons(reg24804, reg24805)
 		reg24807 := PrimCons(reg24803, reg24806)
 		reg24808 := PrimCons(reg24802, reg24807)
-		__ctx.TailApply(__defun__unify_b, V4016, reg24808, V4017, V4018)
+		__e.TailApply(__defun__unify_b, V4016, reg24808, V4017, V4018)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-load", value: __defun__shen_4type_1signature_1of_1load})
 
-	__defun__shen_4type_1signature_1of_1map = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1map = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4006 := __args[0]
 		_ = V4006
 		V4007 := __args[1]
 		_ = V4007
 		V4008 := __args[2]
 		_ = V4008
-		reg24810 := __e.Call(__defun__shen_4newpv, V4007)
+		reg24810 := Call(__e, __defun__shen_4newpv, V4007)
 		A := reg24810
 		_ = A
-		reg24811 := __e.Call(__defun__shen_4newpv, V4007)
+		reg24811 := Call(__e, __defun__shen_4newpv, V4007)
 		B := reg24811
 		_ = B
-		reg24812 := __e.Call(__defun__shen_4incinfs)
+		reg24812 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24812
 		reg24813 := MakeSymbol("-->")
 		reg24814 := Nil
@@ -2045,25 +2045,25 @@ func init() {
 		reg24833 := PrimCons(reg24831, reg24832)
 		reg24834 := PrimCons(reg24818, reg24833)
 		reg24835 := PrimCons(reg24817, reg24834)
-		__ctx.TailApply(__defun__unify_b, V4006, reg24835, V4007, V4008)
+		__e.TailApply(__defun__unify_b, V4006, reg24835, V4007, V4008)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-map", value: __defun__shen_4type_1signature_1of_1map})
 
-	__defun__shen_4type_1signature_1of_1mapcan = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1mapcan = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3996 := __args[0]
 		_ = V3996
 		V3997 := __args[1]
 		_ = V3997
 		V3998 := __args[2]
 		_ = V3998
-		reg24837 := __e.Call(__defun__shen_4newpv, V3997)
+		reg24837 := Call(__e, __defun__shen_4newpv, V3997)
 		A := reg24837
 		_ = A
-		reg24838 := __e.Call(__defun__shen_4newpv, V3997)
+		reg24838 := Call(__e, __defun__shen_4newpv, V3997)
 		B := reg24838
 		_ = B
-		reg24839 := __e.Call(__defun__shen_4incinfs)
+		reg24839 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24839
 		reg24840 := MakeSymbol("-->")
 		reg24841 := MakeSymbol("list")
@@ -2092,19 +2092,19 @@ func init() {
 		reg24864 := PrimCons(reg24862, reg24863)
 		reg24865 := PrimCons(reg24849, reg24864)
 		reg24866 := PrimCons(reg24848, reg24865)
-		__ctx.TailApply(__defun__unify_b, V3996, reg24866, V3997, V3998)
+		__e.TailApply(__defun__unify_b, V3996, reg24866, V3997, V3998)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-mapcan", value: __defun__shen_4type_1signature_1of_1mapcan})
 
-	__defun__shen_4type_1signature_1of_1maxinferences = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1maxinferences = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3986 := __args[0]
 		_ = V3986
 		V3987 := __args[1]
 		_ = V3987
 		V3988 := __args[2]
 		_ = V3988
-		reg24868 := __e.Call(__defun__shen_4incinfs)
+		reg24868 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24868
 		reg24869 := MakeSymbol("number")
 		reg24870 := MakeSymbol("-->")
@@ -2113,19 +2113,19 @@ func init() {
 		reg24873 := PrimCons(reg24871, reg24872)
 		reg24874 := PrimCons(reg24870, reg24873)
 		reg24875 := PrimCons(reg24869, reg24874)
-		__ctx.TailApply(__defun__unify_b, V3986, reg24875, V3987, V3988)
+		__e.TailApply(__defun__unify_b, V3986, reg24875, V3987, V3988)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-maxinferences", value: __defun__shen_4type_1signature_1of_1maxinferences})
 
-	__defun__shen_4type_1signature_1of_1n_1_6string = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1n_1_6string = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3976 := __args[0]
 		_ = V3976
 		V3977 := __args[1]
 		_ = V3977
 		V3978 := __args[2]
 		_ = V3978
-		reg24877 := __e.Call(__defun__shen_4incinfs)
+		reg24877 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24877
 		reg24878 := MakeSymbol("number")
 		reg24879 := MakeSymbol("-->")
@@ -2134,19 +2134,19 @@ func init() {
 		reg24882 := PrimCons(reg24880, reg24881)
 		reg24883 := PrimCons(reg24879, reg24882)
 		reg24884 := PrimCons(reg24878, reg24883)
-		__ctx.TailApply(__defun__unify_b, V3976, reg24884, V3977, V3978)
+		__e.TailApply(__defun__unify_b, V3976, reg24884, V3977, V3978)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-n->string", value: __defun__shen_4type_1signature_1of_1n_1_6string})
 
-	__defun__shen_4type_1signature_1of_1nl = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1nl = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3966 := __args[0]
 		_ = V3966
 		V3967 := __args[1]
 		_ = V3967
 		V3968 := __args[2]
 		_ = V3968
-		reg24886 := __e.Call(__defun__shen_4incinfs)
+		reg24886 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24886
 		reg24887 := MakeSymbol("number")
 		reg24888 := MakeSymbol("-->")
@@ -2155,19 +2155,19 @@ func init() {
 		reg24891 := PrimCons(reg24889, reg24890)
 		reg24892 := PrimCons(reg24888, reg24891)
 		reg24893 := PrimCons(reg24887, reg24892)
-		__ctx.TailApply(__defun__unify_b, V3966, reg24893, V3967, V3968)
+		__e.TailApply(__defun__unify_b, V3966, reg24893, V3967, V3968)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-nl", value: __defun__shen_4type_1signature_1of_1nl})
 
-	__defun__shen_4type_1signature_1of_1not = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1not = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3956 := __args[0]
 		_ = V3956
 		V3957 := __args[1]
 		_ = V3957
 		V3958 := __args[2]
 		_ = V3958
-		reg24895 := __e.Call(__defun__shen_4incinfs)
+		reg24895 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24895
 		reg24896 := MakeSymbol("boolean")
 		reg24897 := MakeSymbol("-->")
@@ -2176,22 +2176,22 @@ func init() {
 		reg24900 := PrimCons(reg24898, reg24899)
 		reg24901 := PrimCons(reg24897, reg24900)
 		reg24902 := PrimCons(reg24896, reg24901)
-		__ctx.TailApply(__defun__unify_b, V3956, reg24902, V3957, V3958)
+		__e.TailApply(__defun__unify_b, V3956, reg24902, V3957, V3958)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-not", value: __defun__shen_4type_1signature_1of_1not})
 
-	__defun__shen_4type_1signature_1of_1nth = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1nth = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3946 := __args[0]
 		_ = V3946
 		V3947 := __args[1]
 		_ = V3947
 		V3948 := __args[2]
 		_ = V3948
-		reg24904 := __e.Call(__defun__shen_4newpv, V3947)
+		reg24904 := Call(__e, __defun__shen_4newpv, V3947)
 		A := reg24904
 		_ = A
-		reg24905 := __e.Call(__defun__shen_4incinfs)
+		reg24905 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24905
 		reg24906 := MakeSymbol("number")
 		reg24907 := MakeSymbol("-->")
@@ -2208,22 +2208,22 @@ func init() {
 		reg24918 := PrimCons(reg24916, reg24917)
 		reg24919 := PrimCons(reg24907, reg24918)
 		reg24920 := PrimCons(reg24906, reg24919)
-		__ctx.TailApply(__defun__unify_b, V3946, reg24920, V3947, V3948)
+		__e.TailApply(__defun__unify_b, V3946, reg24920, V3947, V3948)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-nth", value: __defun__shen_4type_1signature_1of_1nth})
 
-	__defun__shen_4type_1signature_1of_1number_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1number_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3936 := __args[0]
 		_ = V3936
 		V3937 := __args[1]
 		_ = V3937
 		V3938 := __args[2]
 		_ = V3938
-		reg24922 := __e.Call(__defun__shen_4newpv, V3937)
+		reg24922 := Call(__e, __defun__shen_4newpv, V3937)
 		A := reg24922
 		_ = A
-		reg24923 := __e.Call(__defun__shen_4incinfs)
+		reg24923 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24923
 		reg24924 := MakeSymbol("-->")
 		reg24925 := MakeSymbol("boolean")
@@ -2231,25 +2231,25 @@ func init() {
 		reg24927 := PrimCons(reg24925, reg24926)
 		reg24928 := PrimCons(reg24924, reg24927)
 		reg24929 := PrimCons(A, reg24928)
-		__ctx.TailApply(__defun__unify_b, V3936, reg24929, V3937, V3938)
+		__e.TailApply(__defun__unify_b, V3936, reg24929, V3937, V3938)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-number?", value: __defun__shen_4type_1signature_1of_1number_2})
 
-	__defun__shen_4type_1signature_1of_1occurrences = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1occurrences = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3926 := __args[0]
 		_ = V3926
 		V3927 := __args[1]
 		_ = V3927
 		V3928 := __args[2]
 		_ = V3928
-		reg24931 := __e.Call(__defun__shen_4newpv, V3927)
+		reg24931 := Call(__e, __defun__shen_4newpv, V3927)
 		A := reg24931
 		_ = A
-		reg24932 := __e.Call(__defun__shen_4newpv, V3927)
+		reg24932 := Call(__e, __defun__shen_4newpv, V3927)
 		B := reg24932
 		_ = B
-		reg24933 := __e.Call(__defun__shen_4incinfs)
+		reg24933 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24933
 		reg24934 := MakeSymbol("-->")
 		reg24935 := MakeSymbol("-->")
@@ -2262,19 +2262,19 @@ func init() {
 		reg24942 := PrimCons(reg24940, reg24941)
 		reg24943 := PrimCons(reg24934, reg24942)
 		reg24944 := PrimCons(A, reg24943)
-		__ctx.TailApply(__defun__unify_b, V3926, reg24944, V3927, V3928)
+		__e.TailApply(__defun__unify_b, V3926, reg24944, V3927, V3928)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-occurrences", value: __defun__shen_4type_1signature_1of_1occurrences})
 
-	__defun__shen_4type_1signature_1of_1occurs_1check = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1occurs_1check = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3916 := __args[0]
 		_ = V3916
 		V3917 := __args[1]
 		_ = V3917
 		V3918 := __args[2]
 		_ = V3918
-		reg24946 := __e.Call(__defun__shen_4incinfs)
+		reg24946 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24946
 		reg24947 := MakeSymbol("symbol")
 		reg24948 := MakeSymbol("-->")
@@ -2283,19 +2283,19 @@ func init() {
 		reg24951 := PrimCons(reg24949, reg24950)
 		reg24952 := PrimCons(reg24948, reg24951)
 		reg24953 := PrimCons(reg24947, reg24952)
-		__ctx.TailApply(__defun__unify_b, V3916, reg24953, V3917, V3918)
+		__e.TailApply(__defun__unify_b, V3916, reg24953, V3917, V3918)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-occurs-check", value: __defun__shen_4type_1signature_1of_1occurs_1check})
 
-	__defun__shen_4type_1signature_1of_1optimise = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1optimise = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3906 := __args[0]
 		_ = V3906
 		V3907 := __args[1]
 		_ = V3907
 		V3908 := __args[2]
 		_ = V3908
-		reg24955 := __e.Call(__defun__shen_4incinfs)
+		reg24955 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24955
 		reg24956 := MakeSymbol("symbol")
 		reg24957 := MakeSymbol("-->")
@@ -2304,19 +2304,19 @@ func init() {
 		reg24960 := PrimCons(reg24958, reg24959)
 		reg24961 := PrimCons(reg24957, reg24960)
 		reg24962 := PrimCons(reg24956, reg24961)
-		__ctx.TailApply(__defun__unify_b, V3906, reg24962, V3907, V3908)
+		__e.TailApply(__defun__unify_b, V3906, reg24962, V3907, V3908)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-optimise", value: __defun__shen_4type_1signature_1of_1optimise})
 
-	__defun__shen_4type_1signature_1of_1or = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1or = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3896 := __args[0]
 		_ = V3896
 		V3897 := __args[1]
 		_ = V3897
 		V3898 := __args[2]
 		_ = V3898
-		reg24964 := __e.Call(__defun__shen_4incinfs)
+		reg24964 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24964
 		reg24965 := MakeSymbol("boolean")
 		reg24966 := MakeSymbol("-->")
@@ -2331,38 +2331,38 @@ func init() {
 		reg24975 := PrimCons(reg24973, reg24974)
 		reg24976 := PrimCons(reg24966, reg24975)
 		reg24977 := PrimCons(reg24965, reg24976)
-		__ctx.TailApply(__defun__unify_b, V3896, reg24977, V3897, V3898)
+		__e.TailApply(__defun__unify_b, V3896, reg24977, V3897, V3898)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-or", value: __defun__shen_4type_1signature_1of_1or})
 
-	__defun__shen_4type_1signature_1of_1os = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1os = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3886 := __args[0]
 		_ = V3886
 		V3887 := __args[1]
 		_ = V3887
 		V3888 := __args[2]
 		_ = V3888
-		reg24979 := __e.Call(__defun__shen_4incinfs)
+		reg24979 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24979
 		reg24980 := MakeSymbol("-->")
 		reg24981 := MakeSymbol("string")
 		reg24982 := Nil
 		reg24983 := PrimCons(reg24981, reg24982)
 		reg24984 := PrimCons(reg24980, reg24983)
-		__ctx.TailApply(__defun__unify_b, V3886, reg24984, V3887, V3888)
+		__e.TailApply(__defun__unify_b, V3886, reg24984, V3887, V3888)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-os", value: __defun__shen_4type_1signature_1of_1os})
 
-	__defun__shen_4type_1signature_1of_1package_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1package_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3876 := __args[0]
 		_ = V3876
 		V3877 := __args[1]
 		_ = V3877
 		V3878 := __args[2]
 		_ = V3878
-		reg24986 := __e.Call(__defun__shen_4incinfs)
+		reg24986 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24986
 		reg24987 := MakeSymbol("symbol")
 		reg24988 := MakeSymbol("-->")
@@ -2371,57 +2371,57 @@ func init() {
 		reg24991 := PrimCons(reg24989, reg24990)
 		reg24992 := PrimCons(reg24988, reg24991)
 		reg24993 := PrimCons(reg24987, reg24992)
-		__ctx.TailApply(__defun__unify_b, V3876, reg24993, V3877, V3878)
+		__e.TailApply(__defun__unify_b, V3876, reg24993, V3877, V3878)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-package?", value: __defun__shen_4type_1signature_1of_1package_2})
 
-	__defun__shen_4type_1signature_1of_1port = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1port = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3866 := __args[0]
 		_ = V3866
 		V3867 := __args[1]
 		_ = V3867
 		V3868 := __args[2]
 		_ = V3868
-		reg24995 := __e.Call(__defun__shen_4incinfs)
+		reg24995 := Call(__e, __defun__shen_4incinfs)
 		_ = reg24995
 		reg24996 := MakeSymbol("-->")
 		reg24997 := MakeSymbol("string")
 		reg24998 := Nil
 		reg24999 := PrimCons(reg24997, reg24998)
 		reg25000 := PrimCons(reg24996, reg24999)
-		__ctx.TailApply(__defun__unify_b, V3866, reg25000, V3867, V3868)
+		__e.TailApply(__defun__unify_b, V3866, reg25000, V3867, V3868)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-port", value: __defun__shen_4type_1signature_1of_1port})
 
-	__defun__shen_4type_1signature_1of_1porters = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1porters = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3856 := __args[0]
 		_ = V3856
 		V3857 := __args[1]
 		_ = V3857
 		V3858 := __args[2]
 		_ = V3858
-		reg25002 := __e.Call(__defun__shen_4incinfs)
+		reg25002 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25002
 		reg25003 := MakeSymbol("-->")
 		reg25004 := MakeSymbol("string")
 		reg25005 := Nil
 		reg25006 := PrimCons(reg25004, reg25005)
 		reg25007 := PrimCons(reg25003, reg25006)
-		__ctx.TailApply(__defun__unify_b, V3856, reg25007, V3857, V3858)
+		__e.TailApply(__defun__unify_b, V3856, reg25007, V3857, V3858)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-porters", value: __defun__shen_4type_1signature_1of_1porters})
 
-	__defun__shen_4type_1signature_1of_1pos = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1pos = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3846 := __args[0]
 		_ = V3846
 		V3847 := __args[1]
 		_ = V3847
 		V3848 := __args[2]
 		_ = V3848
-		reg25009 := __e.Call(__defun__shen_4incinfs)
+		reg25009 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25009
 		reg25010 := MakeSymbol("string")
 		reg25011 := MakeSymbol("-->")
@@ -2436,19 +2436,19 @@ func init() {
 		reg25020 := PrimCons(reg25018, reg25019)
 		reg25021 := PrimCons(reg25011, reg25020)
 		reg25022 := PrimCons(reg25010, reg25021)
-		__ctx.TailApply(__defun__unify_b, V3846, reg25022, V3847, V3848)
+		__e.TailApply(__defun__unify_b, V3846, reg25022, V3847, V3848)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-pos", value: __defun__shen_4type_1signature_1of_1pos})
 
-	__defun__shen_4type_1signature_1of_1pr = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1pr = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3836 := __args[0]
 		_ = V3836
 		V3837 := __args[1]
 		_ = V3837
 		V3838 := __args[2]
 		_ = V3838
-		reg25024 := __e.Call(__defun__shen_4incinfs)
+		reg25024 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25024
 		reg25025 := MakeSymbol("string")
 		reg25026 := MakeSymbol("-->")
@@ -2467,47 +2467,47 @@ func init() {
 		reg25039 := PrimCons(reg25037, reg25038)
 		reg25040 := PrimCons(reg25026, reg25039)
 		reg25041 := PrimCons(reg25025, reg25040)
-		__ctx.TailApply(__defun__unify_b, V3836, reg25041, V3837, V3838)
+		__e.TailApply(__defun__unify_b, V3836, reg25041, V3837, V3838)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-pr", value: __defun__shen_4type_1signature_1of_1pr})
 
-	__defun__shen_4type_1signature_1of_1print = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1print = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3826 := __args[0]
 		_ = V3826
 		V3827 := __args[1]
 		_ = V3827
 		V3828 := __args[2]
 		_ = V3828
-		reg25043 := __e.Call(__defun__shen_4newpv, V3827)
+		reg25043 := Call(__e, __defun__shen_4newpv, V3827)
 		A := reg25043
 		_ = A
-		reg25044 := __e.Call(__defun__shen_4incinfs)
+		reg25044 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25044
 		reg25045 := MakeSymbol("-->")
 		reg25046 := Nil
 		reg25047 := PrimCons(A, reg25046)
 		reg25048 := PrimCons(reg25045, reg25047)
 		reg25049 := PrimCons(A, reg25048)
-		__ctx.TailApply(__defun__unify_b, V3826, reg25049, V3827, V3828)
+		__e.TailApply(__defun__unify_b, V3826, reg25049, V3827, V3828)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-print", value: __defun__shen_4type_1signature_1of_1print})
 
-	__defun__shen_4type_1signature_1of_1profile = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1profile = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3816 := __args[0]
 		_ = V3816
 		V3817 := __args[1]
 		_ = V3817
 		V3818 := __args[2]
 		_ = V3818
-		reg25051 := __e.Call(__defun__shen_4newpv, V3817)
+		reg25051 := Call(__e, __defun__shen_4newpv, V3817)
 		A := reg25051
 		_ = A
-		reg25052 := __e.Call(__defun__shen_4newpv, V3817)
+		reg25052 := Call(__e, __defun__shen_4newpv, V3817)
 		B := reg25052
 		_ = B
-		reg25053 := __e.Call(__defun__shen_4incinfs)
+		reg25053 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25053
 		reg25054 := MakeSymbol("-->")
 		reg25055 := Nil
@@ -2524,19 +2524,19 @@ func init() {
 		reg25066 := PrimCons(reg25064, reg25065)
 		reg25067 := PrimCons(reg25059, reg25066)
 		reg25068 := PrimCons(reg25058, reg25067)
-		__ctx.TailApply(__defun__unify_b, V3816, reg25068, V3817, V3818)
+		__e.TailApply(__defun__unify_b, V3816, reg25068, V3817, V3818)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-profile", value: __defun__shen_4type_1signature_1of_1profile})
 
-	__defun__shen_4type_1signature_1of_1preclude = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1preclude = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3806 := __args[0]
 		_ = V3806
 		V3807 := __args[1]
 		_ = V3807
 		V3808 := __args[2]
 		_ = V3808
-		reg25070 := __e.Call(__defun__shen_4incinfs)
+		reg25070 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25070
 		reg25071 := MakeSymbol("list")
 		reg25072 := MakeSymbol("symbol")
@@ -2553,19 +2553,19 @@ func init() {
 		reg25083 := PrimCons(reg25081, reg25082)
 		reg25084 := PrimCons(reg25076, reg25083)
 		reg25085 := PrimCons(reg25075, reg25084)
-		__ctx.TailApply(__defun__unify_b, V3806, reg25085, V3807, V3808)
+		__e.TailApply(__defun__unify_b, V3806, reg25085, V3807, V3808)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-preclude", value: __defun__shen_4type_1signature_1of_1preclude})
 
-	__defun__shen_4type_1signature_1of_1shen_4proc_1nl = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1shen_4proc_1nl = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3796 := __args[0]
 		_ = V3796
 		V3797 := __args[1]
 		_ = V3797
 		V3798 := __args[2]
 		_ = V3798
-		reg25087 := __e.Call(__defun__shen_4incinfs)
+		reg25087 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25087
 		reg25088 := MakeSymbol("string")
 		reg25089 := MakeSymbol("-->")
@@ -2574,25 +2574,25 @@ func init() {
 		reg25092 := PrimCons(reg25090, reg25091)
 		reg25093 := PrimCons(reg25089, reg25092)
 		reg25094 := PrimCons(reg25088, reg25093)
-		__ctx.TailApply(__defun__unify_b, V3796, reg25094, V3797, V3798)
+		__e.TailApply(__defun__unify_b, V3796, reg25094, V3797, V3798)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-shen.proc-nl", value: __defun__shen_4type_1signature_1of_1shen_4proc_1nl})
 
-	__defun__shen_4type_1signature_1of_1profile_1results = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1profile_1results = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3786 := __args[0]
 		_ = V3786
 		V3787 := __args[1]
 		_ = V3787
 		V3788 := __args[2]
 		_ = V3788
-		reg25096 := __e.Call(__defun__shen_4newpv, V3787)
+		reg25096 := Call(__e, __defun__shen_4newpv, V3787)
 		A := reg25096
 		_ = A
-		reg25097 := __e.Call(__defun__shen_4newpv, V3787)
+		reg25097 := Call(__e, __defun__shen_4newpv, V3787)
 		B := reg25097
 		_ = B
-		reg25098 := __e.Call(__defun__shen_4incinfs)
+		reg25098 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25098
 		reg25099 := MakeSymbol("-->")
 		reg25100 := Nil
@@ -2615,19 +2615,19 @@ func init() {
 		reg25117 := PrimCons(reg25115, reg25116)
 		reg25118 := PrimCons(reg25104, reg25117)
 		reg25119 := PrimCons(reg25103, reg25118)
-		__ctx.TailApply(__defun__unify_b, V3786, reg25119, V3787, V3788)
+		__e.TailApply(__defun__unify_b, V3786, reg25119, V3787, V3788)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-profile-results", value: __defun__shen_4type_1signature_1of_1profile_1results})
 
-	__defun__shen_4type_1signature_1of_1protect = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1protect = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3776 := __args[0]
 		_ = V3776
 		V3777 := __args[1]
 		_ = V3777
 		V3778 := __args[2]
 		_ = V3778
-		reg25121 := __e.Call(__defun__shen_4incinfs)
+		reg25121 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25121
 		reg25122 := MakeSymbol("symbol")
 		reg25123 := MakeSymbol("-->")
@@ -2636,19 +2636,19 @@ func init() {
 		reg25126 := PrimCons(reg25124, reg25125)
 		reg25127 := PrimCons(reg25123, reg25126)
 		reg25128 := PrimCons(reg25122, reg25127)
-		__ctx.TailApply(__defun__unify_b, V3776, reg25128, V3777, V3778)
+		__e.TailApply(__defun__unify_b, V3776, reg25128, V3777, V3778)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-protect", value: __defun__shen_4type_1signature_1of_1protect})
 
-	__defun__shen_4type_1signature_1of_1preclude_1all_1but = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1preclude_1all_1but = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3766 := __args[0]
 		_ = V3766
 		V3767 := __args[1]
 		_ = V3767
 		V3768 := __args[2]
 		_ = V3768
-		reg25130 := __e.Call(__defun__shen_4incinfs)
+		reg25130 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25130
 		reg25131 := MakeSymbol("list")
 		reg25132 := MakeSymbol("symbol")
@@ -2665,19 +2665,19 @@ func init() {
 		reg25143 := PrimCons(reg25141, reg25142)
 		reg25144 := PrimCons(reg25136, reg25143)
 		reg25145 := PrimCons(reg25135, reg25144)
-		__ctx.TailApply(__defun__unify_b, V3766, reg25145, V3767, V3768)
+		__e.TailApply(__defun__unify_b, V3766, reg25145, V3767, V3768)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-preclude-all-but", value: __defun__shen_4type_1signature_1of_1preclude_1all_1but})
 
-	__defun__shen_4type_1signature_1of_1shen_4prhush = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1shen_4prhush = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3756 := __args[0]
 		_ = V3756
 		V3757 := __args[1]
 		_ = V3757
 		V3758 := __args[2]
 		_ = V3758
-		reg25147 := __e.Call(__defun__shen_4incinfs)
+		reg25147 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25147
 		reg25148 := MakeSymbol("string")
 		reg25149 := MakeSymbol("-->")
@@ -2696,19 +2696,19 @@ func init() {
 		reg25162 := PrimCons(reg25160, reg25161)
 		reg25163 := PrimCons(reg25149, reg25162)
 		reg25164 := PrimCons(reg25148, reg25163)
-		__ctx.TailApply(__defun__unify_b, V3756, reg25164, V3757, V3758)
+		__e.TailApply(__defun__unify_b, V3756, reg25164, V3757, V3758)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-shen.prhush", value: __defun__shen_4type_1signature_1of_1shen_4prhush})
 
-	__defun__shen_4type_1signature_1of_1ps = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1ps = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3746 := __args[0]
 		_ = V3746
 		V3747 := __args[1]
 		_ = V3747
 		V3748 := __args[2]
 		_ = V3748
-		reg25166 := __e.Call(__defun__shen_4incinfs)
+		reg25166 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25166
 		reg25167 := MakeSymbol("symbol")
 		reg25168 := MakeSymbol("-->")
@@ -2721,19 +2721,19 @@ func init() {
 		reg25175 := PrimCons(reg25173, reg25174)
 		reg25176 := PrimCons(reg25168, reg25175)
 		reg25177 := PrimCons(reg25167, reg25176)
-		__ctx.TailApply(__defun__unify_b, V3746, reg25177, V3747, V3748)
+		__e.TailApply(__defun__unify_b, V3746, reg25177, V3747, V3748)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-ps", value: __defun__shen_4type_1signature_1of_1ps})
 
-	__defun__shen_4type_1signature_1of_1read = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1read = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3736 := __args[0]
 		_ = V3736
 		V3737 := __args[1]
 		_ = V3737
 		V3738 := __args[2]
 		_ = V3738
-		reg25179 := __e.Call(__defun__shen_4incinfs)
+		reg25179 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25179
 		reg25180 := MakeSymbol("stream")
 		reg25181 := MakeSymbol("in")
@@ -2746,19 +2746,19 @@ func init() {
 		reg25188 := PrimCons(reg25186, reg25187)
 		reg25189 := PrimCons(reg25185, reg25188)
 		reg25190 := PrimCons(reg25184, reg25189)
-		__ctx.TailApply(__defun__unify_b, V3736, reg25190, V3737, V3738)
+		__e.TailApply(__defun__unify_b, V3736, reg25190, V3737, V3738)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-read", value: __defun__shen_4type_1signature_1of_1read})
 
-	__defun__shen_4type_1signature_1of_1read_1byte = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1read_1byte = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3726 := __args[0]
 		_ = V3726
 		V3727 := __args[1]
 		_ = V3727
 		V3728 := __args[2]
 		_ = V3728
-		reg25192 := __e.Call(__defun__shen_4incinfs)
+		reg25192 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25192
 		reg25193 := MakeSymbol("stream")
 		reg25194 := MakeSymbol("in")
@@ -2771,19 +2771,19 @@ func init() {
 		reg25201 := PrimCons(reg25199, reg25200)
 		reg25202 := PrimCons(reg25198, reg25201)
 		reg25203 := PrimCons(reg25197, reg25202)
-		__ctx.TailApply(__defun__unify_b, V3726, reg25203, V3727, V3728)
+		__e.TailApply(__defun__unify_b, V3726, reg25203, V3727, V3728)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-read-byte", value: __defun__shen_4type_1signature_1of_1read_1byte})
 
-	__defun__shen_4type_1signature_1of_1read_1file_1as_1bytelist = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1read_1file_1as_1bytelist = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3716 := __args[0]
 		_ = V3716
 		V3717 := __args[1]
 		_ = V3717
 		V3718 := __args[2]
 		_ = V3718
-		reg25205 := __e.Call(__defun__shen_4incinfs)
+		reg25205 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25205
 		reg25206 := MakeSymbol("string")
 		reg25207 := MakeSymbol("-->")
@@ -2796,19 +2796,19 @@ func init() {
 		reg25214 := PrimCons(reg25212, reg25213)
 		reg25215 := PrimCons(reg25207, reg25214)
 		reg25216 := PrimCons(reg25206, reg25215)
-		__ctx.TailApply(__defun__unify_b, V3716, reg25216, V3717, V3718)
+		__e.TailApply(__defun__unify_b, V3716, reg25216, V3717, V3718)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-read-file-as-bytelist", value: __defun__shen_4type_1signature_1of_1read_1file_1as_1bytelist})
 
-	__defun__shen_4type_1signature_1of_1read_1file_1as_1string = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1read_1file_1as_1string = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3706 := __args[0]
 		_ = V3706
 		V3707 := __args[1]
 		_ = V3707
 		V3708 := __args[2]
 		_ = V3708
-		reg25218 := __e.Call(__defun__shen_4incinfs)
+		reg25218 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25218
 		reg25219 := MakeSymbol("string")
 		reg25220 := MakeSymbol("-->")
@@ -2817,19 +2817,19 @@ func init() {
 		reg25223 := PrimCons(reg25221, reg25222)
 		reg25224 := PrimCons(reg25220, reg25223)
 		reg25225 := PrimCons(reg25219, reg25224)
-		__ctx.TailApply(__defun__unify_b, V3706, reg25225, V3707, V3708)
+		__e.TailApply(__defun__unify_b, V3706, reg25225, V3707, V3708)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-read-file-as-string", value: __defun__shen_4type_1signature_1of_1read_1file_1as_1string})
 
-	__defun__shen_4type_1signature_1of_1read_1file = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1read_1file = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3696 := __args[0]
 		_ = V3696
 		V3697 := __args[1]
 		_ = V3697
 		V3698 := __args[2]
 		_ = V3698
-		reg25227 := __e.Call(__defun__shen_4incinfs)
+		reg25227 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25227
 		reg25228 := MakeSymbol("string")
 		reg25229 := MakeSymbol("-->")
@@ -2842,19 +2842,19 @@ func init() {
 		reg25236 := PrimCons(reg25234, reg25235)
 		reg25237 := PrimCons(reg25229, reg25236)
 		reg25238 := PrimCons(reg25228, reg25237)
-		__ctx.TailApply(__defun__unify_b, V3696, reg25238, V3697, V3698)
+		__e.TailApply(__defun__unify_b, V3696, reg25238, V3697, V3698)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-read-file", value: __defun__shen_4type_1signature_1of_1read_1file})
 
-	__defun__shen_4type_1signature_1of_1read_1from_1string = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1read_1from_1string = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3686 := __args[0]
 		_ = V3686
 		V3687 := __args[1]
 		_ = V3687
 		V3688 := __args[2]
 		_ = V3688
-		reg25240 := __e.Call(__defun__shen_4incinfs)
+		reg25240 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25240
 		reg25241 := MakeSymbol("string")
 		reg25242 := MakeSymbol("-->")
@@ -2867,41 +2867,41 @@ func init() {
 		reg25249 := PrimCons(reg25247, reg25248)
 		reg25250 := PrimCons(reg25242, reg25249)
 		reg25251 := PrimCons(reg25241, reg25250)
-		__ctx.TailApply(__defun__unify_b, V3686, reg25251, V3687, V3688)
+		__e.TailApply(__defun__unify_b, V3686, reg25251, V3687, V3688)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-read-from-string", value: __defun__shen_4type_1signature_1of_1read_1from_1string})
 
-	__defun__shen_4type_1signature_1of_1release = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1release = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3676 := __args[0]
 		_ = V3676
 		V3677 := __args[1]
 		_ = V3677
 		V3678 := __args[2]
 		_ = V3678
-		reg25253 := __e.Call(__defun__shen_4incinfs)
+		reg25253 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25253
 		reg25254 := MakeSymbol("-->")
 		reg25255 := MakeSymbol("string")
 		reg25256 := Nil
 		reg25257 := PrimCons(reg25255, reg25256)
 		reg25258 := PrimCons(reg25254, reg25257)
-		__ctx.TailApply(__defun__unify_b, V3676, reg25258, V3677, V3678)
+		__e.TailApply(__defun__unify_b, V3676, reg25258, V3677, V3678)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-release", value: __defun__shen_4type_1signature_1of_1release})
 
-	__defun__shen_4type_1signature_1of_1remove = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1remove = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3666 := __args[0]
 		_ = V3666
 		V3667 := __args[1]
 		_ = V3667
 		V3668 := __args[2]
 		_ = V3668
-		reg25260 := __e.Call(__defun__shen_4newpv, V3667)
+		reg25260 := Call(__e, __defun__shen_4newpv, V3667)
 		A := reg25260
 		_ = A
-		reg25261 := __e.Call(__defun__shen_4incinfs)
+		reg25261 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25261
 		reg25262 := MakeSymbol("-->")
 		reg25263 := MakeSymbol("list")
@@ -2921,22 +2921,22 @@ func init() {
 		reg25277 := PrimCons(reg25275, reg25276)
 		reg25278 := PrimCons(reg25262, reg25277)
 		reg25279 := PrimCons(A, reg25278)
-		__ctx.TailApply(__defun__unify_b, V3666, reg25279, V3667, V3668)
+		__e.TailApply(__defun__unify_b, V3666, reg25279, V3667, V3668)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-remove", value: __defun__shen_4type_1signature_1of_1remove})
 
-	__defun__shen_4type_1signature_1of_1reverse = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1reverse = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3656 := __args[0]
 		_ = V3656
 		V3657 := __args[1]
 		_ = V3657
 		V3658 := __args[2]
 		_ = V3658
-		reg25281 := __e.Call(__defun__shen_4newpv, V3657)
+		reg25281 := Call(__e, __defun__shen_4newpv, V3657)
 		A := reg25281
 		_ = A
-		reg25282 := __e.Call(__defun__shen_4incinfs)
+		reg25282 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25282
 		reg25283 := MakeSymbol("list")
 		reg25284 := Nil
@@ -2951,22 +2951,22 @@ func init() {
 		reg25293 := PrimCons(reg25291, reg25292)
 		reg25294 := PrimCons(reg25287, reg25293)
 		reg25295 := PrimCons(reg25286, reg25294)
-		__ctx.TailApply(__defun__unify_b, V3656, reg25295, V3657, V3658)
+		__e.TailApply(__defun__unify_b, V3656, reg25295, V3657, V3658)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-reverse", value: __defun__shen_4type_1signature_1of_1reverse})
 
-	__defun__shen_4type_1signature_1of_1simple_1error = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1simple_1error = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3646 := __args[0]
 		_ = V3646
 		V3647 := __args[1]
 		_ = V3647
 		V3648 := __args[2]
 		_ = V3648
-		reg25297 := __e.Call(__defun__shen_4newpv, V3647)
+		reg25297 := Call(__e, __defun__shen_4newpv, V3647)
 		A := reg25297
 		_ = A
-		reg25298 := __e.Call(__defun__shen_4incinfs)
+		reg25298 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25298
 		reg25299 := MakeSymbol("string")
 		reg25300 := MakeSymbol("-->")
@@ -2974,25 +2974,25 @@ func init() {
 		reg25302 := PrimCons(A, reg25301)
 		reg25303 := PrimCons(reg25300, reg25302)
 		reg25304 := PrimCons(reg25299, reg25303)
-		__ctx.TailApply(__defun__unify_b, V3646, reg25304, V3647, V3648)
+		__e.TailApply(__defun__unify_b, V3646, reg25304, V3647, V3648)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-simple-error", value: __defun__shen_4type_1signature_1of_1simple_1error})
 
-	__defun__shen_4type_1signature_1of_1snd = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1snd = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3636 := __args[0]
 		_ = V3636
 		V3637 := __args[1]
 		_ = V3637
 		V3638 := __args[2]
 		_ = V3638
-		reg25306 := __e.Call(__defun__shen_4newpv, V3637)
+		reg25306 := Call(__e, __defun__shen_4newpv, V3637)
 		A := reg25306
 		_ = A
-		reg25307 := __e.Call(__defun__shen_4newpv, V3637)
+		reg25307 := Call(__e, __defun__shen_4newpv, V3637)
 		B := reg25307
 		_ = B
-		reg25308 := __e.Call(__defun__shen_4incinfs)
+		reg25308 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25308
 		reg25309 := MakeSymbol("*")
 		reg25310 := Nil
@@ -3004,19 +3004,19 @@ func init() {
 		reg25316 := PrimCons(B, reg25315)
 		reg25317 := PrimCons(reg25314, reg25316)
 		reg25318 := PrimCons(reg25313, reg25317)
-		__ctx.TailApply(__defun__unify_b, V3636, reg25318, V3637, V3638)
+		__e.TailApply(__defun__unify_b, V3636, reg25318, V3637, V3638)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-snd", value: __defun__shen_4type_1signature_1of_1snd})
 
-	__defun__shen_4type_1signature_1of_1specialise = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1specialise = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3626 := __args[0]
 		_ = V3626
 		V3627 := __args[1]
 		_ = V3627
 		V3628 := __args[2]
 		_ = V3628
-		reg25320 := __e.Call(__defun__shen_4incinfs)
+		reg25320 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25320
 		reg25321 := MakeSymbol("symbol")
 		reg25322 := MakeSymbol("-->")
@@ -3025,19 +3025,19 @@ func init() {
 		reg25325 := PrimCons(reg25323, reg25324)
 		reg25326 := PrimCons(reg25322, reg25325)
 		reg25327 := PrimCons(reg25321, reg25326)
-		__ctx.TailApply(__defun__unify_b, V3626, reg25327, V3627, V3628)
+		__e.TailApply(__defun__unify_b, V3626, reg25327, V3627, V3628)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-specialise", value: __defun__shen_4type_1signature_1of_1specialise})
 
-	__defun__shen_4type_1signature_1of_1spy = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1spy = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3616 := __args[0]
 		_ = V3616
 		V3617 := __args[1]
 		_ = V3617
 		V3618 := __args[2]
 		_ = V3618
-		reg25329 := __e.Call(__defun__shen_4incinfs)
+		reg25329 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25329
 		reg25330 := MakeSymbol("symbol")
 		reg25331 := MakeSymbol("-->")
@@ -3046,19 +3046,19 @@ func init() {
 		reg25334 := PrimCons(reg25332, reg25333)
 		reg25335 := PrimCons(reg25331, reg25334)
 		reg25336 := PrimCons(reg25330, reg25335)
-		__ctx.TailApply(__defun__unify_b, V3616, reg25336, V3617, V3618)
+		__e.TailApply(__defun__unify_b, V3616, reg25336, V3617, V3618)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-spy", value: __defun__shen_4type_1signature_1of_1spy})
 
-	__defun__shen_4type_1signature_1of_1step = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1step = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3606 := __args[0]
 		_ = V3606
 		V3607 := __args[1]
 		_ = V3607
 		V3608 := __args[2]
 		_ = V3608
-		reg25338 := __e.Call(__defun__shen_4incinfs)
+		reg25338 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25338
 		reg25339 := MakeSymbol("symbol")
 		reg25340 := MakeSymbol("-->")
@@ -3067,19 +3067,19 @@ func init() {
 		reg25343 := PrimCons(reg25341, reg25342)
 		reg25344 := PrimCons(reg25340, reg25343)
 		reg25345 := PrimCons(reg25339, reg25344)
-		__ctx.TailApply(__defun__unify_b, V3606, reg25345, V3607, V3608)
+		__e.TailApply(__defun__unify_b, V3606, reg25345, V3607, V3608)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-step", value: __defun__shen_4type_1signature_1of_1step})
 
-	__defun__shen_4type_1signature_1of_1stinput = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1stinput = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3596 := __args[0]
 		_ = V3596
 		V3597 := __args[1]
 		_ = V3597
 		V3598 := __args[2]
 		_ = V3598
-		reg25347 := __e.Call(__defun__shen_4incinfs)
+		reg25347 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25347
 		reg25348 := MakeSymbol("-->")
 		reg25349 := MakeSymbol("stream")
@@ -3090,19 +3090,19 @@ func init() {
 		reg25354 := Nil
 		reg25355 := PrimCons(reg25353, reg25354)
 		reg25356 := PrimCons(reg25348, reg25355)
-		__ctx.TailApply(__defun__unify_b, V3596, reg25356, V3597, V3598)
+		__e.TailApply(__defun__unify_b, V3596, reg25356, V3597, V3598)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-stinput", value: __defun__shen_4type_1signature_1of_1stinput})
 
-	__defun__shen_4type_1signature_1of_1sterror = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1sterror = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3586 := __args[0]
 		_ = V3586
 		V3587 := __args[1]
 		_ = V3587
 		V3588 := __args[2]
 		_ = V3588
-		reg25358 := __e.Call(__defun__shen_4incinfs)
+		reg25358 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25358
 		reg25359 := MakeSymbol("-->")
 		reg25360 := MakeSymbol("stream")
@@ -3113,19 +3113,19 @@ func init() {
 		reg25365 := Nil
 		reg25366 := PrimCons(reg25364, reg25365)
 		reg25367 := PrimCons(reg25359, reg25366)
-		__ctx.TailApply(__defun__unify_b, V3586, reg25367, V3587, V3588)
+		__e.TailApply(__defun__unify_b, V3586, reg25367, V3587, V3588)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-sterror", value: __defun__shen_4type_1signature_1of_1sterror})
 
-	__defun__shen_4type_1signature_1of_1stoutput = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1stoutput = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3576 := __args[0]
 		_ = V3576
 		V3577 := __args[1]
 		_ = V3577
 		V3578 := __args[2]
 		_ = V3578
-		reg25369 := __e.Call(__defun__shen_4incinfs)
+		reg25369 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25369
 		reg25370 := MakeSymbol("-->")
 		reg25371 := MakeSymbol("stream")
@@ -3136,22 +3136,22 @@ func init() {
 		reg25376 := Nil
 		reg25377 := PrimCons(reg25375, reg25376)
 		reg25378 := PrimCons(reg25370, reg25377)
-		__ctx.TailApply(__defun__unify_b, V3576, reg25378, V3577, V3578)
+		__e.TailApply(__defun__unify_b, V3576, reg25378, V3577, V3578)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-stoutput", value: __defun__shen_4type_1signature_1of_1stoutput})
 
-	__defun__shen_4type_1signature_1of_1string_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1string_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3566 := __args[0]
 		_ = V3566
 		V3567 := __args[1]
 		_ = V3567
 		V3568 := __args[2]
 		_ = V3568
-		reg25380 := __e.Call(__defun__shen_4newpv, V3567)
+		reg25380 := Call(__e, __defun__shen_4newpv, V3567)
 		A := reg25380
 		_ = A
-		reg25381 := __e.Call(__defun__shen_4incinfs)
+		reg25381 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25381
 		reg25382 := MakeSymbol("-->")
 		reg25383 := MakeSymbol("boolean")
@@ -3159,22 +3159,22 @@ func init() {
 		reg25385 := PrimCons(reg25383, reg25384)
 		reg25386 := PrimCons(reg25382, reg25385)
 		reg25387 := PrimCons(A, reg25386)
-		__ctx.TailApply(__defun__unify_b, V3566, reg25387, V3567, V3568)
+		__e.TailApply(__defun__unify_b, V3566, reg25387, V3567, V3568)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-string?", value: __defun__shen_4type_1signature_1of_1string_2})
 
-	__defun__shen_4type_1signature_1of_1str = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1str = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3556 := __args[0]
 		_ = V3556
 		V3557 := __args[1]
 		_ = V3557
 		V3558 := __args[2]
 		_ = V3558
-		reg25389 := __e.Call(__defun__shen_4newpv, V3557)
+		reg25389 := Call(__e, __defun__shen_4newpv, V3557)
 		A := reg25389
 		_ = A
-		reg25390 := __e.Call(__defun__shen_4incinfs)
+		reg25390 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25390
 		reg25391 := MakeSymbol("-->")
 		reg25392 := MakeSymbol("string")
@@ -3182,19 +3182,19 @@ func init() {
 		reg25394 := PrimCons(reg25392, reg25393)
 		reg25395 := PrimCons(reg25391, reg25394)
 		reg25396 := PrimCons(A, reg25395)
-		__ctx.TailApply(__defun__unify_b, V3556, reg25396, V3557, V3558)
+		__e.TailApply(__defun__unify_b, V3556, reg25396, V3557, V3558)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-str", value: __defun__shen_4type_1signature_1of_1str})
 
-	__defun__shen_4type_1signature_1of_1string_1_6n = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1string_1_6n = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3546 := __args[0]
 		_ = V3546
 		V3547 := __args[1]
 		_ = V3547
 		V3548 := __args[2]
 		_ = V3548
-		reg25398 := __e.Call(__defun__shen_4incinfs)
+		reg25398 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25398
 		reg25399 := MakeSymbol("string")
 		reg25400 := MakeSymbol("-->")
@@ -3203,19 +3203,19 @@ func init() {
 		reg25403 := PrimCons(reg25401, reg25402)
 		reg25404 := PrimCons(reg25400, reg25403)
 		reg25405 := PrimCons(reg25399, reg25404)
-		__ctx.TailApply(__defun__unify_b, V3546, reg25405, V3547, V3548)
+		__e.TailApply(__defun__unify_b, V3546, reg25405, V3547, V3548)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-string->n", value: __defun__shen_4type_1signature_1of_1string_1_6n})
 
-	__defun__shen_4type_1signature_1of_1string_1_6symbol = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1string_1_6symbol = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3536 := __args[0]
 		_ = V3536
 		V3537 := __args[1]
 		_ = V3537
 		V3538 := __args[2]
 		_ = V3538
-		reg25407 := __e.Call(__defun__shen_4incinfs)
+		reg25407 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25407
 		reg25408 := MakeSymbol("string")
 		reg25409 := MakeSymbol("-->")
@@ -3224,19 +3224,19 @@ func init() {
 		reg25412 := PrimCons(reg25410, reg25411)
 		reg25413 := PrimCons(reg25409, reg25412)
 		reg25414 := PrimCons(reg25408, reg25413)
-		__ctx.TailApply(__defun__unify_b, V3536, reg25414, V3537, V3538)
+		__e.TailApply(__defun__unify_b, V3536, reg25414, V3537, V3538)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-string->symbol", value: __defun__shen_4type_1signature_1of_1string_1_6symbol})
 
-	__defun__shen_4type_1signature_1of_1sum = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1sum = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3526 := __args[0]
 		_ = V3526
 		V3527 := __args[1]
 		_ = V3527
 		V3528 := __args[2]
 		_ = V3528
-		reg25416 := __e.Call(__defun__shen_4incinfs)
+		reg25416 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25416
 		reg25417 := MakeSymbol("list")
 		reg25418 := MakeSymbol("number")
@@ -3249,22 +3249,22 @@ func init() {
 		reg25425 := PrimCons(reg25423, reg25424)
 		reg25426 := PrimCons(reg25422, reg25425)
 		reg25427 := PrimCons(reg25421, reg25426)
-		__ctx.TailApply(__defun__unify_b, V3526, reg25427, V3527, V3528)
+		__e.TailApply(__defun__unify_b, V3526, reg25427, V3527, V3528)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-sum", value: __defun__shen_4type_1signature_1of_1sum})
 
-	__defun__shen_4type_1signature_1of_1symbol_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1symbol_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3516 := __args[0]
 		_ = V3516
 		V3517 := __args[1]
 		_ = V3517
 		V3518 := __args[2]
 		_ = V3518
-		reg25429 := __e.Call(__defun__shen_4newpv, V3517)
+		reg25429 := Call(__e, __defun__shen_4newpv, V3517)
 		A := reg25429
 		_ = A
-		reg25430 := __e.Call(__defun__shen_4incinfs)
+		reg25430 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25430
 		reg25431 := MakeSymbol("-->")
 		reg25432 := MakeSymbol("boolean")
@@ -3272,19 +3272,19 @@ func init() {
 		reg25434 := PrimCons(reg25432, reg25433)
 		reg25435 := PrimCons(reg25431, reg25434)
 		reg25436 := PrimCons(A, reg25435)
-		__ctx.TailApply(__defun__unify_b, V3516, reg25436, V3517, V3518)
+		__e.TailApply(__defun__unify_b, V3516, reg25436, V3517, V3518)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-symbol?", value: __defun__shen_4type_1signature_1of_1symbol_2})
 
-	__defun__shen_4type_1signature_1of_1systemf = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1systemf = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3506 := __args[0]
 		_ = V3506
 		V3507 := __args[1]
 		_ = V3507
 		V3508 := __args[2]
 		_ = V3508
-		reg25438 := __e.Call(__defun__shen_4incinfs)
+		reg25438 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25438
 		reg25439 := MakeSymbol("symbol")
 		reg25440 := MakeSymbol("-->")
@@ -3293,22 +3293,22 @@ func init() {
 		reg25443 := PrimCons(reg25441, reg25442)
 		reg25444 := PrimCons(reg25440, reg25443)
 		reg25445 := PrimCons(reg25439, reg25444)
-		__ctx.TailApply(__defun__unify_b, V3506, reg25445, V3507, V3508)
+		__e.TailApply(__defun__unify_b, V3506, reg25445, V3507, V3508)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-systemf", value: __defun__shen_4type_1signature_1of_1systemf})
 
-	__defun__shen_4type_1signature_1of_1tail = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1tail = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3496 := __args[0]
 		_ = V3496
 		V3497 := __args[1]
 		_ = V3497
 		V3498 := __args[2]
 		_ = V3498
-		reg25447 := __e.Call(__defun__shen_4newpv, V3497)
+		reg25447 := Call(__e, __defun__shen_4newpv, V3497)
 		A := reg25447
 		_ = A
-		reg25448 := __e.Call(__defun__shen_4incinfs)
+		reg25448 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25448
 		reg25449 := MakeSymbol("list")
 		reg25450 := Nil
@@ -3323,19 +3323,19 @@ func init() {
 		reg25459 := PrimCons(reg25457, reg25458)
 		reg25460 := PrimCons(reg25453, reg25459)
 		reg25461 := PrimCons(reg25452, reg25460)
-		__ctx.TailApply(__defun__unify_b, V3496, reg25461, V3497, V3498)
+		__e.TailApply(__defun__unify_b, V3496, reg25461, V3497, V3498)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-tail", value: __defun__shen_4type_1signature_1of_1tail})
 
-	__defun__shen_4type_1signature_1of_1tlstr = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1tlstr = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3486 := __args[0]
 		_ = V3486
 		V3487 := __args[1]
 		_ = V3487
 		V3488 := __args[2]
 		_ = V3488
-		reg25463 := __e.Call(__defun__shen_4incinfs)
+		reg25463 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25463
 		reg25464 := MakeSymbol("string")
 		reg25465 := MakeSymbol("-->")
@@ -3344,22 +3344,22 @@ func init() {
 		reg25468 := PrimCons(reg25466, reg25467)
 		reg25469 := PrimCons(reg25465, reg25468)
 		reg25470 := PrimCons(reg25464, reg25469)
-		__ctx.TailApply(__defun__unify_b, V3486, reg25470, V3487, V3488)
+		__e.TailApply(__defun__unify_b, V3486, reg25470, V3487, V3488)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-tlstr", value: __defun__shen_4type_1signature_1of_1tlstr})
 
-	__defun__shen_4type_1signature_1of_1tlv = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1tlv = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3476 := __args[0]
 		_ = V3476
 		V3477 := __args[1]
 		_ = V3477
 		V3478 := __args[2]
 		_ = V3478
-		reg25472 := __e.Call(__defun__shen_4newpv, V3477)
+		reg25472 := Call(__e, __defun__shen_4newpv, V3477)
 		A := reg25472
 		_ = A
-		reg25473 := __e.Call(__defun__shen_4incinfs)
+		reg25473 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25473
 		reg25474 := MakeSymbol("vector")
 		reg25475 := Nil
@@ -3374,19 +3374,19 @@ func init() {
 		reg25484 := PrimCons(reg25482, reg25483)
 		reg25485 := PrimCons(reg25478, reg25484)
 		reg25486 := PrimCons(reg25477, reg25485)
-		__ctx.TailApply(__defun__unify_b, V3476, reg25486, V3477, V3478)
+		__e.TailApply(__defun__unify_b, V3476, reg25486, V3477, V3478)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-tlv", value: __defun__shen_4type_1signature_1of_1tlv})
 
-	__defun__shen_4type_1signature_1of_1tc = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1tc = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3466 := __args[0]
 		_ = V3466
 		V3467 := __args[1]
 		_ = V3467
 		V3468 := __args[2]
 		_ = V3468
-		reg25488 := __e.Call(__defun__shen_4incinfs)
+		reg25488 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25488
 		reg25489 := MakeSymbol("symbol")
 		reg25490 := MakeSymbol("-->")
@@ -3395,41 +3395,41 @@ func init() {
 		reg25493 := PrimCons(reg25491, reg25492)
 		reg25494 := PrimCons(reg25490, reg25493)
 		reg25495 := PrimCons(reg25489, reg25494)
-		__ctx.TailApply(__defun__unify_b, V3466, reg25495, V3467, V3468)
+		__e.TailApply(__defun__unify_b, V3466, reg25495, V3467, V3468)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-tc", value: __defun__shen_4type_1signature_1of_1tc})
 
-	__defun__shen_4type_1signature_1of_1tc_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1tc_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3456 := __args[0]
 		_ = V3456
 		V3457 := __args[1]
 		_ = V3457
 		V3458 := __args[2]
 		_ = V3458
-		reg25497 := __e.Call(__defun__shen_4incinfs)
+		reg25497 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25497
 		reg25498 := MakeSymbol("-->")
 		reg25499 := MakeSymbol("boolean")
 		reg25500 := Nil
 		reg25501 := PrimCons(reg25499, reg25500)
 		reg25502 := PrimCons(reg25498, reg25501)
-		__ctx.TailApply(__defun__unify_b, V3456, reg25502, V3457, V3458)
+		__e.TailApply(__defun__unify_b, V3456, reg25502, V3457, V3458)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-tc?", value: __defun__shen_4type_1signature_1of_1tc_2})
 
-	__defun__shen_4type_1signature_1of_1thaw = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1thaw = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3446 := __args[0]
 		_ = V3446
 		V3447 := __args[1]
 		_ = V3447
 		V3448 := __args[2]
 		_ = V3448
-		reg25504 := __e.Call(__defun__shen_4newpv, V3447)
+		reg25504 := Call(__e, __defun__shen_4newpv, V3447)
 		A := reg25504
 		_ = A
-		reg25505 := __e.Call(__defun__shen_4incinfs)
+		reg25505 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25505
 		reg25506 := MakeSymbol("lazy")
 		reg25507 := Nil
@@ -3440,19 +3440,19 @@ func init() {
 		reg25512 := PrimCons(A, reg25511)
 		reg25513 := PrimCons(reg25510, reg25512)
 		reg25514 := PrimCons(reg25509, reg25513)
-		__ctx.TailApply(__defun__unify_b, V3446, reg25514, V3447, V3448)
+		__e.TailApply(__defun__unify_b, V3446, reg25514, V3447, V3448)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-thaw", value: __defun__shen_4type_1signature_1of_1thaw})
 
-	__defun__shen_4type_1signature_1of_1track = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1track = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3436 := __args[0]
 		_ = V3436
 		V3437 := __args[1]
 		_ = V3437
 		V3438 := __args[2]
 		_ = V3438
-		reg25516 := __e.Call(__defun__shen_4incinfs)
+		reg25516 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25516
 		reg25517 := MakeSymbol("symbol")
 		reg25518 := MakeSymbol("-->")
@@ -3461,22 +3461,22 @@ func init() {
 		reg25521 := PrimCons(reg25519, reg25520)
 		reg25522 := PrimCons(reg25518, reg25521)
 		reg25523 := PrimCons(reg25517, reg25522)
-		__ctx.TailApply(__defun__unify_b, V3436, reg25523, V3437, V3438)
+		__e.TailApply(__defun__unify_b, V3436, reg25523, V3437, V3438)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-track", value: __defun__shen_4type_1signature_1of_1track})
 
-	__defun__shen_4type_1signature_1of_1trap_1error = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1trap_1error = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3426 := __args[0]
 		_ = V3426
 		V3427 := __args[1]
 		_ = V3427
 		V3428 := __args[2]
 		_ = V3428
-		reg25525 := __e.Call(__defun__shen_4newpv, V3427)
+		reg25525 := Call(__e, __defun__shen_4newpv, V3427)
 		A := reg25525
 		_ = A
-		reg25526 := __e.Call(__defun__shen_4incinfs)
+		reg25526 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25526
 		reg25527 := MakeSymbol("-->")
 		reg25528 := MakeSymbol("exception")
@@ -3494,22 +3494,22 @@ func init() {
 		reg25540 := PrimCons(reg25538, reg25539)
 		reg25541 := PrimCons(reg25527, reg25540)
 		reg25542 := PrimCons(A, reg25541)
-		__ctx.TailApply(__defun__unify_b, V3426, reg25542, V3427, V3428)
+		__e.TailApply(__defun__unify_b, V3426, reg25542, V3427, V3428)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-trap-error", value: __defun__shen_4type_1signature_1of_1trap_1error})
 
-	__defun__shen_4type_1signature_1of_1tuple_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1tuple_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3416 := __args[0]
 		_ = V3416
 		V3417 := __args[1]
 		_ = V3417
 		V3418 := __args[2]
 		_ = V3418
-		reg25544 := __e.Call(__defun__shen_4newpv, V3417)
+		reg25544 := Call(__e, __defun__shen_4newpv, V3417)
 		A := reg25544
 		_ = A
-		reg25545 := __e.Call(__defun__shen_4incinfs)
+		reg25545 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25545
 		reg25546 := MakeSymbol("-->")
 		reg25547 := MakeSymbol("boolean")
@@ -3517,19 +3517,19 @@ func init() {
 		reg25549 := PrimCons(reg25547, reg25548)
 		reg25550 := PrimCons(reg25546, reg25549)
 		reg25551 := PrimCons(A, reg25550)
-		__ctx.TailApply(__defun__unify_b, V3416, reg25551, V3417, V3418)
+		__e.TailApply(__defun__unify_b, V3416, reg25551, V3417, V3418)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-tuple?", value: __defun__shen_4type_1signature_1of_1tuple_2})
 
-	__defun__shen_4type_1signature_1of_1undefmacro = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1undefmacro = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3406 := __args[0]
 		_ = V3406
 		V3407 := __args[1]
 		_ = V3407
 		V3408 := __args[2]
 		_ = V3408
-		reg25553 := __e.Call(__defun__shen_4incinfs)
+		reg25553 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25553
 		reg25554 := MakeSymbol("symbol")
 		reg25555 := MakeSymbol("-->")
@@ -3538,22 +3538,22 @@ func init() {
 		reg25558 := PrimCons(reg25556, reg25557)
 		reg25559 := PrimCons(reg25555, reg25558)
 		reg25560 := PrimCons(reg25554, reg25559)
-		__ctx.TailApply(__defun__unify_b, V3406, reg25560, V3407, V3408)
+		__e.TailApply(__defun__unify_b, V3406, reg25560, V3407, V3408)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-undefmacro", value: __defun__shen_4type_1signature_1of_1undefmacro})
 
-	__defun__shen_4type_1signature_1of_1union = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1union = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3396 := __args[0]
 		_ = V3396
 		V3397 := __args[1]
 		_ = V3397
 		V3398 := __args[2]
 		_ = V3398
-		reg25562 := __e.Call(__defun__shen_4newpv, V3397)
+		reg25562 := Call(__e, __defun__shen_4newpv, V3397)
 		A := reg25562
 		_ = A
-		reg25563 := __e.Call(__defun__shen_4incinfs)
+		reg25563 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25563
 		reg25564 := MakeSymbol("list")
 		reg25565 := Nil
@@ -3577,25 +3577,25 @@ func init() {
 		reg25583 := PrimCons(reg25581, reg25582)
 		reg25584 := PrimCons(reg25568, reg25583)
 		reg25585 := PrimCons(reg25567, reg25584)
-		__ctx.TailApply(__defun__unify_b, V3396, reg25585, V3397, V3398)
+		__e.TailApply(__defun__unify_b, V3396, reg25585, V3397, V3398)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-union", value: __defun__shen_4type_1signature_1of_1union})
 
-	__defun__shen_4type_1signature_1of_1unprofile = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1unprofile = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3386 := __args[0]
 		_ = V3386
 		V3387 := __args[1]
 		_ = V3387
 		V3388 := __args[2]
 		_ = V3388
-		reg25587 := __e.Call(__defun__shen_4newpv, V3387)
+		reg25587 := Call(__e, __defun__shen_4newpv, V3387)
 		A := reg25587
 		_ = A
-		reg25588 := __e.Call(__defun__shen_4newpv, V3387)
+		reg25588 := Call(__e, __defun__shen_4newpv, V3387)
 		B := reg25588
 		_ = B
-		reg25589 := __e.Call(__defun__shen_4incinfs)
+		reg25589 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25589
 		reg25590 := MakeSymbol("-->")
 		reg25591 := Nil
@@ -3612,19 +3612,19 @@ func init() {
 		reg25602 := PrimCons(reg25600, reg25601)
 		reg25603 := PrimCons(reg25595, reg25602)
 		reg25604 := PrimCons(reg25594, reg25603)
-		__ctx.TailApply(__defun__unify_b, V3386, reg25604, V3387, V3388)
+		__e.TailApply(__defun__unify_b, V3386, reg25604, V3387, V3388)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-unprofile", value: __defun__shen_4type_1signature_1of_1unprofile})
 
-	__defun__shen_4type_1signature_1of_1untrack = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1untrack = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3376 := __args[0]
 		_ = V3376
 		V3377 := __args[1]
 		_ = V3377
 		V3378 := __args[2]
 		_ = V3378
-		reg25606 := __e.Call(__defun__shen_4incinfs)
+		reg25606 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25606
 		reg25607 := MakeSymbol("symbol")
 		reg25608 := MakeSymbol("-->")
@@ -3633,19 +3633,19 @@ func init() {
 		reg25611 := PrimCons(reg25609, reg25610)
 		reg25612 := PrimCons(reg25608, reg25611)
 		reg25613 := PrimCons(reg25607, reg25612)
-		__ctx.TailApply(__defun__unify_b, V3376, reg25613, V3377, V3378)
+		__e.TailApply(__defun__unify_b, V3376, reg25613, V3377, V3378)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-untrack", value: __defun__shen_4type_1signature_1of_1untrack})
 
-	__defun__shen_4type_1signature_1of_1unspecialise = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1unspecialise = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3366 := __args[0]
 		_ = V3366
 		V3367 := __args[1]
 		_ = V3367
 		V3368 := __args[2]
 		_ = V3368
-		reg25615 := __e.Call(__defun__shen_4incinfs)
+		reg25615 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25615
 		reg25616 := MakeSymbol("symbol")
 		reg25617 := MakeSymbol("-->")
@@ -3654,22 +3654,22 @@ func init() {
 		reg25620 := PrimCons(reg25618, reg25619)
 		reg25621 := PrimCons(reg25617, reg25620)
 		reg25622 := PrimCons(reg25616, reg25621)
-		__ctx.TailApply(__defun__unify_b, V3366, reg25622, V3367, V3368)
+		__e.TailApply(__defun__unify_b, V3366, reg25622, V3367, V3368)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-unspecialise", value: __defun__shen_4type_1signature_1of_1unspecialise})
 
-	__defun__shen_4type_1signature_1of_1variable_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1variable_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3356 := __args[0]
 		_ = V3356
 		V3357 := __args[1]
 		_ = V3357
 		V3358 := __args[2]
 		_ = V3358
-		reg25624 := __e.Call(__defun__shen_4newpv, V3357)
+		reg25624 := Call(__e, __defun__shen_4newpv, V3357)
 		A := reg25624
 		_ = A
-		reg25625 := __e.Call(__defun__shen_4incinfs)
+		reg25625 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25625
 		reg25626 := MakeSymbol("-->")
 		reg25627 := MakeSymbol("boolean")
@@ -3677,22 +3677,22 @@ func init() {
 		reg25629 := PrimCons(reg25627, reg25628)
 		reg25630 := PrimCons(reg25626, reg25629)
 		reg25631 := PrimCons(A, reg25630)
-		__ctx.TailApply(__defun__unify_b, V3356, reg25631, V3357, V3358)
+		__e.TailApply(__defun__unify_b, V3356, reg25631, V3357, V3358)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-variable?", value: __defun__shen_4type_1signature_1of_1variable_2})
 
-	__defun__shen_4type_1signature_1of_1vector_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1vector_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3346 := __args[0]
 		_ = V3346
 		V3347 := __args[1]
 		_ = V3347
 		V3348 := __args[2]
 		_ = V3348
-		reg25633 := __e.Call(__defun__shen_4newpv, V3347)
+		reg25633 := Call(__e, __defun__shen_4newpv, V3347)
 		A := reg25633
 		_ = A
-		reg25634 := __e.Call(__defun__shen_4incinfs)
+		reg25634 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25634
 		reg25635 := MakeSymbol("-->")
 		reg25636 := MakeSymbol("boolean")
@@ -3700,41 +3700,41 @@ func init() {
 		reg25638 := PrimCons(reg25636, reg25637)
 		reg25639 := PrimCons(reg25635, reg25638)
 		reg25640 := PrimCons(A, reg25639)
-		__ctx.TailApply(__defun__unify_b, V3346, reg25640, V3347, V3348)
+		__e.TailApply(__defun__unify_b, V3346, reg25640, V3347, V3348)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-vector?", value: __defun__shen_4type_1signature_1of_1vector_2})
 
-	__defun__shen_4type_1signature_1of_1version = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1version = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3336 := __args[0]
 		_ = V3336
 		V3337 := __args[1]
 		_ = V3337
 		V3338 := __args[2]
 		_ = V3338
-		reg25642 := __e.Call(__defun__shen_4incinfs)
+		reg25642 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25642
 		reg25643 := MakeSymbol("-->")
 		reg25644 := MakeSymbol("string")
 		reg25645 := Nil
 		reg25646 := PrimCons(reg25644, reg25645)
 		reg25647 := PrimCons(reg25643, reg25646)
-		__ctx.TailApply(__defun__unify_b, V3336, reg25647, V3337, V3338)
+		__e.TailApply(__defun__unify_b, V3336, reg25647, V3337, V3338)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-version", value: __defun__shen_4type_1signature_1of_1version})
 
-	__defun__shen_4type_1signature_1of_1write_1to_1file = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1write_1to_1file = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3326 := __args[0]
 		_ = V3326
 		V3327 := __args[1]
 		_ = V3327
 		V3328 := __args[2]
 		_ = V3328
-		reg25649 := __e.Call(__defun__shen_4newpv, V3327)
+		reg25649 := Call(__e, __defun__shen_4newpv, V3327)
 		A := reg25649
 		_ = A
-		reg25650 := __e.Call(__defun__shen_4incinfs)
+		reg25650 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25650
 		reg25651 := MakeSymbol("string")
 		reg25652 := MakeSymbol("-->")
@@ -3747,19 +3747,19 @@ func init() {
 		reg25659 := PrimCons(reg25657, reg25658)
 		reg25660 := PrimCons(reg25652, reg25659)
 		reg25661 := PrimCons(reg25651, reg25660)
-		__ctx.TailApply(__defun__unify_b, V3326, reg25661, V3327, V3328)
+		__e.TailApply(__defun__unify_b, V3326, reg25661, V3327, V3328)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-write-to-file", value: __defun__shen_4type_1signature_1of_1write_1to_1file})
 
-	__defun__shen_4type_1signature_1of_1write_1byte = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1write_1byte = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3316 := __args[0]
 		_ = V3316
 		V3317 := __args[1]
 		_ = V3317
 		V3318 := __args[2]
 		_ = V3318
-		reg25663 := __e.Call(__defun__shen_4incinfs)
+		reg25663 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25663
 		reg25664 := MakeSymbol("number")
 		reg25665 := MakeSymbol("-->")
@@ -3778,19 +3778,19 @@ func init() {
 		reg25678 := PrimCons(reg25676, reg25677)
 		reg25679 := PrimCons(reg25665, reg25678)
 		reg25680 := PrimCons(reg25664, reg25679)
-		__ctx.TailApply(__defun__unify_b, V3316, reg25680, V3317, V3318)
+		__e.TailApply(__defun__unify_b, V3316, reg25680, V3317, V3318)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-write-byte", value: __defun__shen_4type_1signature_1of_1write_1byte})
 
-	__defun__shen_4type_1signature_1of_1y_1or_1n_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1y_1or_1n_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3306 := __args[0]
 		_ = V3306
 		V3307 := __args[1]
 		_ = V3307
 		V3308 := __args[2]
 		_ = V3308
-		reg25682 := __e.Call(__defun__shen_4incinfs)
+		reg25682 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25682
 		reg25683 := MakeSymbol("string")
 		reg25684 := MakeSymbol("-->")
@@ -3799,19 +3799,19 @@ func init() {
 		reg25687 := PrimCons(reg25685, reg25686)
 		reg25688 := PrimCons(reg25684, reg25687)
 		reg25689 := PrimCons(reg25683, reg25688)
-		__ctx.TailApply(__defun__unify_b, V3306, reg25689, V3307, V3308)
+		__e.TailApply(__defun__unify_b, V3306, reg25689, V3307, V3308)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-y-or-n?", value: __defun__shen_4type_1signature_1of_1y_1or_1n_2})
 
-	__defun__shen_4type_1signature_1of_1_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3296 := __args[0]
 		_ = V3296
 		V3297 := __args[1]
 		_ = V3297
 		V3298 := __args[2]
 		_ = V3298
-		reg25691 := __e.Call(__defun__shen_4incinfs)
+		reg25691 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25691
 		reg25692 := MakeSymbol("number")
 		reg25693 := MakeSymbol("-->")
@@ -3826,19 +3826,19 @@ func init() {
 		reg25702 := PrimCons(reg25700, reg25701)
 		reg25703 := PrimCons(reg25693, reg25702)
 		reg25704 := PrimCons(reg25692, reg25703)
-		__ctx.TailApply(__defun__unify_b, V3296, reg25704, V3297, V3298)
+		__e.TailApply(__defun__unify_b, V3296, reg25704, V3297, V3298)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of->", value: __defun__shen_4type_1signature_1of_1_6})
 
-	__defun__shen_4type_1signature_1of_1_5 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_5 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3286 := __args[0]
 		_ = V3286
 		V3287 := __args[1]
 		_ = V3287
 		V3288 := __args[2]
 		_ = V3288
-		reg25706 := __e.Call(__defun__shen_4incinfs)
+		reg25706 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25706
 		reg25707 := MakeSymbol("number")
 		reg25708 := MakeSymbol("-->")
@@ -3853,19 +3853,19 @@ func init() {
 		reg25717 := PrimCons(reg25715, reg25716)
 		reg25718 := PrimCons(reg25708, reg25717)
 		reg25719 := PrimCons(reg25707, reg25718)
-		__ctx.TailApply(__defun__unify_b, V3286, reg25719, V3287, V3288)
+		__e.TailApply(__defun__unify_b, V3286, reg25719, V3287, V3288)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-<", value: __defun__shen_4type_1signature_1of_1_5})
 
-	__defun__shen_4type_1signature_1of_1_6_a = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_6_a = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3276 := __args[0]
 		_ = V3276
 		V3277 := __args[1]
 		_ = V3277
 		V3278 := __args[2]
 		_ = V3278
-		reg25721 := __e.Call(__defun__shen_4incinfs)
+		reg25721 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25721
 		reg25722 := MakeSymbol("number")
 		reg25723 := MakeSymbol("-->")
@@ -3880,19 +3880,19 @@ func init() {
 		reg25732 := PrimCons(reg25730, reg25731)
 		reg25733 := PrimCons(reg25723, reg25732)
 		reg25734 := PrimCons(reg25722, reg25733)
-		__ctx.TailApply(__defun__unify_b, V3276, reg25734, V3277, V3278)
+		__e.TailApply(__defun__unify_b, V3276, reg25734, V3277, V3278)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of->=", value: __defun__shen_4type_1signature_1of_1_6_a})
 
-	__defun__shen_4type_1signature_1of_1_5_a = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_5_a = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3266 := __args[0]
 		_ = V3266
 		V3267 := __args[1]
 		_ = V3267
 		V3268 := __args[2]
 		_ = V3268
-		reg25736 := __e.Call(__defun__shen_4incinfs)
+		reg25736 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25736
 		reg25737 := MakeSymbol("number")
 		reg25738 := MakeSymbol("-->")
@@ -3907,22 +3907,22 @@ func init() {
 		reg25747 := PrimCons(reg25745, reg25746)
 		reg25748 := PrimCons(reg25738, reg25747)
 		reg25749 := PrimCons(reg25737, reg25748)
-		__ctx.TailApply(__defun__unify_b, V3266, reg25749, V3267, V3268)
+		__e.TailApply(__defun__unify_b, V3266, reg25749, V3267, V3268)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-<=", value: __defun__shen_4type_1signature_1of_1_5_a})
 
-	__defun__shen_4type_1signature_1of_1_a = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_a = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3256 := __args[0]
 		_ = V3256
 		V3257 := __args[1]
 		_ = V3257
 		V3258 := __args[2]
 		_ = V3258
-		reg25751 := __e.Call(__defun__shen_4newpv, V3257)
+		reg25751 := Call(__e, __defun__shen_4newpv, V3257)
 		A := reg25751
 		_ = A
-		reg25752 := __e.Call(__defun__shen_4incinfs)
+		reg25752 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25752
 		reg25753 := MakeSymbol("-->")
 		reg25754 := MakeSymbol("-->")
@@ -3935,19 +3935,19 @@ func init() {
 		reg25761 := PrimCons(reg25759, reg25760)
 		reg25762 := PrimCons(reg25753, reg25761)
 		reg25763 := PrimCons(A, reg25762)
-		__ctx.TailApply(__defun__unify_b, V3256, reg25763, V3257, V3258)
+		__e.TailApply(__defun__unify_b, V3256, reg25763, V3257, V3258)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-=", value: __defun__shen_4type_1signature_1of_1_a})
 
-	__defun__shen_4type_1signature_1of_1_7 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_7 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3246 := __args[0]
 		_ = V3246
 		V3247 := __args[1]
 		_ = V3247
 		V3248 := __args[2]
 		_ = V3248
-		reg25765 := __e.Call(__defun__shen_4incinfs)
+		reg25765 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25765
 		reg25766 := MakeSymbol("number")
 		reg25767 := MakeSymbol("-->")
@@ -3962,19 +3962,19 @@ func init() {
 		reg25776 := PrimCons(reg25774, reg25775)
 		reg25777 := PrimCons(reg25767, reg25776)
 		reg25778 := PrimCons(reg25766, reg25777)
-		__ctx.TailApply(__defun__unify_b, V3246, reg25778, V3247, V3248)
+		__e.TailApply(__defun__unify_b, V3246, reg25778, V3247, V3248)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-+", value: __defun__shen_4type_1signature_1of_1_7})
 
-	__defun__shen_4type_1signature_1of_1_c = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_c = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3236 := __args[0]
 		_ = V3236
 		V3237 := __args[1]
 		_ = V3237
 		V3238 := __args[2]
 		_ = V3238
-		reg25780 := __e.Call(__defun__shen_4incinfs)
+		reg25780 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25780
 		reg25781 := MakeSymbol("number")
 		reg25782 := MakeSymbol("-->")
@@ -3989,19 +3989,19 @@ func init() {
 		reg25791 := PrimCons(reg25789, reg25790)
 		reg25792 := PrimCons(reg25782, reg25791)
 		reg25793 := PrimCons(reg25781, reg25792)
-		__ctx.TailApply(__defun__unify_b, V3236, reg25793, V3237, V3238)
+		__e.TailApply(__defun__unify_b, V3236, reg25793, V3237, V3238)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-/", value: __defun__shen_4type_1signature_1of_1_c})
 
-	__defun__shen_4type_1signature_1of_1_1 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_1 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3226 := __args[0]
 		_ = V3226
 		V3227 := __args[1]
 		_ = V3227
 		V3228 := __args[2]
 		_ = V3228
-		reg25795 := __e.Call(__defun__shen_4incinfs)
+		reg25795 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25795
 		reg25796 := MakeSymbol("number")
 		reg25797 := MakeSymbol("-->")
@@ -4016,19 +4016,19 @@ func init() {
 		reg25806 := PrimCons(reg25804, reg25805)
 		reg25807 := PrimCons(reg25797, reg25806)
 		reg25808 := PrimCons(reg25796, reg25807)
-		__ctx.TailApply(__defun__unify_b, V3226, reg25808, V3227, V3228)
+		__e.TailApply(__defun__unify_b, V3226, reg25808, V3227, V3228)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of--", value: __defun__shen_4type_1signature_1of_1_1})
 
-	__defun__shen_4type_1signature_1of_1_d = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_d = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3216 := __args[0]
 		_ = V3216
 		V3217 := __args[1]
 		_ = V3217
 		V3218 := __args[2]
 		_ = V3218
-		reg25810 := __e.Call(__defun__shen_4incinfs)
+		reg25810 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25810
 		reg25811 := MakeSymbol("number")
 		reg25812 := MakeSymbol("-->")
@@ -4043,25 +4043,25 @@ func init() {
 		reg25821 := PrimCons(reg25819, reg25820)
 		reg25822 := PrimCons(reg25812, reg25821)
 		reg25823 := PrimCons(reg25811, reg25822)
-		__ctx.TailApply(__defun__unify_b, V3216, reg25823, V3217, V3218)
+		__e.TailApply(__defun__unify_b, V3216, reg25823, V3217, V3218)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-*", value: __defun__shen_4type_1signature_1of_1_d})
 
-	__defun__shen_4type_1signature_1of_1_a_a = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4type_1signature_1of_1_a_a = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3206 := __args[0]
 		_ = V3206
 		V3207 := __args[1]
 		_ = V3207
 		V3208 := __args[2]
 		_ = V3208
-		reg25825 := __e.Call(__defun__shen_4newpv, V3207)
+		reg25825 := Call(__e, __defun__shen_4newpv, V3207)
 		A := reg25825
 		_ = A
-		reg25826 := __e.Call(__defun__shen_4newpv, V3207)
+		reg25826 := Call(__e, __defun__shen_4newpv, V3207)
 		B := reg25826
 		_ = B
-		reg25827 := __e.Call(__defun__shen_4incinfs)
+		reg25827 := Call(__e, __defun__shen_4incinfs)
 		_ = reg25827
 		reg25828 := MakeSymbol("-->")
 		reg25829 := MakeSymbol("-->")
@@ -4074,7 +4074,7 @@ func init() {
 		reg25836 := PrimCons(reg25834, reg25835)
 		reg25837 := PrimCons(reg25828, reg25836)
 		reg25838 := PrimCons(A, reg25837)
-		__ctx.TailApply(__defun__unify_b, V3206, reg25838, V3207, V3208)
+		__e.TailApply(__defun__unify_b, V3206, reg25838, V3207, V3208)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.type-signature-of-==", value: __defun__shen_4type_1signature_1of_1_a_a})

--- a/cmd/shen/writer.go
+++ b/cmd/shen/writer.go
@@ -33,47 +33,47 @@ var __defun__shen_4funexstring Obj           // shen.funexstring
 var __defun__shen_4list_2 Obj                // shen.list?
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg16656 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg16656)
+		__e.Return(reg16656)
 		return
 	}, 0))
-	__defun__pr = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__pr = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4564 := __args[0]
 		_ = V4564
 		V4565 := __args[1]
 		_ = V4565
-		reg16657 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg16657 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg16658 := MakeNumber(0)
-			__ctx.TailApply(__defun__shen_4prh, V4564, V4565, reg16658)
+			__e.TailApply(__defun__shen_4prh, V4564, V4565, reg16658)
 			return
 		}, 0)
-		reg16660 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg16660 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
-			__ctx.Return(V4564)
+			__e.Return(V4564)
 			return
 		}, 1)
-		reg16661 := __e.Try(reg16657).Catch(reg16660)
-		__ctx.Return(reg16661)
+		reg16661 := Try(__e, reg16657).Catch(reg16660)
+		__e.Return(reg16661)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "pr", value: __defun__pr})
 
-	__defun__shen_4prh = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prh = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4569 := __args[0]
 		_ = V4569
 		V4570 := __args[1]
 		_ = V4570
 		V4571 := __args[2]
 		_ = V4571
-		reg16662 := __e.Call(__defun__shen_4write_1char_1and_1inc, V4569, V4570, V4571)
-		__ctx.TailApply(__defun__shen_4prh, V4569, V4570, reg16662)
+		reg16662 := Call(__e, __defun__shen_4write_1char_1and_1inc, V4569, V4570, V4571)
+		__e.TailApply(__defun__shen_4prh, V4569, V4570, reg16662)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.prh", value: __defun__shen_4prh})
 
-	__defun__shen_4write_1char_1and_1inc = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4write_1char_1and_1inc = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4575 := __args[0]
 		_ = V4575
 		V4576 := __args[1]
@@ -86,28 +86,28 @@ func init() {
 		_ = reg16666
 		reg16667 := MakeNumber(1)
 		reg16668 := PrimNumberAdd(V4577, reg16667)
-		__ctx.Return(reg16668)
+		__e.Return(reg16668)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.write-char-and-inc", value: __defun__shen_4write_1char_1and_1inc})
 
-	__defun__print = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__print = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4579 := __args[0]
 		_ = V4579
 		reg16669 := MakeString("~S")
-		reg16670 := __e.Call(__defun__shen_4insert, V4579, reg16669)
+		reg16670 := Call(__e, __defun__shen_4insert, V4579, reg16669)
 		String := reg16670
 		_ = String
-		reg16671 := __e.Call(__defun__stoutput)
-		reg16672 := __e.Call(__defun__shen_4prhush, String, reg16671)
+		reg16671 := Call(__e, __defun__stoutput)
+		reg16672 := Call(__e, __defun__shen_4prhush, String, reg16671)
 		Print := reg16672
 		_ = Print
-		__ctx.Return(V4579)
+		__e.Return(V4579)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "print", value: __defun__print})
 
-	__defun__shen_4prhush = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4prhush = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4582 := __args[0]
 		_ = V4582
 		V4583 := __args[1]
@@ -115,37 +115,37 @@ func init() {
 		reg16673 := MakeSymbol("*hush*")
 		reg16674 := PrimValue(reg16673)
 		if reg16674 == True {
-			__ctx.Return(V4582)
+			__e.Return(V4582)
 			return
 		} else {
-			__ctx.TailApply(__defun__pr, V4582, V4583)
+			__e.TailApply(__defun__pr, V4582, V4583)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.prhush", value: __defun__shen_4prhush})
 
-	__defun__shen_4mkstr = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4mkstr = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4586 := __args[0]
 		_ = V4586
 		V4587 := __args[1]
 		_ = V4587
 		reg16676 := PrimIsString(V4586)
 		if reg16676 == True {
-			reg16677 := __e.Call(__defun__shen_4proc_1nl, V4586)
-			__ctx.TailApply(__defun__shen_4mkstr_1l, reg16677, V4587)
+			reg16677 := Call(__e, __defun__shen_4proc_1nl, V4586)
+			__e.TailApply(__defun__shen_4mkstr_1l, reg16677, V4587)
 			return
 		} else {
 			reg16679 := MakeSymbol("shen.proc-nl")
 			reg16680 := Nil
 			reg16681 := PrimCons(V4586, reg16680)
 			reg16682 := PrimCons(reg16679, reg16681)
-			__ctx.TailApply(__defun__shen_4mkstr_1r, reg16682, V4587)
+			__e.TailApply(__defun__shen_4mkstr_1r, reg16682, V4587)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.mkstr", value: __defun__shen_4mkstr})
 
-	__defun__shen_4mkstr_1l = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4mkstr_1l = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4590 := __args[0]
 		_ = V4590
 		V4591 := __args[1]
@@ -153,26 +153,26 @@ func init() {
 		reg16684 := Nil
 		reg16685 := PrimEqual(reg16684, V4591)
 		if reg16685 == True {
-			__ctx.Return(V4590)
+			__e.Return(V4590)
 			return
 		} else {
 			reg16686 := PrimIsPair(V4591)
 			if reg16686 == True {
 				reg16687 := PrimHead(V4591)
-				reg16688 := __e.Call(__defun__shen_4insert_1l, reg16687, V4590)
+				reg16688 := Call(__e, __defun__shen_4insert_1l, reg16687, V4590)
 				reg16689 := PrimTail(V4591)
-				__ctx.TailApply(__defun__shen_4mkstr_1l, reg16688, reg16689)
+				__e.TailApply(__defun__shen_4mkstr_1l, reg16688, reg16689)
 				return
 			} else {
 				reg16691 := MakeSymbol("shen.mkstr-l")
-				__ctx.TailApply(__defun__shen_4f__error, reg16691)
+				__e.TailApply(__defun__shen_4f__error, reg16691)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.mkstr-l", value: __defun__shen_4mkstr_1l})
 
-	__defun__shen_4insert_1l = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert_1l = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4596 := __args[0]
 		_ = V4596
 		V4597 := __args[1]
@@ -181,10 +181,10 @@ func init() {
 		reg16694 := PrimEqual(reg16693, V4597)
 		if reg16694 == True {
 			reg16695 := MakeString("")
-			__ctx.Return(reg16695)
+			__e.Return(reg16695)
 			return
 		} else {
-			reg16696 := __e.Call(__defun__shen_4_7string_2, V4597)
+			reg16696 := Call(__e, __defun__shen_4_7string_2, V4597)
 			var reg16722 Obj
 			if reg16696 == True {
 				reg16697 := MakeString("~")
@@ -194,7 +194,7 @@ func init() {
 				var reg16717 Obj
 				if reg16700 == True {
 					reg16701 := PrimTailString(V4597)
-					reg16702 := __e.Call(__defun__shen_4_7string_2, reg16701)
+					reg16702 := Call(__e, __defun__shen_4_7string_2, reg16701)
 					var reg16712 Obj
 					if reg16702 == True {
 						reg16703 := MakeString("A")
@@ -251,10 +251,10 @@ func init() {
 				reg16729 := PrimCons(reg16725, reg16728)
 				reg16730 := PrimCons(V4596, reg16729)
 				reg16731 := PrimCons(reg16723, reg16730)
-				__ctx.Return(reg16731)
+				__e.Return(reg16731)
 				return
 			} else {
-				reg16732 := __e.Call(__defun__shen_4_7string_2, V4597)
+				reg16732 := Call(__e, __defun__shen_4_7string_2, V4597)
 				var reg16758 Obj
 				if reg16732 == True {
 					reg16733 := MakeString("~")
@@ -264,7 +264,7 @@ func init() {
 					var reg16753 Obj
 					if reg16736 == True {
 						reg16737 := PrimTailString(V4597)
-						reg16738 := __e.Call(__defun__shen_4_7string_2, reg16737)
+						reg16738 := Call(__e, __defun__shen_4_7string_2, reg16737)
 						var reg16748 Obj
 						if reg16738 == True {
 							reg16739 := MakeString("R")
@@ -321,10 +321,10 @@ func init() {
 					reg16765 := PrimCons(reg16761, reg16764)
 					reg16766 := PrimCons(V4596, reg16765)
 					reg16767 := PrimCons(reg16759, reg16766)
-					__ctx.Return(reg16767)
+					__e.Return(reg16767)
 					return
 				} else {
-					reg16768 := __e.Call(__defun__shen_4_7string_2, V4597)
+					reg16768 := Call(__e, __defun__shen_4_7string_2, V4597)
 					var reg16794 Obj
 					if reg16768 == True {
 						reg16769 := MakeString("~")
@@ -334,7 +334,7 @@ func init() {
 						var reg16789 Obj
 						if reg16772 == True {
 							reg16773 := PrimTailString(V4597)
-							reg16774 := __e.Call(__defun__shen_4_7string_2, reg16773)
+							reg16774 := Call(__e, __defun__shen_4_7string_2, reg16773)
 							var reg16784 Obj
 							if reg16774 == True {
 								reg16775 := MakeString("S")
@@ -391,21 +391,21 @@ func init() {
 						reg16801 := PrimCons(reg16797, reg16800)
 						reg16802 := PrimCons(V4596, reg16801)
 						reg16803 := PrimCons(reg16795, reg16802)
-						__ctx.Return(reg16803)
+						__e.Return(reg16803)
 						return
 					} else {
-						reg16804 := __e.Call(__defun__shen_4_7string_2, V4597)
+						reg16804 := Call(__e, __defun__shen_4_7string_2, V4597)
 						if reg16804 == True {
 							reg16805 := MakeSymbol("cn")
 							reg16806 := MakeNumber(0)
 							reg16807 := PrimPos(V4597, reg16806)
 							reg16808 := PrimTailString(V4597)
-							reg16809 := __e.Call(__defun__shen_4insert_1l, V4596, reg16808)
+							reg16809 := Call(__e, __defun__shen_4insert_1l, V4596, reg16808)
 							reg16810 := Nil
 							reg16811 := PrimCons(reg16809, reg16810)
 							reg16812 := PrimCons(reg16807, reg16811)
 							reg16813 := PrimCons(reg16805, reg16812)
-							__ctx.TailApply(__defun__shen_4factor_1cn, reg16813)
+							__e.TailApply(__defun__shen_4factor_1cn, reg16813)
 							return
 						} else {
 							reg16815 := PrimIsPair(V4597)
@@ -489,12 +489,12 @@ func init() {
 								reg16852 := PrimTail(V4597)
 								reg16853 := PrimTail(reg16852)
 								reg16854 := PrimHead(reg16853)
-								reg16855 := __e.Call(__defun__shen_4insert_1l, V4596, reg16854)
+								reg16855 := Call(__e, __defun__shen_4insert_1l, V4596, reg16854)
 								reg16856 := Nil
 								reg16857 := PrimCons(reg16855, reg16856)
 								reg16858 := PrimCons(reg16851, reg16857)
 								reg16859 := PrimCons(reg16849, reg16858)
-								__ctx.Return(reg16859)
+								__e.Return(reg16859)
 								return
 							} else {
 								reg16860 := PrimIsPair(V4597)
@@ -598,18 +598,18 @@ func init() {
 									reg16907 := PrimTail(V4597)
 									reg16908 := PrimTail(reg16907)
 									reg16909 := PrimHead(reg16908)
-									reg16910 := __e.Call(__defun__shen_4insert_1l, V4596, reg16909)
+									reg16910 := Call(__e, __defun__shen_4insert_1l, V4596, reg16909)
 									reg16911 := PrimTail(V4597)
 									reg16912 := PrimTail(reg16911)
 									reg16913 := PrimTail(reg16912)
 									reg16914 := PrimCons(reg16910, reg16913)
 									reg16915 := PrimCons(reg16906, reg16914)
 									reg16916 := PrimCons(reg16904, reg16915)
-									__ctx.Return(reg16916)
+									__e.Return(reg16916)
 									return
 								} else {
 									reg16917 := MakeSymbol("shen.insert-l")
-									__ctx.TailApply(__defun__shen_4f__error, reg16917)
+									__e.TailApply(__defun__shen_4f__error, reg16917)
 									return
 								}
 							}
@@ -621,7 +621,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.insert-l", value: __defun__shen_4insert_1l})
 
-	__defun__shen_4factor_1cn = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4factor_1cn = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4599 := __args[0]
 		_ = V4599
 		reg16919 := PrimIsPair(V4599)
@@ -858,26 +858,26 @@ func init() {
 			reg17039 := PrimTail(reg17038)
 			reg17040 := PrimCons(reg17034, reg17039)
 			reg17041 := PrimCons(reg17026, reg17040)
-			__ctx.Return(reg17041)
+			__e.Return(reg17041)
 			return
 		} else {
-			__ctx.Return(V4599)
+			__e.Return(V4599)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.factor-cn", value: __defun__shen_4factor_1cn})
 
-	__defun__shen_4proc_1nl = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4proc_1nl = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4601 := __args[0]
 		_ = V4601
 		reg17042 := MakeString("")
 		reg17043 := PrimEqual(reg17042, V4601)
 		if reg17043 == True {
 			reg17044 := MakeString("")
-			__ctx.Return(reg17044)
+			__e.Return(reg17044)
 			return
 		} else {
-			reg17045 := __e.Call(__defun__shen_4_7string_2, V4601)
+			reg17045 := Call(__e, __defun__shen_4_7string_2, V4601)
 			var reg17071 Obj
 			if reg17045 == True {
 				reg17046 := MakeString("~")
@@ -887,7 +887,7 @@ func init() {
 				var reg17066 Obj
 				if reg17049 == True {
 					reg17050 := PrimTailString(V4601)
-					reg17051 := __e.Call(__defun__shen_4_7string_2, reg17050)
+					reg17051 := Call(__e, __defun__shen_4_7string_2, reg17050)
 					var reg17061 Obj
 					if reg17051 == True {
 						reg17052 := MakeString("%")
@@ -939,23 +939,23 @@ func init() {
 				reg17073 := PrimNumberToString(reg17072)
 				reg17074 := PrimTailString(V4601)
 				reg17075 := PrimTailString(reg17074)
-				reg17076 := __e.Call(__defun__shen_4proc_1nl, reg17075)
+				reg17076 := Call(__e, __defun__shen_4proc_1nl, reg17075)
 				reg17077 := PrimStringConcat(reg17073, reg17076)
-				__ctx.Return(reg17077)
+				__e.Return(reg17077)
 				return
 			} else {
-				reg17078 := __e.Call(__defun__shen_4_7string_2, V4601)
+				reg17078 := Call(__e, __defun__shen_4_7string_2, V4601)
 				if reg17078 == True {
 					reg17079 := MakeNumber(0)
 					reg17080 := PrimPos(V4601, reg17079)
 					reg17081 := PrimTailString(V4601)
-					reg17082 := __e.Call(__defun__shen_4proc_1nl, reg17081)
+					reg17082 := Call(__e, __defun__shen_4proc_1nl, reg17081)
 					reg17083 := PrimStringConcat(reg17080, reg17082)
-					__ctx.Return(reg17083)
+					__e.Return(reg17083)
 					return
 				} else {
 					reg17084 := MakeSymbol("shen.proc-nl")
-					__ctx.TailApply(__defun__shen_4f__error, reg17084)
+					__e.TailApply(__defun__shen_4f__error, reg17084)
 					return
 				}
 			}
@@ -963,7 +963,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.proc-nl", value: __defun__shen_4proc_1nl})
 
-	__defun__shen_4mkstr_1r = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4mkstr_1r = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4604 := __args[0]
 		_ = V4604
 		V4605 := __args[1]
@@ -971,7 +971,7 @@ func init() {
 		reg17086 := Nil
 		reg17087 := PrimEqual(reg17086, V4605)
 		if reg17087 == True {
-			__ctx.Return(V4604)
+			__e.Return(V4604)
 			return
 		} else {
 			reg17088 := PrimIsPair(V4605)
@@ -983,29 +983,29 @@ func init() {
 				reg17093 := PrimCons(reg17090, reg17092)
 				reg17094 := PrimCons(reg17089, reg17093)
 				reg17095 := PrimTail(V4605)
-				__ctx.TailApply(__defun__shen_4mkstr_1r, reg17094, reg17095)
+				__e.TailApply(__defun__shen_4mkstr_1r, reg17094, reg17095)
 				return
 			} else {
 				reg17097 := MakeSymbol("shen.mkstr-r")
-				__ctx.TailApply(__defun__shen_4f__error, reg17097)
+				__e.TailApply(__defun__shen_4f__error, reg17097)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.mkstr-r", value: __defun__shen_4mkstr_1r})
 
-	__defun__shen_4insert = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4608 := __args[0]
 		_ = V4608
 		V4609 := __args[1]
 		_ = V4609
 		reg17099 := MakeString("")
-		__ctx.TailApply(__defun__shen_4insert_1h, V4608, V4609, reg17099)
+		__e.TailApply(__defun__shen_4insert_1h, V4608, V4609, reg17099)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.insert", value: __defun__shen_4insert})
 
-	__defun__shen_4insert_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4615 := __args[0]
 		_ = V4615
 		V4616 := __args[1]
@@ -1015,10 +1015,10 @@ func init() {
 		reg17101 := MakeString("")
 		reg17102 := PrimEqual(reg17101, V4616)
 		if reg17102 == True {
-			__ctx.Return(V4617)
+			__e.Return(V4617)
 			return
 		} else {
-			reg17103 := __e.Call(__defun__shen_4_7string_2, V4616)
+			reg17103 := Call(__e, __defun__shen_4_7string_2, V4616)
 			var reg17129 Obj
 			if reg17103 == True {
 				reg17104 := MakeString("~")
@@ -1028,7 +1028,7 @@ func init() {
 				var reg17124 Obj
 				if reg17107 == True {
 					reg17108 := PrimTailString(V4616)
-					reg17109 := __e.Call(__defun__shen_4_7string_2, reg17108)
+					reg17109 := Call(__e, __defun__shen_4_7string_2, reg17108)
 					var reg17119 Obj
 					if reg17109 == True {
 						reg17110 := MakeString("A")
@@ -1079,12 +1079,12 @@ func init() {
 				reg17130 := PrimTailString(V4616)
 				reg17131 := PrimTailString(reg17130)
 				reg17132 := MakeSymbol("shen.a")
-				reg17133 := __e.Call(__defun__shen_4app, V4615, reg17131, reg17132)
+				reg17133 := Call(__e, __defun__shen_4app, V4615, reg17131, reg17132)
 				reg17134 := PrimStringConcat(V4617, reg17133)
-				__ctx.Return(reg17134)
+				__e.Return(reg17134)
 				return
 			} else {
-				reg17135 := __e.Call(__defun__shen_4_7string_2, V4616)
+				reg17135 := Call(__e, __defun__shen_4_7string_2, V4616)
 				var reg17161 Obj
 				if reg17135 == True {
 					reg17136 := MakeString("~")
@@ -1094,7 +1094,7 @@ func init() {
 					var reg17156 Obj
 					if reg17139 == True {
 						reg17140 := PrimTailString(V4616)
-						reg17141 := __e.Call(__defun__shen_4_7string_2, reg17140)
+						reg17141 := Call(__e, __defun__shen_4_7string_2, reg17140)
 						var reg17151 Obj
 						if reg17141 == True {
 							reg17142 := MakeString("R")
@@ -1145,12 +1145,12 @@ func init() {
 					reg17162 := PrimTailString(V4616)
 					reg17163 := PrimTailString(reg17162)
 					reg17164 := MakeSymbol("shen.r")
-					reg17165 := __e.Call(__defun__shen_4app, V4615, reg17163, reg17164)
+					reg17165 := Call(__e, __defun__shen_4app, V4615, reg17163, reg17164)
 					reg17166 := PrimStringConcat(V4617, reg17165)
-					__ctx.Return(reg17166)
+					__e.Return(reg17166)
 					return
 				} else {
-					reg17167 := __e.Call(__defun__shen_4_7string_2, V4616)
+					reg17167 := Call(__e, __defun__shen_4_7string_2, V4616)
 					var reg17193 Obj
 					if reg17167 == True {
 						reg17168 := MakeString("~")
@@ -1160,7 +1160,7 @@ func init() {
 						var reg17188 Obj
 						if reg17171 == True {
 							reg17172 := PrimTailString(V4616)
-							reg17173 := __e.Call(__defun__shen_4_7string_2, reg17172)
+							reg17173 := Call(__e, __defun__shen_4_7string_2, reg17172)
 							var reg17183 Obj
 							if reg17173 == True {
 								reg17174 := MakeString("S")
@@ -1211,22 +1211,22 @@ func init() {
 						reg17194 := PrimTailString(V4616)
 						reg17195 := PrimTailString(reg17194)
 						reg17196 := MakeSymbol("shen.s")
-						reg17197 := __e.Call(__defun__shen_4app, V4615, reg17195, reg17196)
+						reg17197 := Call(__e, __defun__shen_4app, V4615, reg17195, reg17196)
 						reg17198 := PrimStringConcat(V4617, reg17197)
-						__ctx.Return(reg17198)
+						__e.Return(reg17198)
 						return
 					} else {
-						reg17199 := __e.Call(__defun__shen_4_7string_2, V4616)
+						reg17199 := Call(__e, __defun__shen_4_7string_2, V4616)
 						if reg17199 == True {
 							reg17200 := PrimTailString(V4616)
 							reg17201 := MakeNumber(0)
 							reg17202 := PrimPos(V4616, reg17201)
 							reg17203 := PrimStringConcat(V4617, reg17202)
-							__ctx.TailApply(__defun__shen_4insert_1h, V4615, reg17200, reg17203)
+							__e.TailApply(__defun__shen_4insert_1h, V4615, reg17200, reg17203)
 							return
 						} else {
 							reg17205 := MakeSymbol("shen.insert-h")
-							__ctx.TailApply(__defun__shen_4f__error, reg17205)
+							__e.TailApply(__defun__shen_4f__error, reg17205)
 							return
 						}
 					}
@@ -1236,48 +1236,48 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.insert-h", value: __defun__shen_4insert_1h})
 
-	__defun__shen_4app = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4app = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4621 := __args[0]
 		_ = V4621
 		V4622 := __args[1]
 		_ = V4622
 		V4623 := __args[2]
 		_ = V4623
-		reg17207 := __e.Call(__defun__shen_4arg_1_6str, V4621, V4623)
+		reg17207 := Call(__e, __defun__shen_4arg_1_6str, V4621, V4623)
 		reg17208 := PrimStringConcat(reg17207, V4622)
-		__ctx.Return(reg17208)
+		__e.Return(reg17208)
 		return
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.app", value: __defun__shen_4app})
 
-	__defun__shen_4arg_1_6str = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4arg_1_6str = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4631 := __args[0]
 		_ = V4631
 		V4632 := __args[1]
 		_ = V4632
-		reg17209 := __e.Call(__defun__fail)
+		reg17209 := Call(__e, __defun__fail)
 		reg17210 := PrimEqual(V4631, reg17209)
 		if reg17210 == True {
 			reg17211 := MakeString("...")
-			__ctx.Return(reg17211)
+			__e.Return(reg17211)
 			return
 		} else {
-			reg17212 := __e.Call(__defun__shen_4list_2, V4631)
+			reg17212 := Call(__e, __defun__shen_4list_2, V4631)
 			if reg17212 == True {
-				__ctx.TailApply(__defun__shen_4list_1_6str, V4631, V4632)
+				__e.TailApply(__defun__shen_4list_1_6str, V4631, V4632)
 				return
 			} else {
 				reg17214 := PrimIsString(V4631)
 				if reg17214 == True {
-					__ctx.TailApply(__defun__shen_4str_1_6str, V4631, V4632)
+					__e.TailApply(__defun__shen_4str_1_6str, V4631, V4632)
 					return
 				} else {
 					reg17216 := PrimIsVector(V4631)
 					if reg17216 == True {
-						__ctx.TailApply(__defun__shen_4vector_1_6str, V4631, V4632)
+						__e.TailApply(__defun__shen_4vector_1_6str, V4631, V4632)
 						return
 					} else {
-						__ctx.TailApply(__defun__shen_4atom_1_6str, V4631)
+						__e.TailApply(__defun__shen_4atom_1_6str, V4631)
 						return
 					}
 				}
@@ -1286,7 +1286,7 @@ func init() {
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.arg->str", value: __defun__shen_4arg_1_6str})
 
-	__defun__shen_4list_1_6str = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4list_1_6str = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4635 := __args[0]
 		_ = V4635
 		V4636 := __args[1]
@@ -1296,33 +1296,33 @@ func init() {
 		if reg17220 == True {
 			reg17221 := MakeString("(")
 			reg17222 := MakeSymbol("shen.r")
-			reg17223 := __e.Call(__defun__shen_4maxseq)
-			reg17224 := __e.Call(__defun__shen_4iter_1list, V4635, reg17222, reg17223)
+			reg17223 := Call(__e, __defun__shen_4maxseq)
+			reg17224 := Call(__e, __defun__shen_4iter_1list, V4635, reg17222, reg17223)
 			reg17225 := MakeString(")")
-			reg17226 := __e.Call(__defun___8s, reg17224, reg17225)
-			__ctx.TailApply(__defun___8s, reg17221, reg17226)
+			reg17226 := Call(__e, __defun___8s, reg17224, reg17225)
+			__e.TailApply(__defun___8s, reg17221, reg17226)
 			return
 		} else {
 			reg17228 := MakeString("[")
-			reg17229 := __e.Call(__defun__shen_4maxseq)
-			reg17230 := __e.Call(__defun__shen_4iter_1list, V4635, V4636, reg17229)
+			reg17229 := Call(__e, __defun__shen_4maxseq)
+			reg17230 := Call(__e, __defun__shen_4iter_1list, V4635, V4636, reg17229)
 			reg17231 := MakeString("]")
-			reg17232 := __e.Call(__defun___8s, reg17230, reg17231)
-			__ctx.TailApply(__defun___8s, reg17228, reg17232)
+			reg17232 := Call(__e, __defun___8s, reg17230, reg17231)
+			__e.TailApply(__defun___8s, reg17228, reg17232)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.list->str", value: __defun__shen_4list_1_6str})
 
-	__defun__shen_4maxseq = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4maxseq = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg17234 := MakeSymbol("*maximum-print-sequence-size*")
 		reg17235 := PrimValue(reg17234)
-		__ctx.Return(reg17235)
+		__e.Return(reg17235)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.maxseq", value: __defun__shen_4maxseq})
 
-	__defun__shen_4iter_1list = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4iter_1list = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4650 := __args[0]
 		_ = V4650
 		V4651 := __args[1]
@@ -1333,14 +1333,14 @@ func init() {
 		reg17237 := PrimEqual(reg17236, V4650)
 		if reg17237 == True {
 			reg17238 := MakeString("")
-			__ctx.Return(reg17238)
+			__e.Return(reg17238)
 			return
 		} else {
 			reg17239 := MakeNumber(0)
 			reg17240 := PrimEqual(reg17239, V4652)
 			if reg17240 == True {
 				reg17241 := MakeString("... etc")
-				__ctx.Return(reg17241)
+				__e.Return(reg17241)
 				return
 			} else {
 				reg17242 := PrimIsPair(V4650)
@@ -1364,27 +1364,27 @@ func init() {
 				}
 				if reg17250 == True {
 					reg17251 := PrimHead(V4650)
-					__ctx.TailApply(__defun__shen_4arg_1_6str, reg17251, V4651)
+					__e.TailApply(__defun__shen_4arg_1_6str, reg17251, V4651)
 					return
 				} else {
 					reg17253 := PrimIsPair(V4650)
 					if reg17253 == True {
 						reg17254 := PrimHead(V4650)
-						reg17255 := __e.Call(__defun__shen_4arg_1_6str, reg17254, V4651)
+						reg17255 := Call(__e, __defun__shen_4arg_1_6str, reg17254, V4651)
 						reg17256 := MakeString(" ")
 						reg17257 := PrimTail(V4650)
 						reg17258 := MakeNumber(1)
 						reg17259 := PrimNumberSubtract(V4652, reg17258)
-						reg17260 := __e.Call(__defun__shen_4iter_1list, reg17257, V4651, reg17259)
-						reg17261 := __e.Call(__defun___8s, reg17256, reg17260)
-						__ctx.TailApply(__defun___8s, reg17255, reg17261)
+						reg17260 := Call(__e, __defun__shen_4iter_1list, reg17257, V4651, reg17259)
+						reg17261 := Call(__e, __defun___8s, reg17256, reg17260)
+						__e.TailApply(__defun___8s, reg17255, reg17261)
 						return
 					} else {
 						reg17263 := MakeString("|")
 						reg17264 := MakeString(" ")
-						reg17265 := __e.Call(__defun__shen_4arg_1_6str, V4650, V4651)
-						reg17266 := __e.Call(__defun___8s, reg17264, reg17265)
-						__ctx.TailApply(__defun___8s, reg17263, reg17266)
+						reg17265 := Call(__e, __defun__shen_4arg_1_6str, V4650, V4651)
+						reg17266 := Call(__e, __defun___8s, reg17264, reg17265)
+						__e.TailApply(__defun___8s, reg17263, reg17266)
 						return
 					}
 				}
@@ -1393,7 +1393,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.iter-list", value: __defun__shen_4iter_1list})
 
-	__defun__shen_4str_1_6str = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4str_1_6str = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4659 := __args[0]
 		_ = V4659
 		V4660 := __args[1]
@@ -1401,76 +1401,76 @@ func init() {
 		reg17268 := MakeSymbol("shen.a")
 		reg17269 := PrimEqual(reg17268, V4660)
 		if reg17269 == True {
-			__ctx.Return(V4659)
+			__e.Return(V4659)
 			return
 		} else {
 			reg17270 := MakeNumber(34)
 			reg17271 := PrimNumberToString(reg17270)
 			reg17272 := MakeNumber(34)
 			reg17273 := PrimNumberToString(reg17272)
-			reg17274 := __e.Call(__defun___8s, V4659, reg17273)
-			__ctx.TailApply(__defun___8s, reg17271, reg17274)
+			reg17274 := Call(__e, __defun___8s, V4659, reg17273)
+			__e.TailApply(__defun___8s, reg17271, reg17274)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.str->str", value: __defun__shen_4str_1_6str})
 
-	__defun__shen_4vector_1_6str = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4vector_1_6str = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4663 := __args[0]
 		_ = V4663
 		V4664 := __args[1]
 		_ = V4664
-		reg17277 := __e.Call(__defun__shen_4print_1vector_2, V4663)
+		reg17277 := Call(__e, __defun__shen_4print_1vector_2, V4663)
 		if reg17277 == True {
 			reg17278 := MakeNumber(0)
 			reg17279 := PrimVectorGet(V4663, reg17278)
-			reg17280 := __e.Call(__defun__function, reg17279)
+			reg17280 := Call(__e, __defun__function, reg17279)
 			f17276 := reg17280
 			_ = f17276
-			__ctx.TailApply(f17276, V4663)
+			__e.TailApply(f17276, V4663)
 			return
 		} else {
-			reg17282 := __e.Call(__defun__vector_2, V4663)
+			reg17282 := Call(__e, __defun__vector_2, V4663)
 			if reg17282 == True {
 				reg17283 := MakeString("<")
 				reg17284 := MakeNumber(1)
-				reg17285 := __e.Call(__defun__shen_4maxseq)
-				reg17286 := __e.Call(__defun__shen_4iter_1vector, V4663, reg17284, V4664, reg17285)
+				reg17285 := Call(__e, __defun__shen_4maxseq)
+				reg17286 := Call(__e, __defun__shen_4iter_1vector, V4663, reg17284, V4664, reg17285)
 				reg17287 := MakeString(">")
-				reg17288 := __e.Call(__defun___8s, reg17286, reg17287)
-				__ctx.TailApply(__defun___8s, reg17283, reg17288)
+				reg17288 := Call(__e, __defun___8s, reg17286, reg17287)
+				__e.TailApply(__defun___8s, reg17283, reg17288)
 				return
 			} else {
 				reg17290 := MakeString("<")
 				reg17291 := MakeString("<")
 				reg17292 := MakeNumber(0)
-				reg17293 := __e.Call(__defun__shen_4maxseq)
-				reg17294 := __e.Call(__defun__shen_4iter_1vector, V4663, reg17292, V4664, reg17293)
+				reg17293 := Call(__e, __defun__shen_4maxseq)
+				reg17294 := Call(__e, __defun__shen_4iter_1vector, V4663, reg17292, V4664, reg17293)
 				reg17295 := MakeString(">>")
-				reg17296 := __e.Call(__defun___8s, reg17294, reg17295)
-				reg17297 := __e.Call(__defun___8s, reg17291, reg17296)
-				__ctx.TailApply(__defun___8s, reg17290, reg17297)
+				reg17296 := Call(__e, __defun___8s, reg17294, reg17295)
+				reg17297 := Call(__e, __defun___8s, reg17291, reg17296)
+				__e.TailApply(__defun___8s, reg17290, reg17297)
 				return
 			}
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.vector->str", value: __defun__shen_4vector_1_6str})
 
-	__defun__shen_4empty_1absvector_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4empty_1absvector_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4666 := __args[0]
 		_ = V4666
 		reg17299 := MakeSymbol("shen.*empty-absvector*")
 		reg17300 := PrimValue(reg17299)
 		reg17301 := PrimEqual(V4666, reg17300)
-		__ctx.Return(reg17301)
+		__e.Return(reg17301)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.empty-absvector?", value: __defun__shen_4empty_1absvector_2})
 
-	__defun__shen_4print_1vector_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4print_1vector_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4668 := __args[0]
 		_ = V4668
-		reg17302 := __e.Call(__defun__shen_4empty_1absvector_2, V4668)
+		reg17302 := Call(__e, __defun__shen_4empty_1absvector_2, V4668)
 		reg17303 := PrimNot(reg17302)
 		if reg17303 == True {
 			reg17304 := MakeNumber(0)
@@ -1502,7 +1502,7 @@ func init() {
 						reg17316 := PrimNot(reg17315)
 						var reg17322 Obj
 						if reg17316 == True {
-							reg17317 := __e.Call(__defun__shen_4fbound_2, First)
+							reg17317 := Call(__e, __defun__shen_4fbound_2, First)
 							var reg17320 Obj
 							if reg17317 == True {
 								reg17318 := True
@@ -1548,45 +1548,45 @@ func init() {
 			}
 			if reg17334 == True {
 				reg17335 := True
-				__ctx.Return(reg17335)
+				__e.Return(reg17335)
 				return
 			} else {
 				reg17336 := False
-				__ctx.Return(reg17336)
+				__e.Return(reg17336)
 				return
 			}
 		} else {
 			reg17337 := False
-			__ctx.Return(reg17337)
+			__e.Return(reg17337)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.print-vector?", value: __defun__shen_4print_1vector_2})
 
-	__defun__shen_4fbound_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4fbound_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4670 := __args[0]
 		_ = V4670
-		reg17338 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
-			reg17339 := __e.Call(__defun__shen_4lookup_1func, V4670)
+		reg17338 := MakeNative(func(__e Evaluator, __args ...Obj) {
+			reg17339 := Call(__e, __defun__shen_4lookup_1func, V4670)
 			_ = reg17339
 			reg17340 := True
-			__ctx.Return(reg17340)
+			__e.Return(reg17340)
 			return
 		}, 0)
-		reg17341 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg17341 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
 			reg17342 := False
-			__ctx.Return(reg17342)
+			__e.Return(reg17342)
 			return
 		}, 1)
-		reg17343 := __e.Try(reg17338).Catch(reg17341)
-		__ctx.Return(reg17343)
+		reg17343 := Try(__e, reg17338).Catch(reg17341)
+		__e.Return(reg17343)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.fbound?", value: __defun__shen_4fbound_2})
 
-	__defun__shen_4tuple = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4tuple = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4672 := __args[0]
 		_ = V4672
 		reg17344 := MakeString("(@p ")
@@ -1597,26 +1597,26 @@ func init() {
 		reg17349 := PrimVectorGet(V4672, reg17348)
 		reg17350 := MakeString(")")
 		reg17351 := MakeSymbol("shen.s")
-		reg17352 := __e.Call(__defun__shen_4app, reg17349, reg17350, reg17351)
+		reg17352 := Call(__e, __defun__shen_4app, reg17349, reg17350, reg17351)
 		reg17353 := PrimStringConcat(reg17347, reg17352)
 		reg17354 := MakeSymbol("shen.s")
-		reg17355 := __e.Call(__defun__shen_4app, reg17346, reg17353, reg17354)
+		reg17355 := Call(__e, __defun__shen_4app, reg17346, reg17353, reg17354)
 		reg17356 := PrimStringConcat(reg17344, reg17355)
-		__ctx.Return(reg17356)
+		__e.Return(reg17356)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.tuple", value: __defun__shen_4tuple})
 
-	__defun__shen_4dictionary = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4dictionary = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4674 := __args[0]
 		_ = V4674
 		reg17357 := MakeString("(dict ...)")
-		__ctx.Return(reg17357)
+		__e.Return(reg17357)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.dictionary", value: __defun__shen_4dictionary})
 
-	__defun__shen_4iter_1vector = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4iter_1vector = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4685 := __args[0]
 		_ = V4685
 		V4686 := __args[1]
@@ -1629,63 +1629,63 @@ func init() {
 		reg17359 := PrimEqual(reg17358, V4688)
 		if reg17359 == True {
 			reg17360 := MakeString("... etc")
-			__ctx.Return(reg17360)
+			__e.Return(reg17360)
 			return
 		} else {
-			reg17361 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg17361 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg17362 := PrimVectorGet(V4685, V4686)
-				__ctx.Return(reg17362)
+				__e.Return(reg17362)
 				return
 			}, 0)
-			reg17363 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg17363 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg17364 := MakeSymbol("shen.out-of-bounds")
-				__ctx.Return(reg17364)
+				__e.Return(reg17364)
 				return
 			}, 1)
-			reg17365 := __e.Try(reg17361).Catch(reg17363)
+			reg17365 := Try(__e, reg17361).Catch(reg17363)
 			Item := reg17365
 			_ = Item
-			reg17366 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg17366 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				reg17367 := MakeNumber(1)
 				reg17368 := PrimNumberAdd(V4686, reg17367)
 				reg17369 := PrimVectorGet(V4685, reg17368)
-				__ctx.Return(reg17369)
+				__e.Return(reg17369)
 				return
 			}, 0)
-			reg17370 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg17370 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				E := __args[0]
 				_ = E
 				reg17371 := MakeSymbol("shen.out-of-bounds")
-				__ctx.Return(reg17371)
+				__e.Return(reg17371)
 				return
 			}, 1)
-			reg17372 := __e.Try(reg17366).Catch(reg17370)
+			reg17372 := Try(__e, reg17366).Catch(reg17370)
 			Next := reg17372
 			_ = Next
 			reg17373 := MakeSymbol("shen.out-of-bounds")
 			reg17374 := PrimEqual(Item, reg17373)
 			if reg17374 == True {
 				reg17375 := MakeString("")
-				__ctx.Return(reg17375)
+				__e.Return(reg17375)
 				return
 			} else {
 				reg17376 := MakeSymbol("shen.out-of-bounds")
 				reg17377 := PrimEqual(Next, reg17376)
 				if reg17377 == True {
-					__ctx.TailApply(__defun__shen_4arg_1_6str, Item, V4687)
+					__e.TailApply(__defun__shen_4arg_1_6str, Item, V4687)
 					return
 				} else {
-					reg17379 := __e.Call(__defun__shen_4arg_1_6str, Item, V4687)
+					reg17379 := Call(__e, __defun__shen_4arg_1_6str, Item, V4687)
 					reg17380 := MakeString(" ")
 					reg17381 := MakeNumber(1)
 					reg17382 := PrimNumberAdd(V4686, reg17381)
 					reg17383 := MakeNumber(1)
 					reg17384 := PrimNumberSubtract(V4688, reg17383)
-					reg17385 := __e.Call(__defun__shen_4iter_1vector, V4685, reg17382, V4687, reg17384)
-					reg17386 := __e.Call(__defun___8s, reg17380, reg17385)
-					__ctx.TailApply(__defun___8s, reg17379, reg17386)
+					reg17385 := Call(__e, __defun__shen_4iter_1vector, V4685, reg17382, V4687, reg17384)
+					reg17386 := Call(__e, __defun___8s, reg17380, reg17385)
+					__e.TailApply(__defun___8s, reg17379, reg17386)
 					return
 				}
 			}
@@ -1693,27 +1693,27 @@ func init() {
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.iter-vector", value: __defun__shen_4iter_1vector})
 
-	__defun__shen_4atom_1_6str = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4atom_1_6str = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4690 := __args[0]
 		_ = V4690
-		reg17388 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg17388 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg17389 := PrimStr(V4690)
-			__ctx.Return(reg17389)
+			__e.Return(reg17389)
 			return
 		}, 0)
-		reg17390 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg17390 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			E := __args[0]
 			_ = E
-			__ctx.TailApply(__defun__shen_4funexstring)
+			__e.TailApply(__defun__shen_4funexstring)
 			return
 		}, 1)
-		reg17392 := __e.Try(reg17388).Catch(reg17390)
-		__ctx.Return(reg17392)
+		reg17392 := Try(__e, reg17388).Catch(reg17390)
+		__e.Return(reg17392)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.atom->str", value: __defun__shen_4atom_1_6str})
 
-	__defun__shen_4funexstring = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4funexstring = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg17393 := MakeString("\x10")
 		reg17394 := MakeString("f")
 		reg17395 := MakeString("u")
@@ -1721,37 +1721,37 @@ func init() {
 		reg17397 := MakeString("e")
 		reg17398 := MakeString("x")
 		reg17399 := PrimIntern(reg17398)
-		reg17400 := __e.Call(__defun__gensym, reg17399)
+		reg17400 := Call(__e, __defun__gensym, reg17399)
 		reg17401 := MakeSymbol("shen.a")
-		reg17402 := __e.Call(__defun__shen_4arg_1_6str, reg17400, reg17401)
+		reg17402 := Call(__e, __defun__shen_4arg_1_6str, reg17400, reg17401)
 		reg17403 := MakeString("\x11")
-		reg17404 := __e.Call(__defun___8s, reg17402, reg17403)
-		reg17405 := __e.Call(__defun___8s, reg17397, reg17404)
-		reg17406 := __e.Call(__defun___8s, reg17396, reg17405)
-		reg17407 := __e.Call(__defun___8s, reg17395, reg17406)
-		reg17408 := __e.Call(__defun___8s, reg17394, reg17407)
-		__ctx.TailApply(__defun___8s, reg17393, reg17408)
+		reg17404 := Call(__e, __defun___8s, reg17402, reg17403)
+		reg17405 := Call(__e, __defun___8s, reg17397, reg17404)
+		reg17406 := Call(__e, __defun___8s, reg17396, reg17405)
+		reg17407 := Call(__e, __defun___8s, reg17395, reg17406)
+		reg17408 := Call(__e, __defun___8s, reg17394, reg17407)
+		__e.TailApply(__defun___8s, reg17393, reg17408)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "shen.funexstring", value: __defun__shen_4funexstring})
 
-	__defun__shen_4list_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4list_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4692 := __args[0]
 		_ = V4692
-		reg17410 := __e.Call(__defun__empty_2, V4692)
+		reg17410 := Call(__e, __defun__empty_2, V4692)
 		if reg17410 == True {
 			reg17411 := True
-			__ctx.Return(reg17411)
+			__e.Return(reg17411)
 			return
 		} else {
 			reg17412 := PrimIsPair(V4692)
 			if reg17412 == True {
 				reg17413 := True
-				__ctx.Return(reg17413)
+				__e.Return(reg17413)
 				return
 			} else {
 				reg17414 := False
-				__ctx.Return(reg17414)
+				__e.Return(reg17414)
 				return
 			}
 		}

--- a/cmd/shen/yacc.go
+++ b/cmd/shen/yacc.go
@@ -36,12 +36,12 @@ var __defun___5_b_6 Obj                              // <!>
 var __defun___5e_6 Obj                               // <e>
 
 func init() {
-	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__initExprs = append(__initExprs, MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg7394 := MakeString("Copyright (c) 2010-2015, Mark Tarver\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions are met:\n\n1. Redistributions of source code must retain the above copyright notice,\nthis list of conditions and the following disclaimer.\n\n2. Redistributions in binary form must reproduce the above copyright notice,\nthis list of conditions and the following disclaimer in the documentation\nand/or other materials provided with the distribution.\n\n3. Neither the name of the copyright holder nor the names of its contributors\nmay be used to endorse or promote products derived from this software without\nspecific prior written permission.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS'' AND\nANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED\nWARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n")
-		__ctx.Return(reg7394)
+		__e.Return(reg7394)
 		return
 	}, 0))
-	__defun__shen_4yacc = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4yacc = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4694 := __args[0]
 		_ = V4694
 		reg7395 := PrimIsPair(V4694)
@@ -85,58 +85,58 @@ func init() {
 			reg7412 := PrimHead(reg7411)
 			reg7413 := PrimTail(V4694)
 			reg7414 := PrimTail(reg7413)
-			__ctx.TailApply(__defun__shen_4yacc_1_6shen, reg7412, reg7414)
+			__e.TailApply(__defun__shen_4yacc_1_6shen, reg7412, reg7414)
 			return
 		} else {
 			reg7416 := MakeSymbol("shen.yacc")
-			__ctx.TailApply(__defun__shen_4f__error, reg7416)
+			__e.TailApply(__defun__shen_4f__error, reg7416)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.yacc", value: __defun__shen_4yacc})
 
-	__defun__shen_4yacc_1_6shen = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4yacc_1_6shen = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4697 := __args[0]
 		_ = V4697
 		V4698 := __args[1]
 		_ = V4698
 		reg7418 := True
 		reg7419 := Nil
-		reg7420 := __e.Call(__defun__shen_4split__cc__rules, reg7418, V4698, reg7419)
+		reg7420 := Call(__e, __defun__shen_4split__cc__rules, reg7418, V4698, reg7419)
 		CCRules := reg7420
 		_ = CCRules
-		reg7421 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg7421 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			X := __args[0]
 			_ = X
-			__ctx.TailApply(__defun__shen_4cc__body, X)
+			__e.TailApply(__defun__shen_4cc__body, X)
 			return
 		}, 1)
-		reg7423 := __e.Call(__defun__map, reg7421, CCRules)
+		reg7423 := Call(__e, __defun__map, reg7421, CCRules)
 		CCBody := reg7423
 		_ = CCBody
-		reg7424 := __e.Call(__defun__shen_4yacc__cases, CCBody)
+		reg7424 := Call(__e, __defun__shen_4yacc__cases, CCBody)
 		YaccCases := reg7424
 		_ = YaccCases
 		reg7425 := MakeSymbol("define")
 		reg7426 := MakeSymbol("Stream")
 		reg7427 := MakeSymbol("->")
-		reg7428 := __e.Call(__defun__shen_4kill_1code, YaccCases)
+		reg7428 := Call(__e, __defun__shen_4kill_1code, YaccCases)
 		reg7429 := Nil
 		reg7430 := PrimCons(reg7428, reg7429)
 		reg7431 := PrimCons(reg7427, reg7430)
 		reg7432 := PrimCons(reg7426, reg7431)
 		reg7433 := PrimCons(V4697, reg7432)
 		reg7434 := PrimCons(reg7425, reg7433)
-		__ctx.Return(reg7434)
+		__e.Return(reg7434)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.yacc->shen", value: __defun__shen_4yacc_1_6shen})
 
-	__defun__shen_4kill_1code = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4kill_1code = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4700 := __args[0]
 		_ = V4700
 		reg7435 := MakeSymbol("kill")
-		reg7436 := __e.Call(__defun__occurrences, reg7435, V4700)
+		reg7436 := Call(__e, __defun__occurrences, reg7435, V4700)
 		reg7437 := MakeNumber(0)
 		reg7438 := PrimGreatThan(reg7436, reg7437)
 		if reg7438 == True {
@@ -156,24 +156,24 @@ func init() {
 			reg7452 := PrimCons(reg7450, reg7451)
 			reg7453 := PrimCons(V4700, reg7452)
 			reg7454 := PrimCons(reg7439, reg7453)
-			__ctx.Return(reg7454)
+			__e.Return(reg7454)
 			return
 		} else {
-			__ctx.Return(V4700)
+			__e.Return(V4700)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.kill-code", value: __defun__shen_4kill_1code})
 
-	__defun__kill = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__kill = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg7455 := MakeString("yacc kill")
 		reg7456 := PrimSimpleError(reg7455)
-		__ctx.Return(reg7456)
+		__e.Return(reg7456)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "kill", value: __defun__kill})
 
-	__defun__shen_4analyse_1kill = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4analyse_1kill = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4702 := __args[0]
 		_ = V4702
 		reg7457 := PrimErrorToString(V4702)
@@ -182,16 +182,16 @@ func init() {
 		reg7458 := MakeString("yacc kill")
 		reg7459 := PrimEqual(String, reg7458)
 		if reg7459 == True {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		} else {
-			__ctx.Return(V4702)
+			__e.Return(V4702)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.analyse-kill", value: __defun__shen_4analyse_1kill})
 
-	__defun__shen_4split__cc__rules = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4split__cc__rules = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4708 := __args[0]
 		_ = V4708
 		V4709 := __args[1]
@@ -219,18 +219,18 @@ func init() {
 		}
 		if reg7469 == True {
 			reg7470 := Nil
-			__ctx.Return(reg7470)
+			__e.Return(reg7470)
 			return
 		} else {
 			reg7471 := Nil
 			reg7472 := PrimEqual(reg7471, V4709)
 			if reg7472 == True {
-				reg7473 := __e.Call(__defun__reverse, V4710)
+				reg7473 := Call(__e, __defun__reverse, V4710)
 				reg7474 := Nil
-				reg7475 := __e.Call(__defun__shen_4split__cc__rule, V4708, reg7473, reg7474)
+				reg7475 := Call(__e, __defun__shen_4split__cc__rule, V4708, reg7473, reg7474)
 				reg7476 := Nil
 				reg7477 := PrimCons(reg7475, reg7476)
-				__ctx.Return(reg7477)
+				__e.Return(reg7477)
 				return
 			} else {
 				reg7478 := PrimIsPair(V4709)
@@ -253,14 +253,14 @@ func init() {
 					reg7486 = reg7485
 				}
 				if reg7486 == True {
-					reg7487 := __e.Call(__defun__reverse, V4710)
+					reg7487 := Call(__e, __defun__reverse, V4710)
 					reg7488 := Nil
-					reg7489 := __e.Call(__defun__shen_4split__cc__rule, V4708, reg7487, reg7488)
+					reg7489 := Call(__e, __defun__shen_4split__cc__rule, V4708, reg7487, reg7488)
 					reg7490 := PrimTail(V4709)
 					reg7491 := Nil
-					reg7492 := __e.Call(__defun__shen_4split__cc__rules, V4708, reg7490, reg7491)
+					reg7492 := Call(__e, __defun__shen_4split__cc__rules, V4708, reg7490, reg7491)
 					reg7493 := PrimCons(reg7489, reg7492)
-					__ctx.Return(reg7493)
+					__e.Return(reg7493)
 					return
 				} else {
 					reg7494 := PrimIsPair(V4709)
@@ -268,11 +268,11 @@ func init() {
 						reg7495 := PrimTail(V4709)
 						reg7496 := PrimHead(V4709)
 						reg7497 := PrimCons(reg7496, V4710)
-						__ctx.TailApply(__defun__shen_4split__cc__rules, V4708, reg7495, reg7497)
+						__e.TailApply(__defun__shen_4split__cc__rules, V4708, reg7495, reg7497)
 						return
 					} else {
 						reg7499 := MakeSymbol("shen.split_cc_rules")
-						__ctx.TailApply(__defun__shen_4f__error, reg7499)
+						__e.TailApply(__defun__shen_4f__error, reg7499)
 						return
 					}
 				}
@@ -281,7 +281,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.split_cc_rules", value: __defun__shen_4split__cc__rules})
 
-	__defun__shen_4split__cc__rule = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4split__cc__rule = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4718 := __args[0]
 		_ = V4718
 		V4719 := __args[1]
@@ -344,10 +344,10 @@ func init() {
 			reg7525 = reg7524
 		}
 		if reg7525 == True {
-			reg7526 := __e.Call(__defun__reverse, V4720)
+			reg7526 := Call(__e, __defun__reverse, V4720)
 			reg7527 := PrimTail(V4719)
 			reg7528 := PrimCons(reg7526, reg7527)
-			__ctx.Return(reg7528)
+			__e.Return(reg7528)
 			return
 		} else {
 			reg7529 := PrimIsPair(V4719)
@@ -465,7 +465,7 @@ func init() {
 				reg7582 = reg7581
 			}
 			if reg7582 == True {
-				reg7583 := __e.Call(__defun__reverse, V4720)
+				reg7583 := Call(__e, __defun__reverse, V4720)
 				reg7584 := MakeSymbol("where")
 				reg7585 := PrimTail(V4719)
 				reg7586 := PrimTail(reg7585)
@@ -480,21 +480,21 @@ func init() {
 				reg7595 := Nil
 				reg7596 := PrimCons(reg7594, reg7595)
 				reg7597 := PrimCons(reg7583, reg7596)
-				__ctx.Return(reg7597)
+				__e.Return(reg7597)
 				return
 			} else {
 				reg7598 := Nil
 				reg7599 := PrimEqual(reg7598, V4719)
 				if reg7599 == True {
-					reg7600 := __e.Call(__defun__shen_4semantic_1completion_1warning, V4718, V4720)
+					reg7600 := Call(__e, __defun__shen_4semantic_1completion_1warning, V4718, V4720)
 					_ = reg7600
 					reg7601 := MakeSymbol(":=")
-					reg7602 := __e.Call(__defun__reverse, V4720)
-					reg7603 := __e.Call(__defun__shen_4default__semantics, reg7602)
+					reg7602 := Call(__e, __defun__reverse, V4720)
+					reg7603 := Call(__e, __defun__shen_4default__semantics, reg7602)
 					reg7604 := Nil
 					reg7605 := PrimCons(reg7603, reg7604)
 					reg7606 := PrimCons(reg7601, reg7605)
-					__ctx.TailApply(__defun__shen_4split__cc__rule, V4718, reg7606, V4720)
+					__e.TailApply(__defun__shen_4split__cc__rule, V4718, reg7606, V4720)
 					return
 				} else {
 					reg7608 := PrimIsPair(V4719)
@@ -502,11 +502,11 @@ func init() {
 						reg7609 := PrimTail(V4719)
 						reg7610 := PrimHead(V4719)
 						reg7611 := PrimCons(reg7610, V4720)
-						__ctx.TailApply(__defun__shen_4split__cc__rule, V4718, reg7609, reg7611)
+						__e.TailApply(__defun__shen_4split__cc__rule, V4718, reg7609, reg7611)
 						return
 					} else {
 						reg7613 := MakeSymbol("shen.split_cc_rule")
-						__ctx.TailApply(__defun__shen_4f__error, reg7613)
+						__e.TailApply(__defun__shen_4f__error, reg7613)
 						return
 					}
 				}
@@ -515,7 +515,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.split_cc_rule", value: __defun__shen_4split__cc__rule})
 
-	__defun__shen_4semantic_1completion_1warning = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4semantic_1completion_1warning = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4731 := __args[0]
 		_ = V4731
 		V4732 := __args[1]
@@ -524,42 +524,42 @@ func init() {
 		reg7616 := PrimEqual(reg7615, V4731)
 		if reg7616 == True {
 			reg7617 := MakeString("warning: ")
-			reg7618 := __e.Call(__defun__stoutput)
-			reg7619 := __e.Call(__defun__shen_4prhush, reg7617, reg7618)
+			reg7618 := Call(__e, __defun__stoutput)
+			reg7619 := Call(__e, __defun__shen_4prhush, reg7617, reg7618)
 			_ = reg7619
-			reg7620 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+			reg7620 := MakeNative(func(__e Evaluator, __args ...Obj) {
 				X := __args[0]
 				_ = X
 				reg7621 := MakeString(" ")
 				reg7622 := MakeSymbol("shen.a")
-				reg7623 := __e.Call(__defun__shen_4app, X, reg7621, reg7622)
-				reg7624 := __e.Call(__defun__stoutput)
-				__ctx.TailApply(__defun__shen_4prhush, reg7623, reg7624)
+				reg7623 := Call(__e, __defun__shen_4app, X, reg7621, reg7622)
+				reg7624 := Call(__e, __defun__stoutput)
+				__e.TailApply(__defun__shen_4prhush, reg7623, reg7624)
 				return
 			}, 1)
-			reg7626 := __e.Call(__defun__reverse, V4732)
-			reg7627 := __e.Call(__defun__shen_4for_1each, reg7620, reg7626)
+			reg7626 := Call(__e, __defun__reverse, V4732)
+			reg7627 := Call(__e, __defun__shen_4for_1each, reg7620, reg7626)
 			_ = reg7627
 			reg7628 := MakeString("has no semantics.\n")
-			reg7629 := __e.Call(__defun__stoutput)
-			__ctx.TailApply(__defun__shen_4prhush, reg7628, reg7629)
+			reg7629 := Call(__e, __defun__stoutput)
+			__e.TailApply(__defun__shen_4prhush, reg7628, reg7629)
 			return
 		} else {
 			reg7631 := MakeSymbol("shen.skip")
-			__ctx.Return(reg7631)
+			__e.Return(reg7631)
 			return
 		}
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.semantic-completion-warning", value: __defun__shen_4semantic_1completion_1warning})
 
-	__defun__shen_4default__semantics = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4default__semantics = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4734 := __args[0]
 		_ = V4734
 		reg7632 := Nil
 		reg7633 := PrimEqual(reg7632, V4734)
 		if reg7633 == True {
 			reg7634 := Nil
-			__ctx.Return(reg7634)
+			__e.Return(reg7634)
 			return
 		} else {
 			reg7635 := PrimIsPair(V4734)
@@ -571,7 +571,7 @@ func init() {
 				var reg7645 Obj
 				if reg7638 == True {
 					reg7639 := PrimHead(V4734)
-					reg7640 := __e.Call(__defun__shen_4grammar__symbol_2, reg7639)
+					reg7640 := Call(__e, __defun__shen_4grammar__symbol_2, reg7639)
 					var reg7643 Obj
 					if reg7640 == True {
 						reg7641 := True
@@ -600,14 +600,14 @@ func init() {
 			}
 			if reg7650 == True {
 				reg7651 := PrimHead(V4734)
-				__ctx.Return(reg7651)
+				__e.Return(reg7651)
 				return
 			} else {
 				reg7652 := PrimIsPair(V4734)
 				var reg7659 Obj
 				if reg7652 == True {
 					reg7653 := PrimHead(V4734)
-					reg7654 := __e.Call(__defun__shen_4grammar__symbol_2, reg7653)
+					reg7654 := Call(__e, __defun__shen_4grammar__symbol_2, reg7653)
 					var reg7657 Obj
 					if reg7654 == True {
 						reg7655 := True
@@ -625,12 +625,12 @@ func init() {
 					reg7660 := MakeSymbol("append")
 					reg7661 := PrimHead(V4734)
 					reg7662 := PrimTail(V4734)
-					reg7663 := __e.Call(__defun__shen_4default__semantics, reg7662)
+					reg7663 := Call(__e, __defun__shen_4default__semantics, reg7662)
 					reg7664 := Nil
 					reg7665 := PrimCons(reg7663, reg7664)
 					reg7666 := PrimCons(reg7661, reg7665)
 					reg7667 := PrimCons(reg7660, reg7666)
-					__ctx.Return(reg7667)
+					__e.Return(reg7667)
 					return
 				} else {
 					reg7668 := PrimIsPair(V4734)
@@ -638,16 +638,16 @@ func init() {
 						reg7669 := MakeSymbol("cons")
 						reg7670 := PrimHead(V4734)
 						reg7671 := PrimTail(V4734)
-						reg7672 := __e.Call(__defun__shen_4default__semantics, reg7671)
+						reg7672 := Call(__e, __defun__shen_4default__semantics, reg7671)
 						reg7673 := Nil
 						reg7674 := PrimCons(reg7672, reg7673)
 						reg7675 := PrimCons(reg7670, reg7674)
 						reg7676 := PrimCons(reg7669, reg7675)
-						__ctx.Return(reg7676)
+						__e.Return(reg7676)
 						return
 					} else {
 						reg7677 := MakeSymbol("shen.default_semantics")
-						__ctx.TailApply(__defun__shen_4f__error, reg7677)
+						__e.TailApply(__defun__shen_4f__error, reg7677)
 						return
 					}
 				}
@@ -656,13 +656,13 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.default_semantics", value: __defun__shen_4default__semantics})
 
-	__defun__shen_4grammar__symbol_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4grammar__symbol_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4736 := __args[0]
 		_ = V4736
 		reg7679 := PrimIsSymbol(V4736)
 		if reg7679 == True {
-			reg7680 := __e.Call(__defun__explode, V4736)
-			reg7681 := __e.Call(__defun__shen_4strip_1pathname, reg7680)
+			reg7680 := Call(__e, __defun__explode, V4736)
+			reg7681 := Call(__e, __defun__shen_4strip_1pathname, reg7680)
 			Cs := reg7681
 			_ = Cs
 			reg7682 := PrimHead(Cs)
@@ -670,7 +670,7 @@ func init() {
 			reg7684 := PrimEqual(reg7682, reg7683)
 			var reg7693 Obj
 			if reg7684 == True {
-				reg7685 := __e.Call(__defun__reverse, Cs)
+				reg7685 := Call(__e, __defun__reverse, Cs)
 				reg7686 := PrimHead(reg7685)
 				reg7687 := MakeString(">")
 				reg7688 := PrimEqual(reg7686, reg7687)
@@ -689,22 +689,22 @@ func init() {
 			}
 			if reg7693 == True {
 				reg7694 := True
-				__ctx.Return(reg7694)
+				__e.Return(reg7694)
 				return
 			} else {
 				reg7695 := False
-				__ctx.Return(reg7695)
+				__e.Return(reg7695)
 				return
 			}
 		} else {
 			reg7696 := False
-			__ctx.Return(reg7696)
+			__e.Return(reg7696)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.grammar_symbol?", value: __defun__shen_4grammar__symbol_2})
 
-	__defun__shen_4yacc__cases = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4yacc__cases = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4738 := __args[0]
 		_ = V4738
 		reg7697 := PrimIsPair(V4738)
@@ -728,7 +728,7 @@ func init() {
 		}
 		if reg7705 == True {
 			reg7706 := PrimHead(V4738)
-			__ctx.Return(reg7706)
+			__e.Return(reg7706)
 			return
 		} else {
 			reg7707 := PrimIsPair(V4738)
@@ -748,7 +748,7 @@ func init() {
 				reg7718 := PrimCons(P, reg7717)
 				reg7719 := PrimCons(reg7712, reg7718)
 				reg7720 := PrimTail(V4738)
-				reg7721 := __e.Call(__defun__shen_4yacc__cases, reg7720)
+				reg7721 := Call(__e, __defun__shen_4yacc__cases, reg7720)
 				reg7722 := Nil
 				reg7723 := PrimCons(P, reg7722)
 				reg7724 := PrimCons(reg7721, reg7723)
@@ -759,18 +759,18 @@ func init() {
 				reg7729 := PrimCons(reg7710, reg7728)
 				reg7730 := PrimCons(P, reg7729)
 				reg7731 := PrimCons(reg7709, reg7730)
-				__ctx.Return(reg7731)
+				__e.Return(reg7731)
 				return
 			} else {
 				reg7732 := MakeSymbol("shen.yacc_cases")
-				__ctx.TailApply(__defun__shen_4f__error, reg7732)
+				__e.TailApply(__defun__shen_4f__error, reg7732)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.yacc_cases", value: __defun__shen_4yacc__cases})
 
-	__defun__shen_4cc__body = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4cc__body = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4740 := __args[0]
 		_ = V4740
 		reg7734 := PrimIsPair(V4740)
@@ -815,17 +815,17 @@ func init() {
 			reg7752 := MakeSymbol("Stream")
 			reg7753 := PrimTail(V4740)
 			reg7754 := PrimHead(reg7753)
-			__ctx.TailApply(__defun__shen_4syntax, reg7751, reg7752, reg7754)
+			__e.TailApply(__defun__shen_4syntax, reg7751, reg7752, reg7754)
 			return
 		} else {
 			reg7756 := MakeSymbol("shen.cc_body")
-			__ctx.TailApply(__defun__shen_4f__error, reg7756)
+			__e.TailApply(__defun__shen_4f__error, reg7756)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.cc_body", value: __defun__shen_4cc__body})
 
-	__defun__shen_4syntax = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4syntax = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4744 := __args[0]
 		_ = V4744
 		V4745 := __args[1]
@@ -927,7 +927,7 @@ func init() {
 			reg7799 := MakeSymbol("if")
 			reg7800 := PrimTail(V4746)
 			reg7801 := PrimHead(reg7800)
-			reg7802 := __e.Call(__defun__shen_4semantics, reg7801)
+			reg7802 := Call(__e, __defun__shen_4semantics, reg7801)
 			reg7803 := MakeSymbol("shen.pair")
 			reg7804 := MakeSymbol("hd")
 			reg7805 := Nil
@@ -936,7 +936,7 @@ func init() {
 			reg7808 := PrimTail(V4746)
 			reg7809 := PrimTail(reg7808)
 			reg7810 := PrimHead(reg7809)
-			reg7811 := __e.Call(__defun__shen_4semantics, reg7810)
+			reg7811 := Call(__e, __defun__shen_4semantics, reg7810)
 			reg7812 := Nil
 			reg7813 := PrimCons(reg7811, reg7812)
 			reg7814 := PrimCons(reg7807, reg7813)
@@ -949,7 +949,7 @@ func init() {
 			reg7821 := PrimCons(reg7815, reg7820)
 			reg7822 := PrimCons(reg7802, reg7821)
 			reg7823 := PrimCons(reg7799, reg7822)
-			__ctx.Return(reg7823)
+			__e.Return(reg7823)
 			return
 		} else {
 			reg7824 := Nil
@@ -960,55 +960,55 @@ func init() {
 				reg7828 := Nil
 				reg7829 := PrimCons(V4745, reg7828)
 				reg7830 := PrimCons(reg7827, reg7829)
-				reg7831 := __e.Call(__defun__shen_4semantics, V4746)
+				reg7831 := Call(__e, __defun__shen_4semantics, V4746)
 				reg7832 := Nil
 				reg7833 := PrimCons(reg7831, reg7832)
 				reg7834 := PrimCons(reg7830, reg7833)
 				reg7835 := PrimCons(reg7826, reg7834)
-				__ctx.Return(reg7835)
+				__e.Return(reg7835)
 				return
 			} else {
 				reg7836 := PrimIsPair(V4744)
 				if reg7836 == True {
 					reg7837 := PrimHead(V4744)
-					reg7838 := __e.Call(__defun__shen_4grammar__symbol_2, reg7837)
+					reg7838 := Call(__e, __defun__shen_4grammar__symbol_2, reg7837)
 					if reg7838 == True {
-						__ctx.TailApply(__defun__shen_4recursive__descent, V4744, V4745, V4746)
+						__e.TailApply(__defun__shen_4recursive__descent, V4744, V4745, V4746)
 						return
 					} else {
 						reg7840 := PrimHead(V4744)
 						reg7841 := PrimIsVariable(reg7840)
 						if reg7841 == True {
-							__ctx.TailApply(__defun__shen_4variable_1match, V4744, V4745, V4746)
+							__e.TailApply(__defun__shen_4variable_1match, V4744, V4745, V4746)
 							return
 						} else {
 							reg7843 := PrimHead(V4744)
-							reg7844 := __e.Call(__defun__shen_4jump__stream_2, reg7843)
+							reg7844 := Call(__e, __defun__shen_4jump__stream_2, reg7843)
 							if reg7844 == True {
-								__ctx.TailApply(__defun__shen_4jump__stream, V4744, V4745, V4746)
+								__e.TailApply(__defun__shen_4jump__stream, V4744, V4745, V4746)
 								return
 							} else {
 								reg7846 := PrimHead(V4744)
-								reg7847 := __e.Call(__defun__shen_4terminal_2, reg7846)
+								reg7847 := Call(__e, __defun__shen_4terminal_2, reg7846)
 								if reg7847 == True {
-									__ctx.TailApply(__defun__shen_4check__stream, V4744, V4745, V4746)
+									__e.TailApply(__defun__shen_4check__stream, V4744, V4745, V4746)
 									return
 								} else {
 									reg7849 := PrimHead(V4744)
 									reg7850 := PrimIsPair(reg7849)
 									if reg7850 == True {
 										reg7851 := PrimHead(V4744)
-										reg7852 := __e.Call(__defun__shen_4decons, reg7851)
+										reg7852 := Call(__e, __defun__shen_4decons, reg7851)
 										reg7853 := PrimTail(V4744)
-										__ctx.TailApply(__defun__shen_4list_1stream, reg7852, reg7853, V4745, V4746)
+										__e.TailApply(__defun__shen_4list_1stream, reg7852, reg7853, V4745, V4746)
 										return
 									} else {
 										reg7855 := PrimHead(V4744)
 										reg7856 := MakeString(" is not legal syntax\n")
 										reg7857 := MakeSymbol("shen.a")
-										reg7858 := __e.Call(__defun__shen_4app, reg7855, reg7856, reg7857)
+										reg7858 := Call(__e, __defun__shen_4app, reg7855, reg7856, reg7857)
 										reg7859 := PrimSimpleError(reg7858)
-										__ctx.Return(reg7859)
+										__e.Return(reg7859)
 										return
 									}
 								}
@@ -1017,7 +1017,7 @@ func init() {
 					}
 				} else {
 					reg7860 := MakeSymbol("shen.syntax")
-					__ctx.TailApply(__defun__shen_4f__error, reg7860)
+					__e.TailApply(__defun__shen_4f__error, reg7860)
 					return
 				}
 			}
@@ -1025,7 +1025,7 @@ func init() {
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.syntax", value: __defun__shen_4syntax})
 
-	__defun__shen_4list_1stream = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4list_1stream = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4751 := __args[0]
 		_ = V4751
 		V4752 := __args[1]
@@ -1058,7 +1058,7 @@ func init() {
 		Test := reg7882
 		_ = Test
 		reg7883 := MakeSymbol("shen.place")
-		reg7884 := __e.Call(__defun__gensym, reg7883)
+		reg7884 := Call(__e, __defun__gensym, reg7883)
 		Placeholder := reg7884
 		_ = Placeholder
 		reg7885 := MakeSymbol("shen.pair")
@@ -1074,7 +1074,7 @@ func init() {
 		reg7895 := PrimCons(reg7893, reg7894)
 		reg7896 := PrimCons(reg7889, reg7895)
 		reg7897 := PrimCons(reg7885, reg7896)
-		reg7898 := __e.Call(__defun__shen_4syntax, V4752, reg7897, V4754)
+		reg7898 := Call(__e, __defun__shen_4syntax, V4752, reg7897, V4754)
 		RunOn := reg7898
 		_ = RunOn
 		reg7899 := MakeSymbol("shen.pair")
@@ -1090,8 +1090,8 @@ func init() {
 		reg7909 := PrimCons(reg7907, reg7908)
 		reg7910 := PrimCons(reg7903, reg7909)
 		reg7911 := PrimCons(reg7899, reg7910)
-		reg7912 := __e.Call(__defun__shen_4syntax, V4751, reg7911, Placeholder)
-		reg7913 := __e.Call(__defun__shen_4insert_1runon, RunOn, Placeholder, reg7912)
+		reg7912 := Call(__e, __defun__shen_4syntax, V4751, reg7911, Placeholder)
+		reg7913 := Call(__e, __defun__shen_4insert_1runon, RunOn, Placeholder, reg7912)
 		Action := reg7913
 		_ = Action
 		reg7914 := MakeSymbol("if")
@@ -1103,12 +1103,12 @@ func init() {
 		reg7920 := PrimCons(Action, reg7919)
 		reg7921 := PrimCons(Test, reg7920)
 		reg7922 := PrimCons(reg7914, reg7921)
-		__ctx.Return(reg7922)
+		__e.Return(reg7922)
 		return
 	}, 4)
 	__initDefs = append(__initDefs, defType{name: "shen.list-stream", value: __defun__shen_4list_1stream})
 
-	__defun__shen_4decons = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4decons = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4756 := __args[0]
 		_ = V4756
 		reg7923 := PrimIsPair(V4756)
@@ -1210,7 +1210,7 @@ func init() {
 			reg7968 := PrimHead(reg7967)
 			reg7969 := Nil
 			reg7970 := PrimCons(reg7968, reg7969)
-			__ctx.Return(reg7970)
+			__e.Return(reg7970)
 			return
 		} else {
 			reg7971 := PrimIsPair(V4756)
@@ -1293,19 +1293,19 @@ func init() {
 				reg8007 := PrimTail(V4756)
 				reg8008 := PrimTail(reg8007)
 				reg8009 := PrimHead(reg8008)
-				reg8010 := __e.Call(__defun__shen_4decons, reg8009)
+				reg8010 := Call(__e, __defun__shen_4decons, reg8009)
 				reg8011 := PrimCons(reg8006, reg8010)
-				__ctx.Return(reg8011)
+				__e.Return(reg8011)
 				return
 			} else {
-				__ctx.Return(V4756)
+				__e.Return(V4756)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.decons", value: __defun__shen_4decons})
 
-	__defun__shen_4insert_1runon = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4insert_1runon = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4771 := __args[0]
 		_ = V4771
 		V4772 := __args[1]
@@ -1406,52 +1406,52 @@ func init() {
 			reg8054 = reg8053
 		}
 		if reg8054 == True {
-			__ctx.Return(V4771)
+			__e.Return(V4771)
 			return
 		} else {
 			reg8055 := PrimIsPair(V4773)
 			if reg8055 == True {
-				reg8056 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+				reg8056 := MakeNative(func(__e Evaluator, __args ...Obj) {
 					Z := __args[0]
 					_ = Z
-					__ctx.TailApply(__defun__shen_4insert_1runon, V4771, V4772, Z)
+					__e.TailApply(__defun__shen_4insert_1runon, V4771, V4772, Z)
 					return
 				}, 1)
-				__ctx.TailApply(__defun__map, reg8056, V4773)
+				__e.TailApply(__defun__map, reg8056, V4773)
 				return
 			} else {
-				__ctx.Return(V4773)
+				__e.Return(V4773)
 				return
 			}
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.insert-runon", value: __defun__shen_4insert_1runon})
 
-	__defun__shen_4strip_1pathname = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4strip_1pathname = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4779 := __args[0]
 		_ = V4779
 		reg8059 := MakeString(".")
-		reg8060 := __e.Call(__defun__element_2, reg8059, V4779)
+		reg8060 := Call(__e, __defun__element_2, reg8059, V4779)
 		reg8061 := PrimNot(reg8060)
 		if reg8061 == True {
-			__ctx.Return(V4779)
+			__e.Return(V4779)
 			return
 		} else {
 			reg8062 := PrimIsPair(V4779)
 			if reg8062 == True {
 				reg8063 := PrimTail(V4779)
-				__ctx.TailApply(__defun__shen_4strip_1pathname, reg8063)
+				__e.TailApply(__defun__shen_4strip_1pathname, reg8063)
 				return
 			} else {
 				reg8065 := MakeSymbol("shen.strip-pathname")
-				__ctx.TailApply(__defun__shen_4f__error, reg8065)
+				__e.TailApply(__defun__shen_4f__error, reg8065)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.strip-pathname", value: __defun__shen_4strip_1pathname})
 
-	__defun__shen_4recursive__descent = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4recursive__descent = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4783 := __args[0]
 		_ = V4783
 		V4784 := __args[1]
@@ -1469,8 +1469,8 @@ func init() {
 			reg8072 := PrimTail(V4783)
 			reg8073 := MakeSymbol("Parse_")
 			reg8074 := PrimHead(V4783)
-			reg8075 := __e.Call(__defun__concat, reg8073, reg8074)
-			reg8076 := __e.Call(__defun__shen_4syntax, reg8072, reg8075, V4785)
+			reg8075 := Call(__e, __defun__concat, reg8073, reg8074)
+			reg8076 := Call(__e, __defun__shen_4syntax, reg8072, reg8075, V4785)
 			Action := reg8076
 			_ = Action
 			reg8077 := MakeSymbol("fail")
@@ -1481,7 +1481,7 @@ func init() {
 			reg8080 := MakeSymbol("let")
 			reg8081 := MakeSymbol("Parse_")
 			reg8082 := PrimHead(V4783)
-			reg8083 := __e.Call(__defun__concat, reg8081, reg8082)
+			reg8083 := Call(__e, __defun__concat, reg8081, reg8082)
 			reg8084 := MakeSymbol("if")
 			reg8085 := MakeSymbol("not")
 			reg8086 := MakeSymbol("=")
@@ -1490,7 +1490,7 @@ func init() {
 			reg8089 := PrimCons(reg8087, reg8088)
 			reg8090 := MakeSymbol("Parse_")
 			reg8091 := PrimHead(V4783)
-			reg8092 := __e.Call(__defun__concat, reg8090, reg8091)
+			reg8092 := Call(__e, __defun__concat, reg8090, reg8091)
 			reg8093 := Nil
 			reg8094 := PrimCons(reg8092, reg8093)
 			reg8095 := PrimCons(reg8089, reg8094)
@@ -1508,17 +1508,17 @@ func init() {
 			reg8107 := PrimCons(Test, reg8106)
 			reg8108 := PrimCons(reg8083, reg8107)
 			reg8109 := PrimCons(reg8080, reg8108)
-			__ctx.Return(reg8109)
+			__e.Return(reg8109)
 			return
 		} else {
 			reg8110 := MakeSymbol("shen.recursive_descent")
-			__ctx.TailApply(__defun__shen_4f__error, reg8110)
+			__e.TailApply(__defun__shen_4f__error, reg8110)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.recursive_descent", value: __defun__shen_4recursive__descent})
 
-	__defun__shen_4variable_1match = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4variable_1match = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4789 := __args[0]
 		_ = V4789
 		V4790 := __args[1]
@@ -1540,7 +1540,7 @@ func init() {
 			reg8121 := MakeSymbol("let")
 			reg8122 := MakeSymbol("Parse_")
 			reg8123 := PrimHead(V4789)
-			reg8124 := __e.Call(__defun__concat, reg8122, reg8123)
+			reg8124 := Call(__e, __defun__concat, reg8122, reg8123)
 			reg8125 := MakeSymbol("shen.hdhd")
 			reg8126 := Nil
 			reg8127 := PrimCons(V4790, reg8126)
@@ -1559,7 +1559,7 @@ func init() {
 			reg8140 := PrimCons(reg8138, reg8139)
 			reg8141 := PrimCons(reg8134, reg8140)
 			reg8142 := PrimCons(reg8130, reg8141)
-			reg8143 := __e.Call(__defun__shen_4syntax, reg8129, reg8142, V4791)
+			reg8143 := Call(__e, __defun__shen_4syntax, reg8129, reg8142, V4791)
 			reg8144 := Nil
 			reg8145 := PrimCons(reg8143, reg8144)
 			reg8146 := PrimCons(reg8128, reg8145)
@@ -1578,57 +1578,57 @@ func init() {
 			reg8155 := PrimCons(Action, reg8154)
 			reg8156 := PrimCons(Test, reg8155)
 			reg8157 := PrimCons(reg8152, reg8156)
-			__ctx.Return(reg8157)
+			__e.Return(reg8157)
 			return
 		} else {
 			reg8158 := MakeSymbol("shen.variable-match")
-			__ctx.TailApply(__defun__shen_4f__error, reg8158)
+			__e.TailApply(__defun__shen_4f__error, reg8158)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.variable-match", value: __defun__shen_4variable_1match})
 
-	__defun__shen_4terminal_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4terminal_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4801 := __args[0]
 		_ = V4801
 		reg8160 := PrimIsPair(V4801)
 		if reg8160 == True {
 			reg8161 := False
-			__ctx.Return(reg8161)
+			__e.Return(reg8161)
 			return
 		} else {
 			reg8162 := PrimIsVariable(V4801)
 			if reg8162 == True {
 				reg8163 := False
-				__ctx.Return(reg8163)
+				__e.Return(reg8163)
 				return
 			} else {
 				reg8164 := True
-				__ctx.Return(reg8164)
+				__e.Return(reg8164)
 				return
 			}
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.terminal?", value: __defun__shen_4terminal_2})
 
-	__defun__shen_4jump__stream_2 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4jump__stream_2 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4807 := __args[0]
 		_ = V4807
 		reg8165 := MakeSymbol("_")
 		reg8166 := PrimEqual(V4807, reg8165)
 		if reg8166 == True {
 			reg8167 := True
-			__ctx.Return(reg8167)
+			__e.Return(reg8167)
 			return
 		} else {
 			reg8168 := False
-			__ctx.Return(reg8168)
+			__e.Return(reg8168)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.jump_stream?", value: __defun__shen_4jump__stream_2})
 
-	__defun__shen_4check__stream = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4check__stream = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4811 := __args[0]
 		_ = V4811
 		V4812 := __args[1]
@@ -1663,7 +1663,7 @@ func init() {
 			Test := reg8192
 			_ = Test
 			reg8193 := MakeSymbol("NewStream")
-			reg8194 := __e.Call(__defun__gensym, reg8193)
+			reg8194 := Call(__e, __defun__gensym, reg8193)
 			NewStr := reg8194
 			_ = NewStr
 			reg8195 := MakeSymbol("let")
@@ -1681,7 +1681,7 @@ func init() {
 			reg8207 := PrimCons(reg8200, reg8206)
 			reg8208 := PrimCons(reg8196, reg8207)
 			reg8209 := PrimTail(V4811)
-			reg8210 := __e.Call(__defun__shen_4syntax, reg8209, NewStr, V4813)
+			reg8210 := Call(__e, __defun__shen_4syntax, reg8209, NewStr, V4813)
 			reg8211 := Nil
 			reg8212 := PrimCons(reg8210, reg8211)
 			reg8213 := PrimCons(reg8208, reg8212)
@@ -1700,17 +1700,17 @@ func init() {
 			reg8222 := PrimCons(Action, reg8221)
 			reg8223 := PrimCons(Test, reg8222)
 			reg8224 := PrimCons(reg8219, reg8223)
-			__ctx.Return(reg8224)
+			__e.Return(reg8224)
 			return
 		} else {
 			reg8225 := MakeSymbol("shen.check_stream")
-			__ctx.TailApply(__defun__shen_4f__error, reg8225)
+			__e.TailApply(__defun__shen_4f__error, reg8225)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.check_stream", value: __defun__shen_4check__stream})
 
-	__defun__shen_4jump__stream = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4jump__stream = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4817 := __args[0]
 		_ = V4817
 		V4818 := __args[1]
@@ -1743,7 +1743,7 @@ func init() {
 			reg8247 := PrimCons(reg8245, reg8246)
 			reg8248 := PrimCons(reg8241, reg8247)
 			reg8249 := PrimCons(reg8237, reg8248)
-			reg8250 := __e.Call(__defun__shen_4syntax, reg8236, reg8249, V4819)
+			reg8250 := Call(__e, __defun__shen_4syntax, reg8236, reg8249, V4819)
 			Action := reg8250
 			_ = Action
 			reg8251 := MakeSymbol("fail")
@@ -1757,55 +1757,55 @@ func init() {
 			reg8257 := PrimCons(Action, reg8256)
 			reg8258 := PrimCons(Test, reg8257)
 			reg8259 := PrimCons(reg8254, reg8258)
-			__ctx.Return(reg8259)
+			__e.Return(reg8259)
 			return
 		} else {
 			reg8260 := MakeSymbol("shen.jump_stream")
-			__ctx.TailApply(__defun__shen_4f__error, reg8260)
+			__e.TailApply(__defun__shen_4f__error, reg8260)
 			return
 		}
 	}, 3)
 	__initDefs = append(__initDefs, defType{name: "shen.jump_stream", value: __defun__shen_4jump__stream})
 
-	__defun__shen_4semantics = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4semantics = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4821 := __args[0]
 		_ = V4821
 		reg8262 := Nil
 		reg8263 := PrimEqual(reg8262, V4821)
 		if reg8263 == True {
 			reg8264 := Nil
-			__ctx.Return(reg8264)
+			__e.Return(reg8264)
 			return
 		} else {
-			reg8265 := __e.Call(__defun__shen_4grammar__symbol_2, V4821)
+			reg8265 := Call(__e, __defun__shen_4grammar__symbol_2, V4821)
 			if reg8265 == True {
 				reg8266 := MakeSymbol("shen.hdtl")
 				reg8267 := MakeSymbol("Parse_")
-				reg8268 := __e.Call(__defun__concat, reg8267, V4821)
+				reg8268 := Call(__e, __defun__concat, reg8267, V4821)
 				reg8269 := Nil
 				reg8270 := PrimCons(reg8268, reg8269)
 				reg8271 := PrimCons(reg8266, reg8270)
-				__ctx.Return(reg8271)
+				__e.Return(reg8271)
 				return
 			} else {
 				reg8272 := PrimIsVariable(V4821)
 				if reg8272 == True {
 					reg8273 := MakeSymbol("Parse_")
-					__ctx.TailApply(__defun__concat, reg8273, V4821)
+					__e.TailApply(__defun__concat, reg8273, V4821)
 					return
 				} else {
 					reg8275 := PrimIsPair(V4821)
 					if reg8275 == True {
-						reg8276 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+						reg8276 := MakeNative(func(__e Evaluator, __args ...Obj) {
 							Z := __args[0]
 							_ = Z
-							__ctx.TailApply(__defun__shen_4semantics, Z)
+							__e.TailApply(__defun__shen_4semantics, Z)
 							return
 						}, 1)
-						__ctx.TailApply(__defun__map, reg8276, V4821)
+						__e.TailApply(__defun__map, reg8276, V4821)
 						return
 					} else {
-						__ctx.Return(V4821)
+						__e.Return(V4821)
 						return
 					}
 				}
@@ -1814,7 +1814,7 @@ func init() {
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.semantics", value: __defun__shen_4semantics})
 
-	__defun__shen_4pair = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4pair = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4824 := __args[0]
 		_ = V4824
 		V4825 := __args[1]
@@ -1822,42 +1822,42 @@ func init() {
 		reg8279 := Nil
 		reg8280 := PrimCons(V4825, reg8279)
 		reg8281 := PrimCons(V4824, reg8280)
-		__ctx.Return(reg8281)
+		__e.Return(reg8281)
 		return
 	}, 2)
 	__initDefs = append(__initDefs, defType{name: "shen.pair", value: __defun__shen_4pair})
 
-	__defun__shen_4hdtl = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4hdtl = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4827 := __args[0]
 		_ = V4827
 		reg8282 := PrimTail(V4827)
 		reg8283 := PrimHead(reg8282)
-		__ctx.Return(reg8283)
+		__e.Return(reg8283)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.hdtl", value: __defun__shen_4hdtl})
 
-	__defun__shen_4hdhd = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4hdhd = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4829 := __args[0]
 		_ = V4829
 		reg8284 := PrimHead(V4829)
 		reg8285 := PrimHead(reg8284)
-		__ctx.Return(reg8285)
+		__e.Return(reg8285)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.hdhd", value: __defun__shen_4hdhd})
 
-	__defun__shen_4tlhd = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4tlhd = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4831 := __args[0]
 		_ = V4831
 		reg8286 := PrimHead(V4831)
 		reg8287 := PrimTail(reg8286)
-		__ctx.Return(reg8287)
+		__e.Return(reg8287)
 		return
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.tlhd", value: __defun__shen_4tlhd})
 
-	__defun__shen_4snd_1or_1fail = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4snd_1or_1fail = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4839 := __args[0]
 		_ = V4839
 		reg8288 := PrimIsPair(V4839)
@@ -1900,23 +1900,23 @@ func init() {
 		if reg8304 == True {
 			reg8305 := PrimTail(V4839)
 			reg8306 := PrimHead(reg8305)
-			__ctx.Return(reg8306)
+			__e.Return(reg8306)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "shen.snd-or-fail", value: __defun__shen_4snd_1or_1fail})
 
-	__defun__fail = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__fail = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg8308 := MakeSymbol("...")
-		__ctx.Return(reg8308)
+		__e.Return(reg8308)
 		return
 	}, 0)
 	__initDefs = append(__initDefs, defType{name: "fail", value: __defun__fail})
 
-	__defun___5_b_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun___5_b_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4847 := __args[0]
 		_ = V4847
 		reg8309 := PrimIsPair(V4847)
@@ -1962,16 +1962,16 @@ func init() {
 			reg8328 := Nil
 			reg8329 := PrimCons(reg8327, reg8328)
 			reg8330 := PrimCons(reg8326, reg8329)
-			__ctx.Return(reg8330)
+			__e.Return(reg8330)
 			return
 		} else {
-			__ctx.TailApply(__defun__fail)
+			__e.TailApply(__defun__fail)
 			return
 		}
 	}, 1)
 	__initDefs = append(__initDefs, defType{name: "<!>", value: __defun___5_b_6})
 
-	__defun___5e_6 = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun___5e_6 = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V4853 := __args[0]
 		_ = V4853
 		reg8332 := PrimIsPair(V4853)
@@ -2017,11 +2017,11 @@ func init() {
 			reg8351 := Nil
 			reg8352 := PrimCons(reg8350, reg8351)
 			reg8353 := PrimCons(reg8349, reg8352)
-			__ctx.Return(reg8353)
+			__e.Return(reg8353)
 			return
 		} else {
 			reg8354 := MakeSymbol("<e>")
-			__ctx.TailApply(__defun__shen_4f__error, reg8354)
+			__e.TailApply(__defun__shen_4f__error, reg8354)
 			return
 		}
 	}, 1)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tiancaiamao/shen-go
+
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/tiancaiamao/shen-go
-
-go 1.13

--- a/kl/go.mod
+++ b/kl/go.mod
@@ -1,3 +1,0 @@
-module github.com/tiancaiamao/shen-go/kl
-
-go 1.15

--- a/kl/go.mod
+++ b/kl/go.mod
@@ -1,0 +1,3 @@
+module github.com/tiancaiamao/shen-go/kl
+
+go 1.15

--- a/kl/primitives.go
+++ b/kl/primitives.go
@@ -494,7 +494,7 @@ func PrimIsInteger(args ...Obj) Obj {
 }
 
 func PrimEvalKL(e Evaluator, args ...Obj) Obj {
-	return e.evalExp(e, args[0], Nil)
+	return evalExp(e, args[0], Nil)
 }
 
 var genIdx uint64 = 0

--- a/kl/primitives_test.go
+++ b/kl/primitives_test.go
@@ -2,7 +2,7 @@ package kl
 
 import (
 	"bytes"
-	"fmt"
+	// "fmt"
 	"testing"
 )
 
@@ -32,11 +32,11 @@ func TestIntern(t *testing.T) {
 	}
 }
 
-func TestListAllPrimName(t *testing.T) {
-	for _, prim := range AllPrimitives {
-		fmt.Printf(" %s", prim.Name)
-	}
-}
+// func TestListAllPrimName(t *testing.T) {
+// 	for _, prim := range AllPrimitives {
+// 		fmt.Printf(" %s", prim.Name)
+// 	}
+// }
 
 func TestStr(t *testing.T) {
 	// str primitive prints the viewable format of a object.

--- a/kl/stub_test.go
+++ b/kl/stub_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestTrampoline(t *testing.T) {
 	// Make sure no OOM in the tail apply case by using Trampoine
-	_ = NewKLambda().Call(__defun_recur, MakeNumber(100000))
+	_ = Call(NewKLambda(), __defun_recur, MakeNumber(100000))
 }
 
 func TestFact(t *testing.T) {
-	res := NewKLambda().Call(__defun_fact0, MakeInteger(5))
+	res := Call(NewKLambda(), __defun_fact0, MakeInteger(5))
 	n := mustInteger(res)
 	if n != 120 {
 		t.Fail()
@@ -21,15 +21,15 @@ func TestFact(t *testing.T) {
 
 func TestPartialApply(t *testing.T) {
 	e := NewKLambda()
-	fn := e.Call(__defun_fact0)
-	res := e.Call(fn, MakeInteger(5))
+	fn := Call(e, __defun_fact0)
+	res := Call(e, fn, MakeInteger(5))
 	if mustInteger(res) != 120 {
 		fmt.Println(res, mustInteger(res))
 		t.Fail()
 	}
 
-	res = e.Call(MakeNative(func(_e Evaluator, ctx *ControlFlow, args ...Obj) {
-		ctx.Return(__defun_fact0)
+	res = Call(e, MakeNative(func(_e Evaluator, args ...Obj) {
+		_e.Return(__defun_fact0)
 		return
 	}, 0), MakeInteger(5))
 	if mustInteger(res) != 120 {
@@ -40,7 +40,7 @@ func TestPartialApply(t *testing.T) {
 func TestNativeCall(t *testing.T) {
 	e := NewKLambda()
 	e.RegistNativeCall("fact", __defun_fact0)
-	res := e.Eval(cons(MakeSymbol("fact"), cons(MakeInteger(5), Nil)))
+	res := Eval(e, cons(MakeSymbol("fact"), cons(MakeInteger(5), Nil)))
 	if mustInteger(res) != 120 {
 		t.Fail()
 	}
@@ -56,72 +56,72 @@ var __defun__map Obj
 var __defun__shen_4map_1h Obj
 
 func init() {
-	__defun_recur = MakeNative(func(_e Evaluator, ctx *ControlFlow, args ...Obj) {
+	__defun_recur = MakeNative(func(_e Evaluator, args ...Obj) {
 		n := args[0]
 		if equal(n, MakeInteger(0)) == True {
-			ctx.Return(n)
+			_e.Return(n)
 			return
 		} else {
 			n = PrimNumberSubtract(n, MakeInteger(1))
-			ctx.TailApply(__defun_recur, n)
+			_e.TailApply(__defun_recur, n)
 			return
 		}
 	}, 1)
 
-	__defun_fact = MakeNative(func(_e Evaluator, ctx *ControlFlow, args ...Obj) {
+	__defun_fact = MakeNative(func(_e Evaluator, args ...Obj) {
 		sum := args[0]
 		n := args[1]
 		if equal(n, MakeInteger(0)) == True {
-			ctx.Return(sum)
+			_e.Return(sum)
 			return
 		} else {
 			sum = PrimNumberMultiply(sum, n)
 			n = PrimNumberSubtract(n, MakeInteger(1))
-			ctx.TailApply(__defun_fact, sum, n)
+			_e.TailApply(__defun_fact, sum, n)
 			return
 		}
 	}, 2)
 
-	__defun_fact0 = MakeNative(func(_e Evaluator, ctx *ControlFlow, args ...Obj) {
-		res := _e.Call(__defun_fact, MakeNumber(1), args[0])
-		ctx.Return(res)
+	__defun_fact0 = MakeNative(func(_e Evaluator, args ...Obj) {
+		res := Call(_e, __defun_fact, MakeNumber(1), args[0])
+		_e.Return(res)
 		return
 	}, 1)
 
 	// (defun f () (+ 1 (trap-error (+ 2 (simple-error "xxx")) (lambda e 2))))
-	__defun__trycatch = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__trycatch = MakeNative(func(__e Evaluator, __args ...Obj) {
 		reg119880 := MakeNumber(1)
-		reg119881 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg119881 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			reg119882 := MakeNumber(2)
 			reg119883 := MakeString("xxx")
 			reg119884 := PrimSimpleError(reg119883)
 			reg119885 := PrimNumberAdd(reg119882, reg119884)
-			__ctx.Return(reg119885)
+			__e.Return(reg119885)
 			return
 		}, 0)
-		reg119886 := MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+		reg119886 := MakeNative(func(__e Evaluator, __args ...Obj) {
 			e := __args[0]
 			_ = e
 			reg119887 := MakeNumber(2)
-			__ctx.Return(reg119887)
+			__e.Return(reg119887)
 			return
 		}, 1)
-		reg119888 := __e.Try(reg119881).Catch(reg119886)
+		reg119888 := Try(__e, reg119881).Catch(reg119886)
 		reg119889 := PrimNumberAdd(reg119880, reg119888)
-		__ctx.Return(reg119889)
+		__e.Return(reg119889)
 		return
 	}, 0)
 
-	__defun__map = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__map = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3161 := __args[0]
 		_ = V3161
 		V3162 := __args[1]
 		_ = V3162
 		reg100263 := Nil
-		__ctx.TailApply(__defun__shen_4map_1h, V3161, V3162, reg100263)
+		__e.TailApply(__defun__shen_4map_1h, V3161, V3162, reg100263)
 		return
 	}, 2)
-	__defun__shen_4map_1h = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4map_1h = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3168 := __args[0]
 		_ = V3168
 		V3169 := __args[1]
@@ -131,28 +131,28 @@ func init() {
 		reg100265 := Nil
 		reg100266 := PrimEqual(reg100265, V3169)
 		if reg100266 == True {
-			__ctx.TailApply(__defun__reverse, V3170)
+			__e.TailApply(__defun__reverse, V3170)
 			return
 		} else {
 			reg100268 := PrimIsPair(V3169)
 			if reg100268 == True {
 				reg100269 := PrimTail(V3169)
 				reg100270 := PrimHead(V3169)
-				reg100271 := __e.Call(V3168, reg100270)
+				reg100271 := Call(__e, V3168, reg100270)
 				reg100272 := PrimCons(reg100271, V3170)
-				__ctx.TailApply(__defun__shen_4map_1h, V3168, reg100269, reg100272)
+				__e.TailApply(__defun__shen_4map_1h, V3168, reg100269, reg100272)
 				return
 			}
 		}
 	}, 3)
-	__defun__reverse = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__reverse = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3121 := __args[0]
 		_ = V3121
 		reg100177 := Nil
-		__ctx.TailApply(__defun__shen_4reverse__help, V3121, reg100177)
+		__e.TailApply(__defun__shen_4reverse__help, V3121, reg100177)
 		return
 	}, 1)
-	__defun__shen_4reverse__help = MakeNative(func(__e Evaluator, __ctx *ControlFlow, __args ...Obj) {
+	__defun__shen_4reverse__help = MakeNative(func(__e Evaluator, __args ...Obj) {
 		V3124 := __args[0]
 		_ = V3124
 		V3125 := __args[1]
@@ -160,7 +160,7 @@ func init() {
 		reg100179 := Nil
 		reg100180 := PrimEqual(reg100179, V3124)
 		if reg100180 == True {
-			__ctx.Return(V3125)
+			__e.Return(V3125)
 			return
 		} else {
 			reg100181 := PrimIsPair(V3124)
@@ -168,7 +168,7 @@ func init() {
 				reg100182 := PrimTail(V3124)
 				reg100183 := PrimHead(V3124)
 				reg100184 := PrimCons(reg100183, V3125)
-				__ctx.TailApply(__defun__shen_4reverse__help, reg100182, reg100184)
+				__e.TailApply(__defun__shen_4reverse__help, reg100182, reg100184)
 				return
 			}
 		}
@@ -178,16 +178,16 @@ func init() {
 func TestTryCatch(t *testing.T) {
 	e := NewKLambda()
 	// (trap-error (+ 2 (simple-error "xxx")) (lambda X (error-to-string X)))
-	res := e.Try(MakeNative(func(_e Evaluator, ctx *ControlFlow, args ...Obj) {
+	res := Try(e, MakeNative(func(_e Evaluator, args ...Obj) {
 		regXX := MakeString("xxx")
 		regYY := PrimSimpleError(regXX)
 		res := PrimNumberAdd(MakeNumber(2), regYY)
-		ctx.Return(res)
+		_e.Return(res)
 		return
-	}, 0)).Catch(MakeNative(func(_e Evaluator, ctx *ControlFlow, args ...Obj) {
+	}, 0)).Catch(MakeNative(func(_e Evaluator, args ...Obj) {
 		err := args[0]
 		res := PrimErrorToString(err)
-		ctx.Return(res)
+		_e.Return(res)
 		return
 	}, 1))
 
@@ -195,18 +195,18 @@ func TestTryCatch(t *testing.T) {
 		t.Fail()
 	}
 
-	res = e.Call(__defun__trycatch)
+	res = Call(e, __defun__trycatch)
 	if mustInteger(res) != 3 {
 		t.Fail()
 	}
 
-	res = e.Try(MakeNative(func(_e Evaluator, ctx *ControlFlow, args ...Obj) {
-		ctx.Return(MakeNumber(42))
+	res = Try(e, MakeNative(func(_e Evaluator, args ...Obj) {
+		_e.Return(MakeNumber(42))
 		return
-	}, 0)).Catch(MakeNative(func(_e Evaluator, ctx *ControlFlow, args ...Obj) {
+	}, 0)).Catch(MakeNative(func(_e Evaluator, args ...Obj) {
 		err := args[0]
 		res := PrimErrorToString(err)
-		ctx.Return(res)
+		_e.Return(res)
 		return
 	}, 1))
 	if mustInteger(res) != 42 {
@@ -234,7 +234,7 @@ func TestFusion(t *testing.T) {
 			t.Error(err)
 		}
 
-		obtain := e.Eval(sexp)
+		obtain := Eval(e, sexp)
 		if equal(expect, obtain) == False {
 			t.Fail()
 		}

--- a/kl/types.go
+++ b/kl/types.go
@@ -88,12 +88,12 @@ type ScmPrimitive struct {
 
 type scmNative struct {
 	scmHead
-	fn       func(Evaluator, *ControlFlow, ...Obj)
+	fn       func(Evaluator, ...Obj)
 	require  int
 	captured []Obj
 }
 
-func MakeNative(fn func(Evaluator, *ControlFlow, ...Obj), require int, captured ...Obj) Obj {
+func MakeNative(fn func(Evaluator, ...Obj), require int, captured ...Obj) Obj {
 	tmp := scmNative{
 		scmHead:  scmHeadNative,
 		fn:       fn,
@@ -209,6 +209,14 @@ func mustInteger(o Obj) int {
 		return fixnum(o)
 	}
 
+	f := (*scmNumber)(unsafe.Pointer(o)).val
+	return int(f)
+}
+
+func GetInteger(o Obj) int {
+	if isFixnum(o) {
+		return fixnum(o)
+	}
 	f := (*scmNumber)(unsafe.Pointer(o)).val
 	return int(f)
 }


### PR DESCRIPTION
expose those methods:

- TailEval(exp Obj, env Obj)
- TailApply(f Obj, args ...Obj)
- Return(result Obj)
- Get(n int) Obj
    
expose the Call() function:

- func Call(e Evaluator, f Obj, args ...Obj) Obj
    
expose the Eval() function:

- func Eval(e Evaluator, exp Obj) Obj

