### PR TITLE
cora: change the runtime environment representation for 'closure as codegen'

### DIFF
--- a/cmd/cora/main.go
+++ b/cmd/cora/main.go
@@ -36,12 +36,20 @@ func main() {
 	cora.PrimNS1Set(cora.MakeSymbol("cg:bc->go"), bcToGo)
 
 	if !quiet {
-		cora.CoraInit(&e, false)
+		cora.CoraInit(&e, true)
 		if cora.IsError(e.Get(0)) {
 			os.Exit(-1)
 		}
 	}
 	repl(&e)
+}
+
+func macroExpand(sexp cora.Obj) cora.Obj {
+	expand := cora.PrimNS1Value(symMacroExpand)
+	if expand != cora.Nil {
+		sexp = cora.NCall(expand, sexp)
+	}
+	return sexp
 }
 
 func repl(e *cora.ControlFlow) {
@@ -56,13 +64,10 @@ func repl(e *cora.ControlFlow) {
 			break
 		}
 
-		expand := cora.PrimNS1Value(symMacroExpand)
-		if expand != cora.Nil {
-			sexp = cora.Call(e, expand, sexp)
-		}
+		sexp = macroExpand(sexp)
 		// fmt.Println("after macroexpand = ", cora.ObjString(sexp))
 
-		res := cora.Eval(e, sexp)
+		res := cora.Neval(sexp)
 		fmt.Println(cora.ObjString(res))
 	}
 }

--- a/cora/closure.go
+++ b/cora/closure.go
@@ -36,7 +36,7 @@ func (env *compileEnv) findVariable(s Obj) (m int, n int) {
 }
 
 type posRef struct {
-	up int
+	up     int
 	offset int
 }
 
@@ -48,7 +48,7 @@ func compile(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(
 		m, n := env.findVariable(exp)
 		if m == 0 {
 			// local[0] is the closure object, the real args begins from i+1
-			return genLocalRefInst(n+1)
+			return genLocalRefInst(n + 1)
 		}
 		if m > 0 {
 			freeVars[exp] = posRef{up: m, offset: n}
@@ -90,7 +90,7 @@ func compile(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(
 			for v, p := range collectFVs {
 				if p.up != 1 {
 					// Collect to freeVars and delete from this one.
-					freeVars[v] = posRef{up: p.up-1, offset: p.offset}
+					freeVars[v] = posRef{up: p.up - 1, offset: p.offset}
 					delete(collectFVs, v)
 				}
 			}
@@ -152,7 +152,7 @@ func genLocalRefInst(idx int) func(Env) {
 func genClosureRefInst(m, n int) func(Env) {
 	return func(env Env) {
 		clo := mustClosure(env[0])
-		for i:=1; i<m; i++{
+		for i := 1; i < m; i++ {
 			clo = clo.parent
 		}
 		val = clo.freeVars[n]

--- a/cora/closure_test.go
+++ b/cora/closure_test.go
@@ -14,17 +14,17 @@ func TestXXX(t *testing.T) {
 		output string
 	}
 	cases := []testCase{
-	// 	testCase{
-	// 		name:   "curry-partial",
-	// 		input:  `((lambda (x) (lambda (y z) (+ x z))) 1 2 3)`,
-	// 		output: "4",
-	// 	},
+		testCase{
+			name:   "curry-partial",
+			input:  `((lambda (x) (lambda (y z) (+ x z))) 1 2 3)`,
+			output: "4",
+		},
 
-		// testCase{
-		// 	name:   "curry",
-		// 	input:  `((((lambda (x y z) y)) 1 2) 3)`,
-		// 	output: "2",
-		// },
+		testCase{
+			name:   "curry",
+			input:  `((((lambda (x y z) y)) 1 2) 3)`,
+			output: "2",
+		},
 
 		testCase{
 			name: "curry1",
@@ -37,101 +37,101 @@ func TestXXX(t *testing.T) {
 			output: "2",
 		},
 
-	// 	testCase{
-	// 		name: "fib10",
-	// 		input: `(do (set (quote fib)
-	// (lambda (i)
-	// (if (= i 0)
-	//     1
-	//     (if (= i 1)
-	// 	1
-	// 	(+ (fib (- i 1)) (fib (- i 2)))))))
-	// (fib 10))`,
-	// 		output: "89",
-	// 	},
+		testCase{
+			name: "fib10",
+			input: `(do (set (quote fib)
+	(lambda (i)
+	(if (= i 0)
+	    1
+	    (if (= i 1)
+		1
+		(+ (fib (- i 1)) (fib (- i 2)))))))
+	(fib 10))`,
+			output: "89",
+		},
 
-	// 	testCase{
-	// 		name: "proper tail call",
-	// 		input: `(do (set (quote sum)
-	// (lambda (r i)
-	//   (if (= i 0)
-	//       r
-	//       (sum (+ r 1) (- i 1)))))
-	// (sum 0 5000000))`,
-	// 		output: "5000000",
-	// 	},
+		testCase{
+			name: "proper tail call",
+			input: `(do (set (quote sum)
+	(lambda (r i)
+	  (if (= i 0)
+	      r
+	      (sum (+ r 1) (- i 1)))))
+	(sum 0 5000000))`,
+			output: "5000000",
+		},
 
-	// 	testCase{
-	// 		name:   "do in args",
-	// 		input:  `(+ (do 1 (do 2 3)) 4)`,
-	// 		output: "7",
-	// 	},
+		testCase{
+			name:   "do in args",
+			input:  `(+ (do 1 (do 2 3)) 4)`,
+			output: "7",
+		},
 
-	// 	testCase{
-	// 		name:   "partial primitive",
-	// 		input:  `(+ (+ (+ 1 2) 3) 4)`,
-	// 		output: "10",
-	// 	},
+		testCase{
+			name:   "partial primitive",
+			input:  `(+ (+ (+ 1 2) 3) 4)`,
+			output: "10",
+		},
 
-	// 	testCase{
-	// 		name:   "do in tail call",
-	// 		input:  `((lambda (x y z) (do 1 (do 2 z))) 1 2 3)`,
-	// 		output: "3",
-	// 	},
+		testCase{
+			name:   "do in tail call",
+			input:  `((lambda (x y z) (do 1 (do 2 z))) 1 2 3)`,
+			output: "3",
+		},
 
-	// 	testCase{
-	// 		name:   "basic func call",
-	// 		input:  `(do (set (quote id) (lambda (x) x)) (id (do 1 (do 2 42))))`,
-	// 		output: "42",
-	// 	},
+		testCase{
+			name:   "basic func call",
+			input:  `(do (set (quote id) (lambda (x) x)) (id (do 1 (do 2 42))))`,
+			output: "42",
+		},
 
-	// 	testCase{
-	// 		name:   "identify function",
-	// 		input:  `(do (set (quote id) (lambda (x) x)) (id 42))`,
-	// 		output: "42",
-	// 	},
+		testCase{
+			name:   "identify function",
+			input:  `(do (set (quote id) (lambda (x) x)) (id 42))`,
+			output: "42",
+		},
 
-	// 	testCase{
-	// 		name:   "basic set",
-	// 		input:  `(do (set (quote x) 42) x)`,
-	// 		output: "42",
-	// 	},
+		testCase{
+			name:   "basic set",
+			input:  `(do (set (quote x) 42) x)`,
+			output: "42",
+		},
 
-	// 	testCase{
-	// 		name:   "basic if",
-	// 		input:  `(if true 1 2)`,
-	// 		output: "1",
-	// 	},
+		testCase{
+			name:   "basic if",
+			input:  `(if true 1 2)`,
+			output: "1",
+		},
 
-	// 	testCase{
-	// 		name:   "basic lambda",
-	// 		input:  `((lambda (x y z) z) 1 2 3)`,
-	// 		output: "3",
-	// 	},
+		testCase{
+			name:   "basic lambda",
+			input:  `((lambda (x y z) z) 1 2 3)`,
+			output: "3",
+		},
 
-	// 	testCase{
-	// 		name:   "basic do",
-	// 		input:  `(do 1 2)`,
-	// 		output: "2",
-	// 	},
+		testCase{
+			name:   "basic do",
+			input:  `(do 1 2)`,
+			output: "2",
+		},
 
-	// 	testCase{
-	// 		name:   "basic primitive",
-	// 		input:  `(+ 3 7)`,
-	// 		output: "10",
-	// 	},
+		testCase{
+			name:   "basic primitive",
+			input:  `(+ 3 7)`,
+			output: "10",
+		},
 
-	// 	testCase{
-	// 		name:   "partial primitive1",
-	// 		input:  `((+ 1) 2)`,
-	// 		output: "3",
-	// 	},
+		testCase{
+			name:   "partial primitive1",
+			input:  `((+ 1) 2)`,
+			output: "3",
+		},
 
-	// 	testCase{
-	// 		name:   "partial primitive2",
-	// 		input:  `(((+) 1) 2)`,
-	// 		output: "3",
-	// 	},
+		testCase{
+			name:   "partial primitive2",
+			input:  `(((+) 1) 2)`,
+			output: "3",
+		},
 	}
 
 	for _, c := range cases {

--- a/cora/closure_test.go
+++ b/cora/closure_test.go
@@ -14,17 +14,17 @@ func TestXXX(t *testing.T) {
 		output string
 	}
 	cases := []testCase{
-		testCase{
-			name:   "curry-partial",
-			input:  `((lambda (x) (lambda (y z) (+ x z))) 1 2 3)`,
-			output: "4",
-		},
+	// 	testCase{
+	// 		name:   "curry-partial",
+	// 		input:  `((lambda (x) (lambda (y z) (+ x z))) 1 2 3)`,
+	// 		output: "4",
+	// 	},
 
-		testCase{
-			name:   "curry",
-			input:  `((((lambda (x y z) y)) 1 2) 3)`,
-			output: "2",
-		},
+		// testCase{
+		// 	name:   "curry",
+		// 	input:  `((((lambda (x y z) y)) 1 2) 3)`,
+		// 	output: "2",
+		// },
 
 		testCase{
 			name: "curry1",
@@ -37,101 +37,101 @@ func TestXXX(t *testing.T) {
 			output: "2",
 		},
 
-		testCase{
-			name: "fib10",
-			input: `(do (set (quote fib)
-	(lambda (i)
-	(if (= i 0)
-	    1
-	    (if (= i 1)
-		1
-		(+ (fib (- i 1)) (fib (- i 2)))))))
-	(fib 10))`,
-			output: "89",
-		},
+	// 	testCase{
+	// 		name: "fib10",
+	// 		input: `(do (set (quote fib)
+	// (lambda (i)
+	// (if (= i 0)
+	//     1
+	//     (if (= i 1)
+	// 	1
+	// 	(+ (fib (- i 1)) (fib (- i 2)))))))
+	// (fib 10))`,
+	// 		output: "89",
+	// 	},
 
-		testCase{
-			name: "proper tail call",
-			input: `(do (set (quote sum)
-	(lambda (r i)
-	  (if (= i 0)
-	      r
-	      (sum (+ r 1) (- i 1)))))
-	(sum 0 5000000))`,
-			output: "5000000",
-		},
+	// 	testCase{
+	// 		name: "proper tail call",
+	// 		input: `(do (set (quote sum)
+	// (lambda (r i)
+	//   (if (= i 0)
+	//       r
+	//       (sum (+ r 1) (- i 1)))))
+	// (sum 0 5000000))`,
+	// 		output: "5000000",
+	// 	},
 
-		testCase{
-			name:   "do in args",
-			input:  `(+ (do 1 (do 2 3)) 4)`,
-			output: "7",
-		},
+	// 	testCase{
+	// 		name:   "do in args",
+	// 		input:  `(+ (do 1 (do 2 3)) 4)`,
+	// 		output: "7",
+	// 	},
 
-		testCase{
-			name:   "partial primitive",
-			input:  `(+ (+ (+ 1 2) 3) 4)`,
-			output: "10",
-		},
+	// 	testCase{
+	// 		name:   "partial primitive",
+	// 		input:  `(+ (+ (+ 1 2) 3) 4)`,
+	// 		output: "10",
+	// 	},
 
-		testCase{
-			name:   "do in tail call",
-			input:  `((lambda (x y z) (do 1 (do 2 z))) 1 2 3)`,
-			output: "3",
-		},
+	// 	testCase{
+	// 		name:   "do in tail call",
+	// 		input:  `((lambda (x y z) (do 1 (do 2 z))) 1 2 3)`,
+	// 		output: "3",
+	// 	},
 
-		testCase{
-			name:   "basic func call",
-			input:  `(do (set (quote id) (lambda (x) x)) (id (do 1 (do 2 42))))`,
-			output: "42",
-		},
+	// 	testCase{
+	// 		name:   "basic func call",
+	// 		input:  `(do (set (quote id) (lambda (x) x)) (id (do 1 (do 2 42))))`,
+	// 		output: "42",
+	// 	},
 
-		testCase{
-			name:   "identify function",
-			input:  `(do (set (quote id) (lambda (x) x)) (id 42))`,
-			output: "42",
-		},
+	// 	testCase{
+	// 		name:   "identify function",
+	// 		input:  `(do (set (quote id) (lambda (x) x)) (id 42))`,
+	// 		output: "42",
+	// 	},
 
-		testCase{
-			name:   "basic set",
-			input:  `(do (set (quote x) 42) x)`,
-			output: "42",
-		},
+	// 	testCase{
+	// 		name:   "basic set",
+	// 		input:  `(do (set (quote x) 42) x)`,
+	// 		output: "42",
+	// 	},
 
-		testCase{
-			name:   "basic if",
-			input:  `(if true 1 2)`,
-			output: "1",
-		},
+	// 	testCase{
+	// 		name:   "basic if",
+	// 		input:  `(if true 1 2)`,
+	// 		output: "1",
+	// 	},
 
-		testCase{
-			name:   "basic lambda",
-			input:  `((lambda (x y z) z) 1 2 3)`,
-			output: "3",
-		},
+	// 	testCase{
+	// 		name:   "basic lambda",
+	// 		input:  `((lambda (x y z) z) 1 2 3)`,
+	// 		output: "3",
+	// 	},
 
-		testCase{
-			name:   "basic do",
-			input:  `(do 1 2)`,
-			output: "2",
-		},
+	// 	testCase{
+	// 		name:   "basic do",
+	// 		input:  `(do 1 2)`,
+	// 		output: "2",
+	// 	},
 
-		testCase{
-			name:   "basic primitive",
-			input:  `(+ 3 7)`,
-			output: "10",
-		},
+	// 	testCase{
+	// 		name:   "basic primitive",
+	// 		input:  `(+ 3 7)`,
+	// 		output: "10",
+	// 	},
 
-		testCase{
-			name:   "partial primitive1",
-			input:  `((+ 1) 2)`,
-			output: "3",
-		},
+	// 	testCase{
+	// 		name:   "partial primitive1",
+	// 		input:  `((+ 1) 2)`,
+	// 		output: "3",
+	// 	},
 
-		testCase{
-			name:   "partial primitive2",
-			input:  `(((+) 1) 2)`,
-			output: "3",
-		},
+	// 	testCase{
+	// 		name:   "partial primitive2",
+	// 		input:  `(((+) 1) 2)`,
+	// 		output: "3",
+	// 	},
 	}
 
 	for _, c := range cases {
@@ -140,6 +140,14 @@ func TestXXX(t *testing.T) {
 			if ObjString(res) != c.output {
 				fmt.Println("input is:", c.input)
 				fmt.Println("output is:", ObjString(res))
+				t.Fail()
+			}
+			if sp != 0 {
+				fmt.Println("unexpected sp after evaluation:", sp)
+				t.Fail()
+			}
+			if len(stack) != 0 {
+				fmt.Println("unexpected stack after evaluation:", len(stack))
 				t.Fail()
 			}
 		})

--- a/cora/integration_test.go
+++ b/cora/integration_test.go
@@ -14,6 +14,6 @@ func TestIntegration(t *testing.T) {
 	}))
 	PrimNS1Set(symMacroExpand, Nil)
 
-	Call(&e, PrimNS1Value(MakeSymbol("cora.init")))
+	CoraInit(&e, false)
 	Call(&e, PrimNS1Value(MakeSymbol("load")), MakeString("issue_25.cora"))
 }

--- a/cora/kl_primitives.go
+++ b/cora/kl_primitives.go
@@ -61,6 +61,11 @@ var klPrimitives = []struct {
 }
 
 func KLInit(e *ControlFlow, test bool) {
+	klInit0(e)
+	primKLInit(e, test)
+}
+
+func klInit0(e *ControlFlow) {
 	// KLambda primitives
 	for _, item := range klPrimitives {
 		sym := MakeSymbol(item.name)
@@ -77,8 +82,6 @@ func KLInit(e *ControlFlow, test bool) {
 	PrimNS3Set(MakeSymbol("*release*"), MakeString(runtime.Version()))
 	PrimNS3Set(MakeSymbol("*os*"), MakeString(runtime.GOOS))
 	// PrimNS1Set(MakeSymbol("kl.init"), MakeNative(primKLInit, 0))
-
-	primKLInit(e, test)
 }
 
 func PrimStr(o Obj) Obj {

--- a/cora/stub_test.go
+++ b/cora/stub_test.go
@@ -38,6 +38,7 @@ func TestPartialApply(t *testing.T) {
 
 func TestTryCatch(t *testing.T) {
 	var kl ControlFlow
+	klInit0(&kl)
 	Call(&kl, Load)
 	// (trap-error (+ 2 (simple-error "xxx")) (lambda X (error-to-string X)))
 	exp := `(try-catch (lambda () (+ 2 ((fn (quote simple-error)) "xxx"))) (lambda (X) ((fn (quote error-to-string)) X)))`

--- a/cora/types.go
+++ b/cora/types.go
@@ -33,9 +33,10 @@ const (
 type scmClosure struct {
 	scmHead
 	code   func(env Env)
-	env    Env
-	mark   map[int][]Obj
 	params int
+
+	parent *scmClosure
+	freeVars map[int]Obj
 }
 
 type scmCurry struct {
@@ -422,13 +423,13 @@ func MakeSymbol(s string) Obj {
 	return &p.value.scmHead
 }
 
-func MakeClosure(code func(env Env), env Env, nargs int, mark map[int][]Obj) Obj {
+func MakeClosure(code func(env Env), env Env, nargs int, parent *scmClosure, freeVars map[int]Obj) Obj {
 	tmp := scmClosure{
 		scmHead: scmHeadClosure,
 		code:    code,
-		env:     env,
 		params:  nargs,
-		mark:    mark,
+		parent: parent,
+		freeVars:    freeVars,
 	}
 	return &tmp.scmHead
 }

--- a/cora/types.go
+++ b/cora/types.go
@@ -32,9 +32,9 @@ const (
 
 type scmClosure struct {
 	scmHead
-	code   func(env *Env)
-	env    *Env
-	mark   map[int]struct{}
+	code   func(env Env)
+	env    Env
+	mark   map[int][]Obj
 	params int
 }
 
@@ -422,7 +422,7 @@ func MakeSymbol(s string) Obj {
 	return &p.value.scmHead
 }
 
-func MakeClosure(code func(env *Env), env *Env, nargs int, mark map[int]struct{}) Obj {
+func MakeClosure(code func(env Env), env Env, nargs int, mark map[int][]Obj) Obj {
 	tmp := scmClosure{
 		scmHead: scmHeadClosure,
 		code:    code,


### PR DESCRIPTION
Continue with https://github.com/tiancaiamao/shen-go/pull/32/

The old runtime environment representation is a variant of SECD machine.
Although there is an optimization that the local variable is optimized to not allocate in Env (heap), the env object itself is still there.

After this commit, the runtime representation is just like the C language -- no Environment!
I use closure convert to collect the free variable in the Closure struct.
In the calling protocol, args[0] is the closure object itself, so the free variable is accessible through `args[0]->parent->parent->freeVars[n]`
The Closure struct will record the it closed free variable, and also the parent closure within which it's created.

This runtime representation is much efficient than before, it avoid the allocating of Environment object in every call.
Run shen-go test:
```
Before 160s
After 35s
```