### PR TITLE
[codex] Exit top-level loop on stdin EOF

### DIFF
--- a/S39/Sources/toplevel.shen
+++ b/S39/Sources/toplevel.shen
@@ -11,9 +11,14 @@
 (define loop
    -> (do (initialise_environment)
           (prompt) 
-          (trap-error (read-evaluate-print) 
-                      (/. E (do (pr (error-to-string E) (stoutput)) (nl 0))))  
-          (loop)))
+          (let Result (trap-error (read-evaluate-print)
+                                  (/. E (let Error (error-to-string E)
+                                             (if (= Error "error: empty stream")
+                                                 Error
+                                                 (do (pr Error (stoutput)) (nl 0))))))
+               (if (= Result "error: empty stream")
+                   Result
+                   (loop)))))
 
 (define credits
  -> (do (output "~%Shen, www.shenlanguage.org, copyright (C) 2010-2024, Mark Tarver~%")

--- a/cmd/shen/toplevel.go
+++ b/cmd/shen/toplevel.go
@@ -41,6 +41,13 @@ Z5297 := __e.Get(1)
 _ = Z5297
 tmp8423 := PrimErrorToString(Z5297)
 
+tmp84231 := PrimEqual(tmp8423, MakeString("error: empty stream"))
+
+if True == tmp84231 {
+__e.Return(tmp8423)
+return
+}
+
 tmp8424 := Call(__e, PrimFunc(symstoutput))
 
 
@@ -58,7 +65,12 @@ return
 tmp8426 := Call(__e, try_1catch, tmp8421, tmp8422)
 
 
-_ = tmp8426
+tmp84261 := PrimEqual(tmp8426, MakeString("error: empty stream"))
+
+if True == tmp84261 {
+__e.Return(tmp8426)
+return
+}
 
 __e.TailApply(PrimFunc(symshen_4loop))
 return
@@ -1837,4 +1849,3 @@ return
 
 
 }, 0)
-


### PR DESCRIPTION
## Summary

- stop the top-level Shen loop when stdin reaches EOF
- keep existing error printing for non-EOF read/eval errors
- update the generated Go top-level runtime to match the Shen source change

## Why

When Shen is run with piped stdin or redirected file input, EOF becomes `error: empty stream`. The top-level loop traps that error, prints it, and then recurses, which causes an endless stream of `error: empty stream` messages after the input file has finished.

This treats that EOF condition as a clean termination signal instead.

## Validation

- `go test ./...`
- `make shen`
- `printf '(+ 1 2)\n' | ./shen`
- `./shen < /Users/kat/Desktop/a/tests.shen`
