### PR TITLE
*: make 'type' as a macro instead of a primitive, all test pass

### DIFF
--- a/S31/KLambda/sys.kl
+++ b/S31/KLambda/sys.kl
@@ -36,8 +36,6 @@
 
 (defun limit (V3376) (<-address V3376 0))
 
-(defun symbol? (V3377) (cond ((or (boolean? V3377) (or (number? V3377) (or (string? V3377) (or (cons? V3377) (or (empty? V3377) (vector? V3377)))))) false) ((element? V3377 (cons { (cons } (cons (intern ":") (cons (intern ";") (cons (intern ",") ())))))) true) (true (trap-error (let String (str V3377) (shen.analyse-symbol? String)) (lambda E false)))))
-
 (defun shen.analyse-symbol? (V3380) (cond ((shen.+string? V3380) (and (shen.alpha? (string->n (hdstr V3380))) (shen.alphanums? (tlstr V3380)))) (true (simple-error "implementation error in shen.analyse-symbol?"))))
 
 (defun shen.alphanums? (V3383) (cond ((= "" V3383) true) ((shen.+string? V3383) (let N (string->n (hdstr V3383)) (and (or (shen.alpha? N) (shen.digit? N)) (shen.alphanums? (tlstr V3383))))) (true (simple-error "implementation error in shen.alphanums?"))))

--- a/cora/build.cora
+++ b/cora/build.cora
@@ -4,7 +4,7 @@
   env ['if x y z] => ['if (kl->cora env x) (kl->cora env y) (kl->cora env z)]
   env ['do x y] => ['do (kl->cora env x) (kl->cora env y)]
   env ['lambda x y] => ['lambda [x] (kl->cora [x . env] y)]
-
+  env ['type exp _] => (kl->cora env exp)
   env ['defun f x y] => ['ns2-set ['quote f] ['lambda x (kl->cora x y)]]
   env ['let x y z] => [['lambda [x] (kl->cora (cons x env) z)] (kl->cora env y)]
   env ['trap-error body handler] => ['try-catch ['lambda [] (kl->cora env body)] (kl->cora env handler)]


### PR DESCRIPTION
- make 'type' as a macro
- override the symbol? primitive

S31 use something like `(type XXX (list Symbol))`, eval the second parameter will result in error.
So `type` primitive should be a primitive, it should be a macro-like so the evaluation rule can ignore the second parameter.

See https://groups.google.com/g/qilang/c/3ZhDzl_-e9s

Now all test S31 test pass using the interpreter mode.