### PR TITLE
*: fix issue 12, issue 18 and PrimEqual for scmNative

### DIFF
--- a/cmd/kl/main.go
+++ b/cmd/kl/main.go
@@ -111,7 +111,7 @@ var klPrimitives = []struct {
 	{"symbol?", 1, kl.PrimIsSymbol},
 	{"read-file-as-bytelist", 1, kl.PrimReadFileAsByteList},
 	{"read-file-as-string", 1, kl.PrimReadFileAsString},
-	{"variable?", 1, kl.PrimIsVariable},
+	{"variable?", 1, PrimIsVariable},
 	{"integer?", 1, kl.PrimIsInteger},
 }
 
@@ -191,4 +191,16 @@ func primLoad(e *kl.ControlFlow) {
 		}
 	}
 	e.Return(kl.MakeSymbol("loaded"))
+}
+
+func PrimIsVariable(x kl.Obj) kl.Obj {
+	if !kl.IsSymbol(x) {
+		return kl.False
+	}
+
+	sym := kl.GetSymbol(x)
+	if len(sym) == 0 || sym[0] < 'A' || sym[0] > 'Z' {
+		return kl.False
+	}
+	return kl.True
 }

--- a/cmd/shen/main.go
+++ b/cmd/shen/main.go
@@ -141,7 +141,7 @@ var klPrimitives = []struct {
 	{"symbol?", 1, kl.PrimIsSymbol},
 	{"read-file-as-bytelist", 1, kl.PrimReadFileAsByteList},
 	{"read-file-as-string", 1, kl.PrimReadFileAsString},
-	{"variable?", 1, kl.PrimIsVariable},
+	{"variable?", 1, PrimIsVariable},
 	{"integer?", 1, kl.PrimIsInteger},
 }
 
@@ -221,4 +221,16 @@ func primLoad(e *kl.ControlFlow) {
 		}
 	}
 	e.Return(kl.MakeSymbol("loaded"))
+}
+
+func PrimIsVariable(x kl.Obj) kl.Obj {
+	if !kl.IsSymbol(x) {
+		return kl.False
+	}
+
+	sym := kl.GetSymbol(x)
+	if len(sym) == 0 || sym[0] < 'A' || sym[0] > 'Z' {
+		return kl.False
+	}
+	return kl.True
 }

--- a/kl/eval.go
+++ b/kl/eval.go
@@ -221,7 +221,7 @@ func eval(e *ControlFlow) {
 	exp := e.data[e.pos]
 	env := e.data[e.pos+1]
 
-	enableDebug := mustSymbol(symDebug).value
+	enableDebug := mustSymbol(symDebug).cora
 	if enableDebug != nil && enableDebug != Nil {
 		fmt.Println("eval === exp:", ObjString(exp))
 	}

--- a/kl/library.go
+++ b/kl/library.go
@@ -72,7 +72,7 @@ func equal(x, y Obj) Obj {
 				return False
 			}
 		}
-	case scmHeadStream, scmHeadProcedure /* , scmHeadPrimitive */ :
+	case scmHeadStream, scmHeadProcedure, scmHeadNative:
 		if x != y {
 			return False
 		}

--- a/kl/primitives_test.go
+++ b/kl/primitives_test.go
@@ -65,3 +65,10 @@ func TestStr(t *testing.T) {
 		t.Error("str of procedure should not be all alpha")
 	}
 }
+
+func TestFixnum(t *testing.T) {
+	n := MakeNumber(3000001)
+	if PrimIsPair(n) != False {
+		t.Error("3000000 should not be a cons")
+	}
+}

--- a/kl/types.go
+++ b/kl/types.go
@@ -248,7 +248,7 @@ var symOr, symIf, symCond, symTrapError, symDo, symMacroExpand Obj
 
 var addrForFixnum [1 << 20]byte
 
-const fixnumCount = 8 << 20
+const fixnumCount = 1 << 20
 
 var fixnumBaseAddr = uintptr(unsafe.Pointer(&addrForFixnum[0]))
 var fixnumEndAddr = fixnumBaseAddr + fixnumCount
@@ -428,6 +428,9 @@ func (o *scmPair) fmt(buf io.Writer, start bool) {
 func (o *scmHead) GoString() string {
 	switch *o {
 	case scmHeadNumber:
+		if isFixnum(o) {
+			return fmt.Sprintf("%d", uintptr(unsafe.Pointer(o))-fixnumBaseAddr)
+		}
 		f := mustNumber(o)
 		if !isPreciseInteger(f) {
 			return fmt.Sprintf("%f", f)

--- a/kl/types.go
+++ b/kl/types.go
@@ -428,9 +428,6 @@ func (o *scmPair) fmt(buf io.Writer, start bool) {
 func (o *scmHead) GoString() string {
 	switch *o {
 	case scmHeadNumber:
-		if isFixnum(o) {
-			return fmt.Sprintf("%d", uintptr(unsafe.Pointer(o))-fixnumBaseAddr)
-		}
 		f := mustNumber(o)
 		if !isPreciseInteger(f) {
 			return fmt.Sprintf("%f", f)


### PR DESCRIPTION
Fix https://github.com/tiancaiamao/shen-go/issues/18  and  https://github.com/tiancaiamao/shen-go/issues/12

They are caused by fixnum goes out of range of the underlying memory.

Fix comparison of two Native, before this change:

```
(load-so "init.so")
(= map reverse) // should return false, but get true!
```