### PR TITLE
*: re-implement the eval-kl primitive using the closure way

### DIFF
--- a/cmd/kl/main.go
+++ b/cmd/kl/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	cora.Init(&e, true)
 	klambda.Init(&e, true)
-	cora.PrimNS1Set(cora.MakeSymbol("try-catch"), cora.MakeNative(cora.PrimTryCatch(true), 2))
+	cora.PrimNS2Set(cora.MakeSymbol("try-catch"), cora.MakeNative(cora.PrimTryCatch(true), 2))
 
 	r := cora.NewSexpReader(os.Stdin, false)
 	for i := 0; ; i++ {
@@ -42,7 +42,7 @@ func main() {
 			}
 			break
 		}
-		res := evalKL(&e, sexp)
+		res := cora.EvalKL(sexp)
 		fmt.Println(cora.ObjString(res))
 	}
 }
@@ -50,14 +50,3 @@ func main() {
 var (
 	symMacroExpand = cora.MakeSymbol("macroexpand")
 )
-
-var symKLToCora = cora.MakeSymbol("kl->cora")
-
-func evalKL(e *cora.ControlFlow, exp cora.Obj) cora.Obj {
-	// exp1 := cora.Call(e, cora.PrimNS1Value(symKLToCora), cora.Nil, exp)
-	exp1 := cora.NCall(cora.PrimNS1Value(symKLToCora), cora.Nil, exp)
-
-	// fmt.Println("evalKL with ===", kl.ObjString(exp1))
-	res := cora.Neval(exp1)
-	return res
-}

--- a/cora/klambda.go
+++ b/cora/klambda.go
@@ -1,0 +1,197 @@
+package cora
+
+import (
+	"fmt"
+)
+
+func EvalKL(exp Obj) Obj {
+	c := compileKL(exp, nil, true, nil)
+	run(c)
+	stack = stack[:sp]
+	return val
+}
+
+var klMacro map[Obj]func(obj Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env)
+
+func compileKL(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	switch *exp {
+	case scmHeadNumber, scmHeadString, scmHeadVector, scmHeadBoolean, scmHeadNull:
+		return genConstInst(exp)
+	case scmHeadSymbol:
+		m, n := env.findVariable(exp)
+		if m == 0 {
+			// local[0] is the closure object, the real args begins from i+1
+			return genLocalRefInst(n + 1)
+		}
+		if m > 0 {
+			freeVars[exp] = posRef{up: m, offset: n}
+			return genClosureRefInst(m, n)
+		}
+
+		return genConstInst(exp)
+	}
+
+	pair := mustPair(exp)
+	if IsSymbol(pair.car) {
+		tl := pair.cdr // handle special form
+		switch pair.car {
+		case symIf: // (if a b c)
+			if listLength(pair.cdr) == 3 {
+				x := compileKL(car(tl), env, false, freeVars)
+				y := compileKL(cadr(tl), env, tail, freeVars)
+				z := compileKL(caddr(tl), env, tail, freeVars)
+				return genIfInst(x, y, z)
+			} // if may also be a function for partial apply
+		case symDo: // (do A A)
+			x := compileKL(car(tl), env, false, freeVars)
+			y := compileKL(cadr(tl), env, tail, freeVars)
+			return genDoInst(x, y, tail)
+		case symLambda: // (lambda x body)
+			args := cons(car(tl), Nil)
+			body := cadr(tl)
+			return compileLambda(args, body, env, freeVars)
+		}
+	}
+
+	var cached [5]func(Env)
+	insts := cached[:0]
+	if IsSymbol(pair.car) {
+		if fn, ok := klMacro[pair.car]; ok {
+			return fn(pair.cdr, env, tail, freeVars)
+		}
+		inst := compileSymbolInCall(pair.car, env, false, freeVars)
+		insts = append(insts, inst)
+		exp = pair.cdr
+	}
+
+	for *exp == scmHeadPair {
+		inst := compileKL(car(exp), env, false, freeVars)
+		insts = append(insts, inst)
+		exp = cdr(exp)
+	}
+	return genCallInst(insts, exp, tail)
+}
+
+func compileLambda(args, body Obj, env *compileEnv, freeVars map[Obj]posRef) func(env Env) {
+	env1 := &compileEnv{
+		parent: env,
+		args:   args,
+	}
+
+	collectFVs := make(map[Obj]posRef)
+	op := compileKL(body, env1, true, collectFVs)
+	nargs := listLength(args)
+
+	for v, p := range collectFVs {
+		if p.up != 1 {
+			// Collect to freeVars and delete from this one.
+			freeVars[v] = posRef{up: p.up - 1, offset: p.offset}
+			delete(collectFVs, v)
+		}
+	}
+	return genMakeClosureInst(op, nargs, collectFVs)
+}
+
+func compileOrMacro(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	// (or x y) => (if x true (if y true false))
+	x := car(exp)
+	y := cadr(exp)
+	tmp := cons(symIf, cons(y, cons(True, cons(False, Nil))))
+	exp = cons(symIf, cons(x, cons(True, cons(tmp, Nil))))
+	return compileKL(exp, env, tail, freeVars)
+}
+
+func compileAndMacro(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	// (and x y) => (if x (if y true false) false)
+	x := car(exp)
+	y := cadr(exp)
+	tmp := cons(symIf, cons(y, cons(True, cons(False, Nil))))
+	exp = cons(symIf, cons(x, cons(tmp, cons(False, Nil))))
+	return compileKL(exp, env, tail, freeVars)
+}
+
+func compileCondMacro(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	exp = compileCondMacroHelp(exp)
+	return compileKL(exp, env, tail, freeVars)
+}
+
+func compileCondMacroHelp(exp Obj) Obj {
+	// (cond (x y) ...)
+	if exp == Nil {
+		return cons(MakeSymbol("simple-error"), cons(MakeString("no cond match"), Nil))
+	}
+	xy := car(exp)
+	x := car(xy)
+	y := cadr(xy)
+	tmp := compileCondMacroHelp(cdr(exp))
+	return cons(symIf, cons(x, cons(y, cons(tmp, Nil))))
+}
+
+func compileDefunMacro(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	// (defun f (x y) ..) => ((fn 'set) (quote f) (lambda (x y) ...))
+	fName := car(exp)
+	args := cadr(exp)
+	body := caddr(exp)
+	inst := compileLambda(args, body, env, freeVars)
+	return genKLGlobalSetInst(fName, inst)
+}
+
+func compileSymbolInCall(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	m, n := env.findVariable(exp)
+	if m == 0 {
+		// local[0] is the closure object, the real args begins from i+1
+		return genLocalRefInst(n + 1)
+	}
+	if m > 0 {
+		freeVars[exp] = posRef{up: m, offset: n}
+		return genClosureRefInst(m, n)
+	}
+	return genKLGlobalRefInst(exp)
+}
+
+func genKLGlobalRefInst(sym Obj) func(Env) {
+	return func(env Env) {
+		s := mustSymbol(sym)
+		if s.function == nil {
+			fmt.Println("NOT DEFINED")
+			panic("undefined symbol:" + s.str)
+		}
+		val = s.function
+	}
+}
+
+func genKLGlobalSetInst(fName Obj, inst func(Env)) func(Env) {
+	return func(env Env) {
+		inst(env)
+		val = PrimNS2Set(fName, val)
+	}
+}
+
+func compileLetMacro(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	// (let x y z) => ((lambda x z) y)
+	x := car(exp)
+	y := cadr(exp)
+	z := cdr(cdr(exp))
+	fn := cons(symLambda, cons(x, z))
+	exp = cons(fn, cons(y, Nil))
+	return compileKL(exp, env, tail, freeVars)
+}
+
+func compileFreezeMacro(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	// (freeze body) => (lambda () body)
+	return compileLambda(Nil, car(exp), env, freeVars)
+}
+
+func compileTrapErrorMacro(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	// (trap-error body handler) => (try-catch (lambda () body) handler)
+	body := car(exp)
+	handler := cdr(exp)
+	action := cons(symLambda, cons(Nil, cons(body, Nil)))
+	exp = cons(MakeSymbol("try-catch"), cons(action, handler))
+	return compileKL(exp, env, tail, freeVars)
+}
+
+func compileTypeMacro(exp Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env) {
+	// (type exp _) => exp
+	return compileKL(car(exp), env, tail, freeVars)
+}

--- a/cora/types.go
+++ b/cora/types.go
@@ -272,7 +272,7 @@ func isPair(o Obj) (bool, *scmPair) {
 
 var True, False, Nil, undefined Obj
 var uptime time.Time
-var symQuote, symDefun, symLambda, symFreeze, symLet, symAnd Obj
+var symQuote, symDefun, symLambda, symFreeze, symLet, symAnd, symType Obj
 var symOr, symIf, symCond, symTrapError, symDo, symMacroExpand Obj
 
 var fixnumBaseAddr uintptr
@@ -336,12 +336,24 @@ func init() {
 	symFreeze = MakeSymbol("freeze")
 	symLet = MakeSymbol("let")
 	symAnd = MakeSymbol("and")
+	symType = MakeSymbol("type")
 	symOr = MakeSymbol("or")
 	symIf = MakeSymbol("if")
 	symCond = MakeSymbol("cond")
 	symTrapError = MakeSymbol("trap-error")
 	symDo = MakeSymbol("do")
 	symMacroExpand = MakeSymbol("macroexpand")
+
+	klMacro = map[Obj]func(obj Obj, env *compileEnv, tail bool, freeVars map[Obj]posRef) func(env Env){
+		symType:      compileTypeMacro,
+		symDefun:     compileDefunMacro,
+		symFreeze:    compileFreezeMacro,
+		symLet:       compileLetMacro,
+		symCond:      compileCondMacro,
+		symAnd:       compileAndMacro,
+		symOr:        compileOrMacro,
+		symTrapError: compileTrapErrorMacro,
+	}
 }
 
 func MakeInteger(v int) Obj {

--- a/lib/klambda/kl_primitives.go
+++ b/lib/klambda/kl_primitives.go
@@ -151,7 +151,7 @@ func primLoad(e *ControlFlow) {
 			break
 		}
 
-		res := evalKL(e, exp)
+		res := EvalKL(exp)
 		if IsError(res) {
 			e.Return(res)
 			return
@@ -161,24 +161,9 @@ func primLoad(e *ControlFlow) {
 }
 
 func primEvalKL(e *ControlFlow) {
-	exp1 := e.Get(1)
-	res := evalKL(e, exp1)
+	exp := e.Get(1)
+	res := EvalKL(exp)
 	e.Return(res)
-}
-
-func evalKL(e *ControlFlow, exp Obj) Obj {
-	defer func() {
-		if r := recover(); r != nil {
-			fmt.Println("evalKL panic:", ObjString(exp))
-			panic(r)
-		}
-	}()
-	// exp1 := Call(e, PrimNS1Value(MakeSymbol("kl->cora")), Nil, exp)
-	exp1 := NCall(PrimNS1Value(MakeSymbol("kl->cora")), Nil, exp)
-
-	// fmt.Println("evalKL with ===", kl.ObjString(exp1))
-	res := Neval(exp1)
-	return res
 }
 
 // func PrimIsVariable(x Obj) Obj {


### PR DESCRIPTION
Add file cora/klambda.go, it implements eval-kl primitive using the new way
test time running the test suite decrease from 40s+ to 20s+