### PR TITLE
src: add a let-loop macro

### DIFF
--- a/src/let-loop.cora
+++ b/src/let-loop.cora
@@ -1,0 +1,43 @@
+;; (let-loop recur (i 0 y 1)
+;;           (if (= i 100)
+;;               42
+;;             (recur (+ i 1) y)))
+;;  ==>
+;; (let f (lambda (meta n sum)
+;; 	  (let recur (meta meta)
+;; 	       (if (= n 100)
+;; 		   sum
+;; 		 (recur (+ n 1) (+ sum n)))))
+;;      (f f))
+
+(func extract-params-h
+      res [] => (reverse res)
+      res [x y . l] => (extract-params-h [x . res] l))
+
+(func extract-init-h
+      res [] => (reverse res)
+      res [x y . l] => (extract-init-h [y . res] l))
+
+(func rewrite-let-loop-macro
+      [recur param-init body] => (let params (extract-params-h [] param-init)
+                                    inits (extract-init-h [] param-init)
+				    meta (gensym 'meta)
+				    f (gensym 'f)
+				    [['let f ['lambda [meta . params]
+				    	      	  ['let recur [meta meta]
+				    	     	    body]]
+					[f f]] . inits]))
+
+(defmacro let-loop (exp)
+  (rewrite-let-loop-macro (cdr exp)))
+
+;; (func fold
+;;       acc fn [] => acc
+;;       acc fn [h . t] => (fold (fn acc h) fn t))
+
+;; (func range-h
+;;       res start end => (reverse res) where (= start end)
+;;       res start end => (range-h [start . res] (+ start 1) end))
+
+;; (defun range (start end)
+;;   (range-h () start end))


### PR DESCRIPTION
The let loop macro works just like the scheme language:

```
(let-loop recur (i 0 y 1)
          (if (= i 100)
              42
            (recur (+ i 1) y)))
```

And I have written a [blog](HTTP://www.zenlife.tk/let-loop-macro.md) for it (in CN)