### PR TITLE
*: compile on OpenBSD

### DIFF
--- a/klambda/types.go
+++ b/klambda/types.go
@@ -313,7 +313,7 @@ func init() {
 		0,                 /*offset int64*/
 		fixnumCount,       /*length int*/
 		syscall.PROT_READ, /*prot int*/
-		syscall.MAP_ANONYMOUS|syscall.MAP_PRIVATE /*flags int*/)
+		syscall.MAP_ANON|syscall.MAP_PRIVATE /*flags int*/)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
OpenBSD's syscall package doesn't define MAP_ANONYMOUS, but it does
define the MAP_ANON alias.  Using MAP_ANON allows shen-go to compile
on OpenBSD and Linux.

If I'm reading go/src/syscall/zerrors_*.go correctly, this should also
allow shen-go to compile on NetBSD, DragonflyBSD, and Darwin.