### PR TITLE
Compile KL to a bytecode VM (~15× faster tak, ~60× faster tail loops)

### DIFF
--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -1,0 +1,59 @@
+# shen-go Benchmark Results
+
+Machine: Linux amd64  
+Kernel: S39.2  
+Date: 2026-05-05  
+
+## Measurements
+
+### `tak(18,12,6)` single call (wall time, seconds)
+
+| Milestone | Time (s) | vs baseline |
+|---|---|---|
+| Baseline (tree-walker, interpreter only) | 0.088 | 1× |
+| Phase 0 (float-fix only, no perf change) | 0.088 | 1× |
+| Phase 2 (bytecode VM, indexed slots) | 0.013 | **6.6×** |
+
+### `(sum 0 5000000)` tail-recursive integer loop (wall time in Go tests)
+
+| Milestone | Time (s) |
+|---|---|
+| Baseline | 2.99 |
+| Phase 2 VM | 0.24 |
+
+Speedup on the tight tail-call loop: **12.5×**
+
+---
+
+## Method
+
+```
+# Define tak via KL defun, then time with get-time run:
+printf '(defun tak (X Y Z) ...) (get-time run) (tak 18 12 6) (get-time run)\n' \
+  | ./shen-go/shen
+# tak time = t2 - t1
+```
+
+---
+
+## Notes
+
+- Phase 0: fixed float comparison bug (`mustInteger` → `mustNumber` for `<`, `<=`, `>`, `>=`).
+  No performance change.
+- Phase 2: `defun` now compiles to a bytecode VM with flat indexed slots (no alist env).
+  Both REPL-defined KL `defun` and Shen-level `define` are compiled.
+  `lambda`/`freeze`/`trap-error`/`let`/`cond` all compile to bytecode.
+  Closures capture upvalues by value at creation time.
+
+---
+
+## Remaining gap to shen-cl
+
+shen-cl (SBCL) typically runs `tak(18,12,6)` in under 0.002s.  
+Current gap: ~6.5× (0.013s vs ~0.002s).  
+Target: within 3–5× of shen-cl.
+
+Next steps to close the gap:
+- Phase 3: fixnum fast paths for integer arithmetic (avoid float boxing)
+- Phase 4: decision-tree pattern matching
+- Phase 5: self-tail-call loop (update locals in-place, jump to top)

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -13,6 +13,7 @@ Date: 2026-05-05
 | Baseline (tree-walker, interpreter only) | 0.088 | 1× |
 | Phase 0 (float-fix only, no perf change) | 0.088 | 1× |
 | Phase 2 (bytecode VM, indexed slots) | 0.013 | **6.6×** |
+| Phase 3+5 (arithmetic fast paths + self-tail loop) | 0.006 | **14.7×** |
 
 ### `(sum 0 5000000)` tail-recursive integer loop (wall time in Go tests)
 
@@ -20,8 +21,15 @@ Date: 2026-05-05
 |---|---|
 | Baseline | 2.99 |
 | Phase 2 VM | 0.24 |
+| Phase 3+5 (self-tail + fast integer =,-) | 0.05 |
 
-Speedup on the tight tail-call loop: **12.5×**
+Speedup on tight tail-call loop: **60×**
+
+### `fib(30)` (non-tail double recursion)
+
+| Milestone | Time (s) |
+|---|---|
+| Phase 3+5 | 0.29 |
 
 ---
 
@@ -54,6 +62,5 @@ Current gap: ~6.5× (0.013s vs ~0.002s).
 Target: within 3–5× of shen-cl.
 
 Next steps to close the gap:
-- Phase 3: fixnum fast paths for integer arithmetic (avoid float boxing)
-- Phase 4: decision-tree pattern matching
-- Phase 5: self-tail-call loop (update locals in-place, jump to top)
+- Phase 4: decision-tree pattern matching compilation
+- Inline allocation pooling to reduce GC pressure

--- a/bench/bench.shen
+++ b/bench/bench.shen
@@ -1,0 +1,57 @@
+\ Benchmark suite for shen-go compiler work.
+\ Measures tak (arithmetic/recursion), fib (recursion), nrev (list), map-double (HOF).
+\ Run: printf '(load "bench/bench.shen")\n' | ./shen
+
+(define bench-tak
+  X Y Z N ->
+    (if (= N 0)
+        done
+        (let _ (tak X Y Z)
+          (bench-tak X Y Z (- N 1)))))
+
+(define tak
+  X Y Z ->
+    (if (not (< Y X))
+        Z
+        (tak (tak (- X 1) Y Z)
+             (tak (- Y 1) Z X)
+             (tak (- Z 1) X Y))))
+
+(define fib
+  0 -> 0
+  1 -> 1
+  N -> (+ (fib (- N 1)) (fib (- N 2))))
+
+(define iota-help
+  N Acc -> Acc where (= N 0)
+  N Acc -> (iota-help (- N 1) (cons N Acc)))
+
+(define iota
+  N -> (iota-help N []))
+
+(define nrev
+  [] -> []
+  [H | T] -> (append (nrev T) [H]))
+
+(define map-double
+  [] -> []
+  [H | T] -> (cons (* H 2) (map-double T)))
+
+(define run-bench
+  Name Thunk ->
+    (let T0 (get-time run)
+         _  (Thunk)
+         T1 (get-time run)
+      (do (output "~A: ~A s~%" Name (- T1 T0))
+          (- T1 T0))))
+
+(output "~%--- shen-go benchmarks ---~%")
+
+(run-bench "tak(18,12,6)x200" (freeze (bench-tak 18 12 6 200)))
+(run-bench "fib(25)" (freeze (fib 25)))
+(let L (iota 1000)
+  (run-bench "nrev(1000)" (freeze (nrev L))))
+(let L (iota 10000)
+  (run-bench "map-double(10000)" (freeze (map-double L))))
+
+(output "~%--- done ---~%")

--- a/kl/compiler.go
+++ b/kl/compiler.go
@@ -373,11 +373,76 @@ func (c *klCompiler) compileTrapError(body, handler Obj, tail bool) {
 	}
 }
 
+// intrinsicOp maps a 2-arg primitive symbol to a fast-path opcode.
+// Returns 0 if no fast path exists.
+func intrinsicOp2(sym Obj) uint8 {
+	switch sym {
+	case symAdd:
+		return OP_ADD
+	case symSub:
+		return OP_SUB
+	case symMul:
+		return OP_MUL
+	case symLT:
+		return OP_LT
+	case symLE:
+		return OP_LE
+	case symGT:
+		return OP_GT
+	case symGE:
+		return OP_GE
+	case symNumEq:
+		return OP_EQ
+	}
+	return 0
+}
+
 func (c *klCompiler) compileCall(fn Obj, args Obj, tail bool) {
 	nArgs := 0
+	argList := make([]Obj, 0, 4)
+	for l := args; *l == scmHeadPair; l = cdr(l) {
+		argList = append(argList, car(l))
+		nArgs++
+	}
 
+	// ---- 1-arg intrinsics ----
+	if IsSymbol(fn) && nArgs == 1 && fn == symNot {
+		c.compileExpr(argList[0], false)
+		c.emit(OP_NOT, 0, 0)
+		if tail {
+			c.emit(OP_RETURN, 0, 0)
+		}
+		return
+	}
+
+	// ---- 2-arg arithmetic intrinsics ----
+	if IsSymbol(fn) && nArgs == 2 {
+		if op := intrinsicOp2(fn); op != 0 {
+			c.compileExpr(argList[0], false)
+			c.compileExpr(argList[1], false)
+			c.emit(op, 0, 0)
+			if tail {
+				c.emit(OP_RETURN, 0, 0)
+			}
+			return
+		}
+	}
+
+	// ---- Self-tail-call optimization ----
+	if tail && IsSymbol(fn) && mustSymbol(fn).str == c.fn.Name {
+		kind, _ := c.resolveVar(fn)
+		if kind == varGlobal && nArgs == c.fn.Arity {
+			// It's a self-call in tail position: emit args then OP_SELF_TAIL_CALL.
+			for _, a := range argList {
+				c.compileExpr(a, false)
+			}
+			c.emit(OP_SELF_TAIL_CALL, int32(nArgs), 0)
+			return
+		}
+	}
+
+	// ---- General call ----
 	if IsSymbol(fn) {
-		// Resolve symbol in function position.
 		kind, idx := c.resolveVar(fn)
 		switch kind {
 		case varLocal:
@@ -388,13 +453,11 @@ func (c *klCompiler) compileCall(fn Obj, args Obj, tail bool) {
 			c.emit(OP_LOAD_GLOBAL, c.addConst(fn), 0)
 		}
 	} else {
-		// Complex function expression.
 		c.compileExpr(fn, false)
 	}
 
-	for l := args; *l == scmHeadPair; l = cdr(l) {
-		c.compileExpr(car(l), false)
-		nArgs++
+	for _, a := range argList {
+		c.compileExpr(a, false)
 	}
 
 	if tail {

--- a/kl/compiler.go
+++ b/kl/compiler.go
@@ -242,26 +242,29 @@ func (c *klCompiler) compileForm(form Obj, tail bool) {
 func (c *klCompiler) compileDefun(name, params, body Obj) {
 	paramSlice := ListToSlice(params)
 	nameStr := mustSymbol(name).str
-	inner := newCompiler(nameStr, len(paramSlice), paramSlice, nil) // top-level: no outer
+	// Thread c as outer so the body can close over the enclosing lexical scope,
+	// matching the interpreter which does makeProcedure(..., env).
+	inner := newCompiler(nameStr, len(paramSlice), paramSlice, c)
 	inner.compileExpr(body, true)
-	bfObj := makeBytecodeObj(inner.fn, nil)
-	// Emit: bind and push the name symbol
-	// (defun f ...) at runtime: compile to bytecode and bind, then push name.
-	// We emit this as a constant + global store via LOAD_CONST + native call,
-	// but actually we can just emit a LOAD_CONST of the compiled func and
-	// a call to the defun primitive.  For simplicity, use the approach of
-	// OP_LOAD_CONST bfObj, OP_LOAD_CONST nameSym, then swap + call defun.
-	// Even simpler: use a special compilation-time action.
-	//
-	// Actually the cleanest approach: emit code that at runtime calls
-	// BindSymbolFunc(name, bfObj).  We do this by pushing two consts and
-	// calling the built-in "defun" primitive.
-	symConst := c.addConst(name)
-	fnConst := c.addConst(bfObj)
+
 	defunSym := c.addConst(MakeSymbol("defun"))
+	nameConst := c.addConst(name)
 	c.emit(OP_LOAD_GLOBAL, defunSym, 0)
-	c.emit(OP_LOAD_CONST, symConst, 0)
-	c.emit(OP_LOAD_CONST, fnConst, 0)
+	c.emit(OP_LOAD_CONST, nameConst, 0)
+
+	// If the body referenced outer variables, emit their values as upvalues
+	// and create a closure; otherwise emit the bytecode func as a plain constant.
+	for _, uv := range inner.upvals {
+		switch uv.outerRef.kind {
+		case varLocal:
+			c.emit(OP_LOAD_LOCAL, int32(uv.outerRef.index), 0)
+		case varUpval:
+			c.emit(OP_LOAD_UPVAL, int32(uv.outerRef.index), 0)
+		}
+	}
+	innerObj := makeBytecodeObj(inner.fn, nil)
+	innerConst := c.addConst(innerObj)
+	c.emit(OP_MAKE_CLOSURE, innerConst, int32(len(inner.upvals)))
 	c.emit(OP_CALL, 2, 0)
 }
 
@@ -443,14 +446,22 @@ func (c *klCompiler) compileCall(fn Obj, args Obj, tail bool) {
 
 	// ---- General call ----
 	if IsSymbol(fn) {
-		kind, idx := c.resolveVar(fn)
-		switch kind {
-		case varLocal:
-			c.emit(OP_LOAD_LOCAL, int32(idx), 0)
-		case varUpval:
-			c.emit(OP_LOAD_UPVAL, int32(idx), 0)
-		case varGlobal:
+		// Match interpreter precedence (evalFunction): if the symbol has a
+		// global function binding, that takes priority over a same-named local.
+		// This handles cases like a parameter named 'cons' shadowing the global.
+		sym := mustSymbol(fn)
+		if sym.function != nil {
 			c.emit(OP_LOAD_GLOBAL, c.addConst(fn), 0)
+		} else {
+			kind, idx := c.resolveVar(fn)
+			switch kind {
+			case varLocal:
+				c.emit(OP_LOAD_LOCAL, int32(idx), 0)
+			case varUpval:
+				c.emit(OP_LOAD_UPVAL, int32(idx), 0)
+			case varGlobal:
+				c.emit(OP_LOAD_GLOBAL, c.addConst(fn), 0)
+			}
 		}
 	} else {
 		c.compileExpr(fn, false)

--- a/kl/compiler.go
+++ b/kl/compiler.go
@@ -1,0 +1,405 @@
+package kl
+
+// klCompiler compiles a KL form to bytecode.
+type klCompiler struct {
+	fn      *BytecodeFunc
+	locals  map[Obj]int    // symbol pointer -> slot index
+	upvals  []upvalInfo    // upvalues captured from outer scope
+	outer   *klCompiler    // enclosing compiler (for closures)
+}
+
+type upvalInfo struct {
+	sym      Obj
+	outerRef varRef // where to find it in the outer scope
+}
+
+type varRef struct {
+	kind  varKind
+	index int
+}
+
+type varKind int
+
+const (
+	varLocal  varKind = iota
+	varUpval
+	varGlobal
+)
+
+// CompileFunc compiles a KL top-level defun body to a BytecodeFunc object.
+// params is the list of parameter symbols; body is the KL expression.
+func CompileFunc(name string, params []Obj, body Obj) Obj {
+	c := newCompiler(name, len(params), params, nil)
+	c.compileExpr(body, true)
+	return makeBytecodeObj(c.fn, nil)
+}
+
+func newCompiler(name string, arity int, params []Obj, outer *klCompiler) *klCompiler {
+	c := &klCompiler{
+		fn: &BytecodeFunc{
+			Name:    name,
+			Arity:   arity,
+			Nlocals: arity,
+		},
+		locals: make(map[Obj]int),
+		outer:  outer,
+	}
+	for i, p := range params {
+		c.locals[p] = i
+	}
+	return c
+}
+
+func (c *klCompiler) emit(op uint8, a, b int32) int {
+	idx := len(c.fn.Code)
+	c.fn.Code = append(c.fn.Code, Instr{Op: op, A: a, B: b})
+	return idx
+}
+
+func (c *klCompiler) addConst(v Obj) int32 {
+	for i, cv := range c.fn.Consts {
+		if cv == v {
+			return int32(i)
+		}
+	}
+	c.fn.Consts = append(c.fn.Consts, v)
+	return int32(len(c.fn.Consts) - 1)
+}
+
+func (c *klCompiler) newLocal(sym Obj) int32 {
+	slot := int32(c.fn.Nlocals)
+	c.fn.Nlocals++
+	c.locals[sym] = int(slot)
+	return slot
+}
+
+func (c *klCompiler) resolveVar(sym Obj) (varKind, int) {
+	if idx, ok := c.locals[sym]; ok {
+		return varLocal, idx
+	}
+	for i, uv := range c.upvals {
+		if uv.sym == sym {
+			return varUpval, i
+		}
+	}
+	if c.outer != nil {
+		outerKind, outerIdx := c.outer.resolveVar(sym)
+		if outerKind == varGlobal {
+			return varGlobal, 0
+		}
+		uvIdx := len(c.upvals)
+		c.upvals = append(c.upvals, upvalInfo{
+			sym:      sym,
+			outerRef: varRef{kind: outerKind, index: outerIdx},
+		})
+		return varUpval, uvIdx
+	}
+	return varGlobal, 0
+}
+
+// patchJump patches a previously emitted jump instruction's A operand.
+func (c *klCompiler) patchJump(instrIdx int) {
+	target := len(c.fn.Code)
+	c.fn.Code[instrIdx].A = int32(target - instrIdx - 1)
+}
+
+// compileExpr compiles a KL expression.  tail indicates whether this is
+// in tail position (may emit OP_TAIL_CALL / OP_RETURN instead of OP_CALL).
+func (c *klCompiler) compileExpr(form Obj, tail bool) {
+	switch *form {
+	case scmHeadNumber, scmHeadString, scmHeadBoolean, scmHeadNull:
+		c.emit(OP_LOAD_CONST, c.addConst(form), 0)
+		if tail {
+			c.emit(OP_RETURN, 0, 0)
+		}
+		return
+
+	case scmHeadSymbol:
+		kind, idx := c.resolveVar(form)
+		switch kind {
+		case varLocal:
+			c.emit(OP_LOAD_LOCAL, int32(idx), 0)
+		case varUpval:
+			c.emit(OP_LOAD_UPVAL, int32(idx), 0)
+		case varGlobal:
+			// In value position, a symbol not in scope evaluates to itself.
+			c.emit(OP_LOAD_CONST, c.addConst(form), 0)
+		}
+		if tail {
+			c.emit(OP_RETURN, 0, 0)
+		}
+		return
+
+	case scmHeadPair:
+		c.compileForm(form, tail)
+		return
+
+	default:
+		// Vector, stream, procedure, native, etc. — treat as constants.
+		c.emit(OP_LOAD_CONST, c.addConst(form), 0)
+		if tail {
+			c.emit(OP_RETURN, 0, 0)
+		}
+		return
+	}
+}
+
+// compileForm handles pair forms: special forms and function calls.
+func (c *klCompiler) compileForm(form Obj, tail bool) {
+	pair := mustPair(form)
+	if !IsSymbol(pair.car) {
+		// Complex function expression: (expr args...)
+		c.compileCall(pair.car, pair.cdr, tail)
+		return
+	}
+	head := pair.car
+	rest := pair.cdr
+
+	switch head {
+	case symDefun:
+		// (defun f (x...) body)
+		name := car(rest)
+		params := cadr(rest)
+		body := caddr(rest)
+		c.compileDefun(name, params, body)
+		if tail {
+			c.emit(OP_RETURN, 0, 0)
+		}
+
+	case symLambda:
+		// (lambda x body)
+		param := car(rest)
+		body := cadr(rest)
+		c.compileLambda([]Obj{param}, body)
+		if tail {
+			c.emit(OP_RETURN, 0, 0)
+		}
+
+	case symFreeze:
+		// (freeze body)
+		body := car(rest)
+		c.compileLambda(nil, body)
+		if tail {
+			c.emit(OP_RETURN, 0, 0)
+		}
+
+	case symLet:
+		// (let x val body)
+		x := car(rest)
+		val := cadr(rest)
+		body := caddr(rest)
+		c.compileLet(x, val, body, tail)
+
+	case symIf:
+		args := rest
+		if listLength(args) == 3 {
+			c.compileIf(car(args), cadr(args), caddr(args), tail)
+		} else {
+			// (if ...) with wrong arg count: fall through as a call
+			c.compileCall(head, rest, tail)
+		}
+
+	case symAnd:
+		// (and a b) => (if a b false)
+		a := car(rest)
+		b := cadr(rest)
+		c.compileIf(a, b, False, tail)
+
+	case symOr:
+		// (or a b) => (if a true b)
+		a := car(rest)
+		b := cadr(rest)
+		c.compileIf(a, True, b, tail)
+
+	case symCond:
+		c.compileCond(rest, tail)
+
+	case symDo:
+		// (do a b)
+		a := car(rest)
+		b := cadr(rest)
+		c.compileExpr(a, false)
+		c.emit(OP_POP, 0, 0)
+		c.compileExpr(b, tail)
+
+	case symType:
+		// (type x _) — just compile x, ignore the type annotation
+		c.compileExpr(car(rest), tail)
+
+	case symTrapError:
+		// (trap-error body handler)
+		// Lower to: (try-catch (freeze body) handler)
+		body := car(rest)
+		handler := cadr(rest)
+		c.compileTrapError(body, handler, tail)
+
+	default:
+		// Regular function call with a symbol in head position.
+		c.compileCall(head, rest, tail)
+	}
+}
+
+func (c *klCompiler) compileDefun(name, params, body Obj) {
+	paramSlice := ListToSlice(params)
+	nameStr := mustSymbol(name).str
+	inner := newCompiler(nameStr, len(paramSlice), paramSlice, nil) // top-level: no outer
+	inner.compileExpr(body, true)
+	bfObj := makeBytecodeObj(inner.fn, nil)
+	// Emit: bind and push the name symbol
+	// (defun f ...) at runtime: compile to bytecode and bind, then push name.
+	// We emit this as a constant + global store via LOAD_CONST + native call,
+	// but actually we can just emit a LOAD_CONST of the compiled func and
+	// a call to the defun primitive.  For simplicity, use the approach of
+	// OP_LOAD_CONST bfObj, OP_LOAD_CONST nameSym, then swap + call defun.
+	// Even simpler: use a special compilation-time action.
+	//
+	// Actually the cleanest approach: emit code that at runtime calls
+	// BindSymbolFunc(name, bfObj).  We do this by pushing two consts and
+	// calling the built-in "defun" primitive.
+	symConst := c.addConst(name)
+	fnConst := c.addConst(bfObj)
+	defunSym := c.addConst(MakeSymbol("defun"))
+	c.emit(OP_LOAD_GLOBAL, defunSym, 0)
+	c.emit(OP_LOAD_CONST, symConst, 0)
+	c.emit(OP_LOAD_CONST, fnConst, 0)
+	c.emit(OP_CALL, 2, 0)
+}
+
+func (c *klCompiler) compileLambda(params []Obj, body Obj) {
+	inner := newCompiler("lambda", len(params), params, c)
+	inner.compileExpr(body, true)
+
+	// The inner compiler may have discovered upvalues; emit loads for them.
+	for _, uv := range inner.upvals {
+		switch uv.outerRef.kind {
+		case varLocal:
+			c.emit(OP_LOAD_LOCAL, int32(uv.outerRef.index), 0)
+		case varUpval:
+			c.emit(OP_LOAD_UPVAL, int32(uv.outerRef.index), 0)
+		}
+	}
+
+	innerObj := makeBytecodeObj(inner.fn, nil) // upvals populated at runtime
+	innerConst := c.addConst(innerObj)
+	c.emit(OP_MAKE_CLOSURE, innerConst, int32(len(inner.upvals)))
+}
+
+func (c *klCompiler) compileLet(x, val, body Obj, tail bool) {
+	// Evaluate val.
+	c.compileExpr(val, false)
+	// Assign to a new local slot (or reuse if x is already a local).
+	// We always allocate a new slot to handle shadowing correctly.
+	oldIdx, hadOld := c.locals[x]
+	slot := c.newLocal(x)
+	c.emit(OP_STORE_LOCAL, slot, 0)
+	// Compile body.
+	c.compileExpr(body, tail)
+	// Restore previous mapping (for shadowing).
+	if hadOld {
+		c.locals[x] = oldIdx
+	} else {
+		delete(c.locals, x)
+	}
+}
+
+func (c *klCompiler) compileIf(cond, thenExpr, elseExpr Obj, tail bool) {
+	c.compileExpr(cond, false)
+	// Emit JUMP_FALSE with placeholder; patch after then-branch.
+	jumpFalseIdx := c.emit(OP_JUMP_FALSE, 0, 0)
+	c.compileExpr(thenExpr, tail)
+	if !tail {
+		// Emit JUMP over else-branch; patch after else.
+		jumpOverIdx := c.emit(OP_JUMP, 0, 0)
+		c.patchJump(jumpFalseIdx)
+		c.compileExpr(elseExpr, tail)
+		c.patchJump(jumpOverIdx)
+	} else {
+		// In tail position both branches already emit RETURN; just patch the false jump.
+		c.patchJump(jumpFalseIdx)
+		c.compileExpr(elseExpr, tail)
+	}
+}
+
+func (c *klCompiler) compileCond(clauses Obj, tail bool) {
+	if *clauses == scmHeadNull {
+		// No matching clause: return Nil.
+		c.emit(OP_LOAD_CONST, c.addConst(Nil), 0)
+		if tail {
+			c.emit(OP_RETURN, 0, 0)
+		}
+		return
+	}
+	clause := car(clauses)
+	rest := cdr(clauses)
+	cond := car(clause)
+	action := cadr(clause)
+
+	if cond == True {
+		// (cond (true action) ...) — unconditional
+		c.compileExpr(action, tail)
+		return
+	}
+
+	c.compileExpr(cond, false)
+	jumpFalseIdx := c.emit(OP_JUMP_FALSE, 0, 0)
+	c.compileExpr(action, tail)
+	if !tail {
+		jumpOverIdx := c.emit(OP_JUMP, 0, 0)
+		c.patchJump(jumpFalseIdx)
+		c.compileCond(rest, tail)
+		c.patchJump(jumpOverIdx)
+	} else {
+		c.patchJump(jumpFalseIdx)
+		c.compileCond(rest, tail)
+	}
+}
+
+// compileTrapError lowers (trap-error body handler) to (try-catch (freeze body) handler).
+// Stack layout for CALL/TAIL_CALL 2: [..., fn, arg1, arg2]
+func (c *klCompiler) compileTrapError(body, handler Obj, tail bool) {
+	// 1. Push try-catch global function.
+	tryCatchSym := c.addConst(MakeSymbol("try-catch"))
+	c.emit(OP_LOAD_GLOBAL, tryCatchSym, 0)
+	// 2. Push (freeze body) as arg1.
+	c.compileLambda(nil, body)
+	// 3. Push handler as arg2.
+	c.compileExpr(handler, false)
+	// 4. Call try-catch with 2 args.
+	// trap-error must NOT be a tail call: the panic/recover in try-catch
+	// needs a real Go stack frame to catch from.
+	c.emit(OP_CALL, 2, 0)
+	if tail {
+		c.emit(OP_RETURN, 0, 0)
+	}
+}
+
+func (c *klCompiler) compileCall(fn Obj, args Obj, tail bool) {
+	nArgs := 0
+
+	if IsSymbol(fn) {
+		// Resolve symbol in function position.
+		kind, idx := c.resolveVar(fn)
+		switch kind {
+		case varLocal:
+			c.emit(OP_LOAD_LOCAL, int32(idx), 0)
+		case varUpval:
+			c.emit(OP_LOAD_UPVAL, int32(idx), 0)
+		case varGlobal:
+			c.emit(OP_LOAD_GLOBAL, c.addConst(fn), 0)
+		}
+	} else {
+		// Complex function expression.
+		c.compileExpr(fn, false)
+	}
+
+	for l := args; *l == scmHeadPair; l = cdr(l) {
+		c.compileExpr(car(l), false)
+		nArgs++
+	}
+
+	if tail {
+		c.emit(OP_TAIL_CALL, int32(nArgs), 0)
+	} else {
+		c.emit(OP_CALL, int32(nArgs), 0)
+	}
+}

--- a/kl/eval.go
+++ b/kl/eval.go
@@ -179,7 +179,7 @@ func Try(e *ControlFlow, f Obj) (res tryResult) {
 			fmt.Println(string(buf[:n]))
 		}
 	}()
-	MustNative(f)
+	// f must be a 0-arity callable (native thunk or bytecode closure).
 	val := Call(e, f)
 	res = tryResult{e: e, data: val}
 	return
@@ -196,6 +196,11 @@ func apply(ctl *ControlFlow) {
 	f := ctl.data[ctl.pos]
 	args := ctl.data[ctl.pos+1:]
 	switch *f {
+	case scmHeadBytecodeFunc:
+		argsCopy := make([]Obj, len(args))
+		copy(argsCopy, args)
+		vmApply(ctl, f, argsCopy)
+		return
 	case scmHeadProcedure:
 		args := ctl.data[ctl.pos+1:]
 		proc := mustProcedure(f)
@@ -258,7 +263,8 @@ func eval(e *ControlFlow) {
 
 	switch *exp {
 	// handle constant
-	case scmHeadNumber, scmHeadString, scmHeadVector, scmHeadBoolean, scmHeadNull, scmHeadProcedure /* , scmHeadPrimitive */ :
+	case scmHeadNumber, scmHeadString, scmHeadVector, scmHeadBoolean, scmHeadNull,
+		scmHeadProcedure, scmHeadBytecodeFunc /* , scmHeadPrimitive */ :
 		e.Return(exp)
 		return
 	case scmHeadSymbol:
@@ -274,9 +280,11 @@ func eval(e *ControlFlow) {
 		exp = pair.cdr // handle special form
 		switch pair.car {
 		case symDefun: // (defun f (x y) z)
-			proc := makeProcedure(cadr(exp), caddr(exp), env)
 			funName := car(exp)
-			BindSymbolFunc(funName, proc)
+			params := ListToSlice(cadr(exp))
+			body := caddr(exp)
+			compiled := CompileFunc(mustSymbol(funName).str, params, body)
+			BindSymbolFunc(funName, compiled)
 			e.Return(funName)
 			return
 		case symLambda: // (lambda x x)
@@ -391,7 +399,7 @@ func evalFunction(e *ControlFlow, fn Obj, env Obj) Obj {
 	}
 
 	switch *fn {
-	case /* scmHeadPrimitive, */ scmHeadProcedure, scmHeadNative:
+	case /* scmHeadPrimitive, */ scmHeadProcedure, scmHeadNative, scmHeadBytecodeFunc:
 		return fn
 	case scmHeadPair:
 		return evalExp(e, fn, env)

--- a/kl/eval_test.go
+++ b/kl/eval_test.go
@@ -194,6 +194,80 @@ func evalString(ctx *ControlFlow, exp string) Obj {
 	return Eval(ctx, sexp)
 }
 
+// TestBytecodeVM validates key VM features: closure capture, trap-error,
+// let-shadowing, currying, and tail calls through compiled defuns.
+func TestBytecodeVM(t *testing.T) {
+	type tc struct {
+		name  string
+		input string
+		want  string
+	}
+	cases := []tc{
+		{
+			"compiled tak",
+			`(do (defun tak (X Y Z)
+			       (if (not (< Y X)) Z
+			           (tak (tak (- X 1) Y Z)
+			                (tak (- Y 1) Z X)
+			                (tak (- Z 1) X Y))))
+			     (tak 12 6 3))`,
+			"4", // tak(12,6,3) = 4 per standard definition
+		},
+		{
+			"closure upval capture",
+			`(do (defun make-adder (X) (lambda Y (+ X Y)))
+			     ((make-adder 10) 5))`,
+			"15",
+		},
+		{
+			"let shadowing in compiled fn",
+			`(do (defun f (X)
+			       (let X 99
+			            X))
+			     (f 1))`,
+			"99",
+		},
+		{
+			"trap-error in compiled fn",
+			`(do (defun safe (X)
+			       (trap-error (simple-error "oops") (lambda E (error-to-string E))))
+			     (safe 1))`,
+			`"oops"`,
+		},
+		{
+			"compiled fib",
+			`(do (defun fib (N)
+			       (if (= N 0) 0
+			           (if (= N 1) 1
+			               (+ (fib (- N 1)) (fib (- N 2))))))
+			     (fib 10))`,
+			"55",
+		},
+		{
+			"compiled tail-recursive sum",
+			`(do (defun sum (R I)
+			       (if (= I 0) R (sum (+ R 1) (- I 1))))
+			     (sum 0 1000000))`,
+			"1000000",
+		},
+		{
+			"currying through compiled fn",
+			`(do (defun add (X Y) (+ X Y))
+			     ((add 3) 4))`,
+			"7",
+		},
+	}
+	var ctx ControlFlow
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ObjString(evalString(&ctx, c.input))
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
 func TestTypeIsMacro(t *testing.T) {
 	var ctx ControlFlow
 	// type is implemented as a macro rather than a primitive.

--- a/kl/eval_test.go
+++ b/kl/eval_test.go
@@ -256,6 +256,64 @@ func TestBytecodeVM(t *testing.T) {
 			     ((add 3) 4))`,
 			"7",
 		},
+		// P1 regression: defun inside defun must capture outer lexical scope.
+		{
+			"nested defun captures outer local",
+			`(do (defun outer (X)
+			       (do (defun inner (Y) (+ X Y))
+			           (inner 10)))
+			     (outer 5))`,
+			"15",
+		},
+		// P1 regression: (if non-bool ...) must signal an error, not silently
+		// treat any non-False value as truthy.  Wrap in a compiled defun so the
+		// OP_JUMP_FALSE path is exercised (not just the tree-walker's evalIf).
+		{
+			"if on non-boolean panics",
+			`(do (defun bad-if () (if 42 1 2))
+			     (trap-error (bad-if) (lambda E (error-to-string E))))`,
+			`"if requires a boolean"`,
+		},
+		// P2 regression: a symbol that has a global function binding must be
+		// looked up as OP_LOAD_GLOBAL even when a same-named local is in scope.
+		{
+			"global fn takes precedence over local in call position",
+			`(do (defun id (X) X)
+			     (do (defun call-id (id) (id id))
+			         (call-id 42)))`,
+			"42",
+		},
+		// Multi-level closure: closure inside closure must chain upvalue capture.
+		{
+			"multi-level closure upval chain",
+			`(do (defun make-adder2 (X)
+			       (lambda Y (lambda Z (+ X (+ Y Z)))))
+			     (((make-adder2 1) 2) 3))`,
+			"6",
+		},
+		// Over-application of a compiled (bytecode) function.
+		{
+			"over-application of bytecode fn",
+			`(do (defun add (X Y) (+ X Y))
+			     (add 3 4))`,
+			"7",
+		},
+		// VM-path float comparisons through compiled defuns.
+		{
+			"compiled float comparisons",
+			`(do (defun lt (X Y) (< X Y))
+			     (do (defun le (X Y) (<= X Y))
+			         (do (defun gt (X Y) (> X Y))
+			             (do (defun ge (X Y) (>= X Y))
+			                 (if (lt 1.5 2.0)
+			                     (if (le 2.0 2.0)
+			                         (if (gt 3.0 1.5)
+			                             (if (ge 2.0 2.0) true false)
+			                             false)
+			                         false)
+			                     false)))))`,
+			"true",
+		},
 	}
 	var ctx ControlFlow
 	for _, c := range cases {

--- a/kl/library.go
+++ b/kl/library.go
@@ -79,7 +79,7 @@ func equal(x, y Obj) Obj {
 				return False
 			}
 		}
-	case scmHeadStream, scmHeadProcedure /* , scmHeadPrimitive */ :
+	case scmHeadStream, scmHeadProcedure, scmHeadBytecodeFunc /* , scmHeadPrimitive */ :
 		if x != y {
 			return False
 		}

--- a/kl/primitives.go
+++ b/kl/primitives.go
@@ -185,6 +185,12 @@ func PrimStr(o Obj) Obj {
 		return MakeString(fmt.Sprintf(`"%s"`, mustString(o)))
 	case scmHeadProcedure:
 		return MakeString("#<procedure >")
+	case scmHeadBytecodeFunc:
+		bf := mustBytecodeFunc(o)
+		if bf.fn.Name != "" {
+			return MakeString("#<compiled " + bf.fn.Name + ">")
+		}
+		return MakeString("#<compiled >")
 	case scmHeadBoolean:
 		switch o {
 		case True:
@@ -284,42 +290,37 @@ func PrimErrorToString(o Obj) Obj {
 }
 
 func PrimGreatThan(x, y Obj) Obj {
-	x1 := mustInteger(x)
-	y1 := mustInteger(y)
+	x1 := mustNumber(x)
+	y1 := mustNumber(y)
 	if x1 > y1 {
 		return True
-
 	}
 	return False
 }
 
 func PrimLessThan(a, b Obj) Obj {
-	x := mustInteger(a)
-	y := mustInteger(b)
+	x := mustNumber(a)
+	y := mustNumber(b)
 	if x < y {
 		return True
-
 	}
 	return False
 }
 
 func PrimLessEqual(a, b Obj) Obj {
-	x := mustInteger(a)
-	y := mustInteger(b)
+	x := mustNumber(a)
+	y := mustNumber(b)
 	if x <= y {
 		return True
-
 	}
 	return False
-
 }
 
 func PrimGreatEqual(a, b Obj) Obj {
-	x := mustInteger(a)
-	y := mustInteger(b)
+	x := mustNumber(a)
+	y := mustNumber(b)
 	if x >= y {
 		return True
-
 	}
 	return False
 }
@@ -696,8 +697,15 @@ func MakePrimitive(name string, arity int, f interface{}) Obj {
 
 func primDefun(key, val Obj) Obj {
 	sym := mustSymbol(key)
+	// If given a raw scmProcedure (from the Shen-level compiler), compile it.
+	if *val == scmHeadProcedure {
+		proc := mustProcedure(val)
+		compiled := CompileFunc(sym.str, proc.arg, proc.body)
+		sym.function = compiled
+		return key
+	}
 	sym.function = val
-	return val
+	return key
 }
 
 func primTryCatch(e *ControlFlow) {

--- a/kl/primitives_test.go
+++ b/kl/primitives_test.go
@@ -72,3 +72,34 @@ func TestFixnum(t *testing.T) {
 		t.Error("3000000 should not be a cons")
 	}
 }
+
+// Regression test: float comparisons must not truncate to int.
+// Before fix, (< 1.5 1.8) returned false because mustInteger(1.5)==1 and mustInteger(1.8)==1.
+func TestFloatComparisons(t *testing.T) {
+	cases := []struct {
+		fn       string
+		a, b     float64
+		expected Obj
+	}{
+		{"<", 1.5, 1.8, True},
+		{"<", 1.8, 1.5, False},
+		{"<", 1.0, 1.0, False},
+		{"<=", 1.5, 1.8, True},
+		{"<=", 1.0, 1.0, True},
+		{"<=", 1.8, 1.5, False},
+		{">", 1.8, 1.5, True},
+		{">", 1.5, 1.8, False},
+		{">", 1.0, 1.0, False},
+		{">=", 1.8, 1.5, True},
+		{">=", 1.0, 1.0, True},
+		{">=", 1.5, 1.8, False},
+	}
+	var ctl ControlFlow
+	for _, c := range cases {
+		fn := ctl.Global(MakeSymbol(c.fn))
+		got := Call(&ctl, fn, MakeNumber(c.a), MakeNumber(c.b))
+		if got != c.expected {
+			t.Errorf("(%s %v %v): expected %v, got %v", c.fn, c.a, c.b, ObjString(c.expected), ObjString(got))
+		}
+	}
+}

--- a/kl/types.go
+++ b/kl/types.go
@@ -469,6 +469,12 @@ func (o *scmHead) GoString() string {
 			return fmt.Sprintf("#primitive(%s)", prim.name)
 		}
 		return "#native"
+	case scmHeadBytecodeFunc:
+		bf := mustBytecodeFunc(o)
+		if bf.fn.Name != "" {
+			return fmt.Sprintf("#compiled(%s)", bf.fn.Name)
+		}
+		return "#compiled"
 	}
 	return fmt.Sprintf("unknown type %d", *o)
 }

--- a/kl/types.go
+++ b/kl/types.go
@@ -243,6 +243,8 @@ var uptime time.Time
 var symQuote, symDefun, symLambda, symFreeze, symLet, symAnd Obj
 var symOr, symIf, symCond, symTrapError, symDo, symMacroExpand Obj
 var symType Obj
+// Arithmetic intrinsic symbols for the compiler fast-path detection.
+var symAdd, symSub, symMul, symLT, symLE, symGT, symGE, symNumEq, symNot Obj
 
 const fixnumCount = 1 << 20
 
@@ -303,6 +305,15 @@ func init() {
 	symMacroExpand = MakeSymbol("macroexpand")
 	_ = symMacroExpand // mark as used to satisfy staticcheck
 	symType = MakeSymbol("type")
+	symAdd = MakeSymbol("+")
+	symSub = MakeSymbol("-")
+	symMul = MakeSymbol("*")
+	symLT = MakeSymbol("<")
+	symLE = MakeSymbol("<=")
+	symGT = MakeSymbol(">")
+	symGE = MakeSymbol(">=")
+	symNumEq = MakeSymbol("=")
+	symNot = MakeSymbol("not")
 }
 
 func MakeInteger(v int) Obj {

--- a/kl/vm.go
+++ b/kl/vm.go
@@ -1,0 +1,198 @@
+package kl
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// ---- Opcodes ----
+
+const (
+	OP_LOAD_CONST   = uint8(0)  // push consts[A]
+	OP_LOAD_LOCAL   = uint8(1)  // push locals[A]
+	OP_STORE_LOCAL  = uint8(2)  // locals[A] = pop(); does NOT pop from value stack
+	OP_LOAD_GLOBAL  = uint8(3)  // push mustSymbol(consts[A]).function
+	OP_LOAD_UPVAL   = uint8(4)  // push upvals[A]
+	OP_CALL         = uint8(5)  // non-tail call: fn at stack[top-A-1], A args above
+	OP_TAIL_CALL    = uint8(6)  // tail call: same layout, signal trampoline
+	OP_RETURN       = uint8(7)  // ctl.Return(pop())
+	OP_JUMP         = uint8(8)  // pc += A (signed, A is int32)
+	OP_JUMP_FALSE   = uint8(9)  // pop(); if == False: pc += A
+	OP_MAKE_CLOSURE = uint8(10) // consts[A] is *BytecodeFunc; pop B upvals; push closure
+	OP_POP          = uint8(11) // discard top of stack
+)
+
+// Instr is a single VM instruction.  A and B are signed operands.
+type Instr struct {
+	Op uint8
+	A  int32
+	B  int32
+}
+
+// BytecodeFunc holds the compiled representation of a KL function.
+type BytecodeFunc struct {
+	Name    string
+	Arity   int
+	Nlocals int   // number of local slots (includes arity slots for params)
+	Code    []Instr
+	Consts  []Obj // constant pool (numbers, strings, symbols, nested BytecodeFunc objs)
+}
+
+// scmBytecodeFunc wraps a BytecodeFunc as an Obj so it can live in the Shen heap.
+type scmBytecodeFunc struct {
+	scmHead
+	fn     *BytecodeFunc
+	upvals []Obj // captured values for closures
+}
+
+const scmHeadBytecodeFunc scmHead = 50
+
+func makeBytecodeObj(fn *BytecodeFunc, upvals []Obj) Obj {
+	tmp := &scmBytecodeFunc{
+		scmHead: scmHeadBytecodeFunc,
+		fn:      fn,
+		upvals:  upvals,
+	}
+	return &tmp.scmHead
+}
+
+func isBytecodeFunc(o Obj) bool {
+	return *o == scmHeadBytecodeFunc
+}
+
+func mustBytecodeFunc(o Obj) *scmBytecodeFunc {
+	return (*scmBytecodeFunc)(unsafe.Pointer(o))
+}
+
+// vmApply is the entry point called from apply() for bytecode functions.
+// It handles arity checking and partial application, then calls vmExec.
+func vmApply(ctl *ControlFlow, bfObj Obj, args []Obj) {
+	bf := mustBytecodeFunc(bfObj)
+	fn := bf.fn
+	provided := len(args)
+
+	switch {
+	case provided < fn.Arity:
+		// Partial application: build a closure that waits for the remaining args.
+		ctl.Return(vmPartialApply(fn.Arity, args, bfObj, bf.upvals))
+	case provided == fn.Arity:
+		vmExec(ctl, bf, args)
+	case provided > fn.Arity:
+		// Over-application: call with the right arity, then apply the result.
+		res := Call(ctl, bfObj, args[:fn.Arity]...)
+		ctl.TailApply(res, args[fn.Arity:]...)
+	}
+}
+
+// vmPartialApply creates a closure that captures the supplied args and waits
+// for the remaining (required - len(provided)) arguments.
+func vmPartialApply(required int, providedArgs []Obj, proc Obj, upvals []Obj) Obj {
+	symbols := makeTempSymbols(required)
+	env1 := envExtend(Nil, symbols[:len(providedArgs)], providedArgs)
+
+	args := Nil
+	for i, count := len(symbols)-1, required-len(providedArgs); count > 0; count-- {
+		args = cons(symbols[i], args)
+		i--
+	}
+
+	body := Nil
+	for i := len(symbols) - 1; i >= 0; i-- {
+		body = cons(symbols[i], body)
+	}
+	body = cons(proc, body)
+
+	return makeProcedure(args, body, env1)
+}
+
+// vmExec runs one activation of a bytecode function.
+// It either calls ctl.Return with the result or sets up a tail call.
+func vmExec(ctl *ControlFlow, bf *scmBytecodeFunc, args []Obj) {
+	fn := bf.fn
+	upvals := bf.upvals
+
+	locals := make([]Obj, fn.Nlocals)
+	copy(locals, args)
+
+	stack := make([]Obj, 0, 16)
+	pc := 0
+	code := fn.Code
+	consts := fn.Consts
+
+	for {
+		instr := code[pc]
+		pc++
+		switch instr.Op {
+
+		case OP_LOAD_CONST:
+			stack = append(stack, consts[instr.A])
+
+		case OP_LOAD_LOCAL:
+			stack = append(stack, locals[instr.A])
+
+		case OP_STORE_LOCAL:
+			locals[instr.A] = stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+
+		case OP_LOAD_GLOBAL:
+			sym := mustSymbol(consts[instr.A])
+			if sym.function == nil {
+				panic(MakeError(fmt.Sprintf("function %s not bound", sym.str)))
+			}
+			stack = append(stack, sym.function)
+
+		case OP_LOAD_UPVAL:
+			stack = append(stack, upvals[instr.A])
+
+		case OP_CALL:
+			n := int(instr.A)
+			base := len(stack) - n - 1
+			callee := stack[base]
+			callArgs := make([]Obj, n)
+			copy(callArgs, stack[base+1:])
+			stack = stack[:base]
+			result := Call(ctl, callee, callArgs...)
+			stack = append(stack, result)
+
+		case OP_TAIL_CALL:
+			n := int(instr.A)
+			base := len(stack) - n - 1
+			callee := stack[base]
+			callArgs := make([]Obj, n)
+			copy(callArgs, stack[base+1:])
+			ctl.TailApply(callee, callArgs...)
+			return
+
+		case OP_RETURN:
+			ctl.Return(stack[len(stack)-1])
+			return
+
+		case OP_JUMP:
+			pc += int(instr.A)
+
+		case OP_JUMP_FALSE:
+			v := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if v == False {
+				pc += int(instr.A)
+			}
+
+		case OP_MAKE_CLOSURE:
+			nUpvals := int(instr.B)
+			innerBFObj := consts[instr.A]
+			innerBF := mustBytecodeFunc(innerBFObj)
+			captured := make([]Obj, nUpvals)
+			base := len(stack) - nUpvals
+			copy(captured, stack[base:])
+			stack = stack[:base]
+			closure := makeBytecodeObj(innerBF.fn, captured)
+			stack = append(stack, closure)
+
+		case OP_POP:
+			stack = stack[:len(stack)-1]
+
+		default:
+			panic(fmt.Sprintf("vmExec: unknown opcode %d at pc %d", instr.Op, pc-1))
+		}
+	}
+}

--- a/kl/vm.go
+++ b/kl/vm.go
@@ -8,18 +8,29 @@ import (
 // ---- Opcodes ----
 
 const (
-	OP_LOAD_CONST   = uint8(0)  // push consts[A]
-	OP_LOAD_LOCAL   = uint8(1)  // push locals[A]
-	OP_STORE_LOCAL  = uint8(2)  // locals[A] = pop(); does NOT pop from value stack
-	OP_LOAD_GLOBAL  = uint8(3)  // push mustSymbol(consts[A]).function
-	OP_LOAD_UPVAL   = uint8(4)  // push upvals[A]
-	OP_CALL         = uint8(5)  // non-tail call: fn at stack[top-A-1], A args above
-	OP_TAIL_CALL    = uint8(6)  // tail call: same layout, signal trampoline
-	OP_RETURN       = uint8(7)  // ctl.Return(pop())
-	OP_JUMP         = uint8(8)  // pc += A (signed, A is int32)
-	OP_JUMP_FALSE   = uint8(9)  // pop(); if == False: pc += A
-	OP_MAKE_CLOSURE = uint8(10) // consts[A] is *BytecodeFunc; pop B upvals; push closure
-	OP_POP          = uint8(11) // discard top of stack
+	OP_LOAD_CONST      = uint8(0)  // push consts[A]
+	OP_LOAD_LOCAL      = uint8(1)  // push locals[A]
+	OP_STORE_LOCAL     = uint8(2)  // locals[A] = pop()
+	OP_LOAD_GLOBAL     = uint8(3)  // push mustSymbol(consts[A]).function
+	OP_LOAD_UPVAL      = uint8(4)  // push upvals[A]
+	OP_CALL            = uint8(5)  // non-tail call: fn at stack[top-A-1], A args above
+	OP_TAIL_CALL       = uint8(6)  // tail call: same layout, signal trampoline
+	OP_RETURN          = uint8(7)  // ctl.Return(pop())
+	OP_JUMP            = uint8(8)  // pc += A (signed)
+	OP_JUMP_FALSE      = uint8(9)  // pop(); if == False: pc += A
+	OP_MAKE_CLOSURE    = uint8(10) // consts[A]=BytecodeFunc; pop B upvals; push closure
+	OP_POP             = uint8(11) // discard top of stack
+	OP_SELF_TAIL_CALL  = uint8(12) // A args on stack → update locals[0..A-1], jump pc=0
+	// Arithmetic fast-paths (avoid trampoline + float64 boxing for fixnums)
+	OP_ADD             = uint8(13) // pop y,x: push x+y
+	OP_SUB             = uint8(14) // pop y,x: push x-y
+	OP_MUL             = uint8(15) // pop y,x: push x*y
+	OP_LT              = uint8(16) // pop y,x: push x<y
+	OP_LE              = uint8(17) // pop y,x: push x<=y
+	OP_GT              = uint8(18) // pop y,x: push x>y
+	OP_GE              = uint8(19) // pop y,x: push x>=y
+	OP_EQ              = uint8(20) // pop y,x: push x=y  (numeric equality only)
+	OP_NOT             = uint8(21) // pop x: push (not x)
 )
 
 // Instr is a single VM instruction.  A and B are signed operands.
@@ -62,6 +73,59 @@ func isBytecodeFunc(o Obj) bool {
 
 func mustBytecodeFunc(o Obj) *scmBytecodeFunc {
 	return (*scmBytecodeFunc)(unsafe.Pointer(o))
+}
+
+// ---- Arithmetic helpers (fixnum fast paths) ----
+
+func numAdd(x, y Obj) Obj {
+	if isFixnum(x) && isFixnum(y) {
+		return MakeInteger(fixnum(x) + fixnum(y))
+	}
+	return MakeNumber(mustNumber(x) + mustNumber(y))
+}
+
+func numSub(x, y Obj) Obj {
+	if isFixnum(x) && isFixnum(y) {
+		return MakeInteger(fixnum(x) - fixnum(y))
+	}
+	return MakeNumber(mustNumber(x) - mustNumber(y))
+}
+
+func numMul(x, y Obj) Obj {
+	if isFixnum(x) && isFixnum(y) {
+		return MakeInteger(fixnum(x) * fixnum(y))
+	}
+	return MakeNumber(mustNumber(x) * mustNumber(y))
+}
+
+// numCmp: returns True if sign(x - y) == wantSign (-1 for <, 0 for ==).
+func numCmp(x, y Obj, wantSign int) Obj {
+	if isFixnum(x) && isFixnum(y) {
+		diff := fixnum(x) - fixnum(y)
+		if (wantSign < 0 && diff < 0) {
+			return True
+		}
+		return False
+	}
+	xf := mustNumber(x)
+	yf := mustNumber(y)
+	if (wantSign < 0 && xf < yf) {
+		return True
+	}
+	return False
+}
+
+func numCmpLE(x, y Obj) Obj {
+	if isFixnum(x) && isFixnum(y) {
+		if fixnum(x) <= fixnum(y) {
+			return True
+		}
+		return False
+	}
+	if mustNumber(x) <= mustNumber(y) {
+		return True
+	}
+	return False
 }
 
 // vmApply is the entry point called from apply() for bytecode functions.
@@ -190,6 +254,72 @@ func vmExec(ctl *ControlFlow, bf *scmBytecodeFunc, args []Obj) {
 
 		case OP_POP:
 			stack = stack[:len(stack)-1]
+
+		case OP_SELF_TAIL_CALL:
+			n := int(instr.A)
+			// All n args are on top of stack; copy into locals[0..n-1] and loop.
+			copy(locals[:n], stack[len(stack)-n:])
+			stack = stack[:len(stack)-n]
+			pc = 0
+
+		case OP_ADD:
+			y := stack[len(stack)-1]
+			x := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			stack = append(stack, numAdd(x, y))
+
+		case OP_SUB:
+			y := stack[len(stack)-1]
+			x := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			stack = append(stack, numSub(x, y))
+
+		case OP_MUL:
+			y := stack[len(stack)-1]
+			x := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			stack = append(stack, numMul(x, y))
+
+		case OP_LT:
+			y := stack[len(stack)-1]
+			x := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			stack = append(stack, numCmp(x, y, -1))
+
+		case OP_LE:
+			y := stack[len(stack)-1]
+			x := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			stack = append(stack, numCmpLE(x, y))
+
+		case OP_GT:
+			y := stack[len(stack)-1]
+			x := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			stack = append(stack, numCmp(y, x, -1)) // x > y ↔ y < x
+
+		case OP_GE:
+			y := stack[len(stack)-1]
+			x := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			stack = append(stack, numCmpLE(y, x)) // x >= y ↔ y <= x
+
+		case OP_EQ:
+			y := stack[len(stack)-1]
+			x := stack[len(stack)-2]
+			stack = stack[:len(stack)-2]
+			stack = append(stack, equal(x, y))
+
+		case OP_NOT:
+			x := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if x == True {
+				stack = append(stack, False)
+			} else if x == False {
+				stack = append(stack, True)
+			} else {
+				panic(MakeError("not: expected boolean"))
+			}
 
 		default:
 			panic(fmt.Sprintf("vmExec: unknown opcode %d at pc %d", instr.Op, pc-1))

--- a/kl/vm.go
+++ b/kl/vm.go
@@ -29,7 +29,7 @@ const (
 	OP_LE              = uint8(17) // pop y,x: push x<=y
 	OP_GT              = uint8(18) // pop y,x: push x>y
 	OP_GE              = uint8(19) // pop y,x: push x>=y
-	OP_EQ              = uint8(20) // pop y,x: push x=y  (numeric equality only)
+	OP_EQ              = uint8(20) // pop y,x: push x=y  (structural equality, delegates to equal())
 	OP_NOT             = uint8(21) // pop x: push (not x)
 )
 
@@ -67,10 +67,6 @@ func makeBytecodeObj(fn *BytecodeFunc, upvals []Obj) Obj {
 	return &tmp.scmHead
 }
 
-func isBytecodeFunc(o Obj) bool {
-	return *o == scmHeadBytecodeFunc
-}
-
 func mustBytecodeFunc(o Obj) *scmBytecodeFunc {
 	return (*scmBytecodeFunc)(unsafe.Pointer(o))
 }
@@ -98,18 +94,14 @@ func numMul(x, y Obj) Obj {
 	return MakeNumber(mustNumber(x) * mustNumber(y))
 }
 
-// numCmp: returns True if sign(x - y) == wantSign (-1 for <, 0 for ==).
-func numCmp(x, y Obj, wantSign int) Obj {
+func numCmpLT(x, y Obj) Obj {
 	if isFixnum(x) && isFixnum(y) {
-		diff := fixnum(x) - fixnum(y)
-		if (wantSign < 0 && diff < 0) {
+		if fixnum(x) < fixnum(y) {
 			return True
 		}
 		return False
 	}
-	xf := mustNumber(x)
-	yf := mustNumber(y)
-	if (wantSign < 0 && xf < yf) {
+	if mustNumber(x) < mustNumber(y) {
 		return True
 	}
 	return False
@@ -138,7 +130,7 @@ func vmApply(ctl *ControlFlow, bfObj Obj, args []Obj) {
 	switch {
 	case provided < fn.Arity:
 		// Partial application: build a closure that waits for the remaining args.
-		ctl.Return(vmPartialApply(fn.Arity, args, bfObj, bf.upvals))
+		ctl.Return(vmPartialApply(fn.Arity, args, bfObj))
 	case provided == fn.Arity:
 		vmExec(ctl, bf, args)
 	case provided > fn.Arity:
@@ -150,7 +142,7 @@ func vmApply(ctl *ControlFlow, bfObj Obj, args []Obj) {
 
 // vmPartialApply creates a closure that captures the supplied args and waits
 // for the remaining (required - len(provided)) arguments.
-func vmPartialApply(required int, providedArgs []Obj, proc Obj, upvals []Obj) Obj {
+func vmPartialApply(required int, providedArgs []Obj, proc Obj) Obj {
 	symbols := makeTempSymbols(required)
 	env1 := envExtend(Nil, symbols[:len(providedArgs)], providedArgs)
 
@@ -239,6 +231,8 @@ func vmExec(ctl *ControlFlow, bf *scmBytecodeFunc, args []Obj) {
 			stack = stack[:len(stack)-1]
 			if v == False {
 				pc += int(instr.A)
+			} else if v != True {
+				panic(MakeError("if requires a boolean"))
 			}
 
 		case OP_MAKE_CLOSURE:
@@ -284,7 +278,7 @@ func vmExec(ctl *ControlFlow, bf *scmBytecodeFunc, args []Obj) {
 			y := stack[len(stack)-1]
 			x := stack[len(stack)-2]
 			stack = stack[:len(stack)-2]
-			stack = append(stack, numCmp(x, y, -1))
+			stack = append(stack, numCmpLT(x, y))
 
 		case OP_LE:
 			y := stack[len(stack)-1]
@@ -296,7 +290,7 @@ func vmExec(ctl *ControlFlow, bf *scmBytecodeFunc, args []Obj) {
 			y := stack[len(stack)-1]
 			x := stack[len(stack)-2]
 			stack = stack[:len(stack)-2]
-			stack = append(stack, numCmp(y, x, -1)) // x > y ↔ y < x
+			stack = append(stack, numCmpLT(y, x)) // x > y ↔ y < x
 
 		case OP_GE:
 			y := stack[len(stack)-1]

--- a/thoughts/shen-go-compiler-design.md
+++ b/thoughts/shen-go-compiler-design.md
@@ -1,0 +1,150 @@
+# shen-go Compiler Design
+
+**Date**: 2026-05-05  
+**Branch**: `claude/shen-go-compiler-Stnpj`  
+**Goal**: Close the 60× interpreter gap to within 3–5× of shen-cl on bench/bench.shen
+
+---
+
+## Problem Statement
+
+The current shen-go evaluates user-defined Shen functions entirely through a
+KL tree-walking interpreter.  The profiler shows roughly 85% of CPU time in
+interpreter plumbing (`eval`, `trampoline`, `apply`) and ~25% in Go GC.
+Arithmetic and other "useful" work is sub-1%.
+
+The three concrete bottlenecks are:
+
+1. **`envGet` (O(depth) alist scan)** – every variable lookup walks a
+   linked list of `(sym . val)` cons cells.
+2. **`envExtend` (heap allocation)** – every function call allocates
+   `2 × arity` cons cells to extend the environment.
+3. **`eval` tree dispatch** – every node requires a tag switch and a
+   9-way special-form dispatch, all resolvable at compile time.
+
+A secondary correctness bug: `<`, `<=`, `>`, `>=` called `mustInteger`
+(which truncates floats) instead of `mustNumber`.  Fixed in Phase 0.
+
+---
+
+## Architecture Choice: Bytecode VM (Option A)
+
+**Chosen**: stack-based bytecode VM with per-call flat local-variable frames.
+
+**Rejected alternatives**:
+- *AOT-to-Go plugin*: Go plugin ABI is fragile; per-defun compile latency
+  is hundreds of ms; no Windows; no clean redefinition.
+- *CPS/direct-threaded*: harder to debug, limited advantage over a switch VM
+  on Go (no tail-call guarantee in Go).
+- *LLVM/native*: too heavy; no JIT in the Go toolchain.
+
+**Why the bytecode VM**:
+- Each `defun` is compiled once at define time to a flat `[]Instr` sequence.
+- Variables become integer-indexed slots in a per-call `[]Obj` frame.
+  `envGet` (O(depth)) → array read O(1).  `envExtend` cons allocation →
+  eliminated entirely for the common case.
+- Special-form dispatch happens at compile time; the VM loop is a single
+  `switch` over `uint8` opcodes.
+- Closures (lambda/freeze) carry `upvals []Obj` — a snapshot of captured
+  values at creation time.  No alist chain.
+- TCO: tail calls set `ControlFlowApply` and return to the existing
+  trampoline.  Self-tail calls are trampolined without growing the Go stack.
+- `trap-error` is lowered to `(try-catch (freeze body) handler)` at compile
+  time, reusing the existing panic/recover primitive.
+
+---
+
+## Instruction Set
+
+```
+OP_LOAD_CONST  A   — push consts[A]
+OP_LOAD_LOCAL  A   — push locals[A]
+OP_STORE_LOCAL A   — locals[A] = pop()
+OP_LOAD_GLOBAL A   — push mustSymbol(consts[A]).function  (runtime lookup)
+OP_LOAD_UPVAL  A   — push upvals[A]
+OP_CALL        A   — non-tail call: pop fn + A args, push result
+OP_TAIL_CALL   A   — tail call: set ControlFlowApply, return to trampoline
+OP_RETURN          — ctl.Return(pop())
+OP_JUMP        A   — pc += A  (signed)
+OP_JUMP_FALSE  A   — if pop()==False: pc += A
+OP_MAKE_CLOSURE A B — consts[A] is a *BytecodeFunc; pop B upvals from stack;
+                       push closure Obj
+OP_POP             — discard top of stack
+```
+
+`LOAD_GLOBAL` resolves the symbol's `.function` at call time so that
+redefined functions are always picked up without re-compilation.
+
+---
+
+## Compilation Rules
+
+| KL form | Compiled to |
+|---|---|
+| number/string/bool/nil | `OP_LOAD_CONST` |
+| local symbol | `OP_LOAD_LOCAL idx` |
+| upvalue symbol | `OP_LOAD_UPVAL idx` |
+| global symbol (value pos) | `OP_LOAD_CONST sym` (returns symbol itself) |
+| `(defun f (x…) body)` | compile body; bind `scmBytecodeFunc` to `f.function` |
+| `(lambda x body)` | inner compile; `OP_MAKE_CLOSURE` with captured upvals |
+| `(freeze body)` | same as lambda with 0 params |
+| `(let x val body)` | compile val, `OP_STORE_LOCAL`, compile body |
+| `(if a b c)` | compile a, `OP_JUMP_FALSE`, compile b, `OP_JUMP`, compile c |
+| `(and a b)` | → `(if a b false)` |
+| `(or a b)` | → `(if a true b)` |
+| `(cond …)` | → nested ifs |
+| `(do a b)` | compile a (non-tail), `OP_POP`, compile b (inherits tail) |
+| `(type x _)` | compile x |
+| `(trap-error b h)` | → `(try-catch (freeze b) h)` |
+| `(f arg…)` | compile f + args, `OP_CALL`/`OP_TAIL_CALL` |
+
+---
+
+## Integration with Existing Code
+
+- `eval()` special-form handler for `defun` calls `CompileFunc` and stores
+  the resulting `scmBytecodeFunc` in the symbol's `.function` slot.
+- `apply()` gains a `scmHeadBytecodeFunc` case that calls `vmExec`.
+- The existing `scmProcedure` / tree-walker path remains as a fallback for
+  any form that fails compilation (should not happen in practice).
+- `primDefun` (called by Shen-level compiler) also compiles its argument if
+  it receives a `scmProcedure`.
+- `ObjString`, `equal`, and the `apply` partial-application logic all handle
+  `scmBytecodeFunc` alongside the existing types.
+
+---
+
+## Upvalue Capture
+
+Upvalues are discovered during compilation of a nested lambda/freeze.
+When the inner compiler cannot resolve a symbol as a local or already-known
+upvalue, it queries the outer compiler's `resolveVar`.  The outer compiler
+may itself recurse upward for multi-level closures.
+
+At closure creation (in the outer function's bytecode), the outer compiler
+emits `OP_LOAD_LOCAL` or `OP_LOAD_UPVAL` for each captured variable before
+`OP_MAKE_CLOSURE`.  The inner function's bytecode accesses them via
+`OP_LOAD_UPVAL`.
+
+---
+
+## Phased Plan (remaining milestones)
+
+| Phase | Description | Expected gain |
+|---|---|---|
+| 0 | Float fix; design doc; bench baseline | correctness |
+| 2 | Bytecode VM (params → slots; compile defun/lambda/let) | 4–8× |
+| 3 | Numeric specialization (fixnum fast paths) | 2–3× on tak/fib |
+| 4 | Pattern-match compilation to decision trees | 1.5–2× on nrev/map |
+| 5 | Inline cache for global lookup; self-tail jump | 1.2–1.5× |
+
+---
+
+## Things Tried and Reverted
+
+*(fill in as work proceeds)*
+
+- Phase 1 (annotated-AST indexed slots) was folded directly into Phase 2.
+  Keeping the tree-walker with slot annotations would have required threading
+  a `frame []Obj` through all eval/apply paths — essentially a partial VM —
+  so it was cleaner to build the full VM directly.


### PR DESCRIPTION
## Summary

This adds a **stack-based bytecode VM** for KL, replacing the tree-walking
interpreter as the execution path for every `defun` (both REPL/KL `defun`
and the Shen-level `define`, which lowers to KL `defun`). The tree-walker
remains in place and is still used for top-level forms and as a fallback.

Each function is compiled once, at define time, to a flat `[]Instr` sequence
with integer-indexed local slots:

- **Variable access** `envGet` (O(depth) alist scan) → array index O(1).
- **Calls** no longer allocate `2×arity` cons cells per call to extend the
  environment.
- **Special-form dispatch** happens at compile time; the VM loop is a single
  `switch` over `uint8` opcodes.
- **Closures** (`lambda`/`freeze`) capture upvalues by value at creation time.
- **TCO**: tail calls reuse the existing trampoline; self-tail calls loop in
  place without growing the Go stack.
- **Arithmetic fast paths**: `+ - * < <= > >= = not` compile to dedicated
  opcodes with a fixnum fast path, avoiding boxing and the trampoline.

A correctness fix is also included (Phase 0): `<`, `<=`, `>`, `>=` used
`mustInteger` (which truncated floats) instead of `mustNumber`.

## Performance (S39.2 kernel)

| Benchmark | Baseline (tree-walker) | This PR | Speedup |
|---|---|---|---|
| `tak(18,12,6)` | 0.088s | 0.006s | **~15×** |
| `(sum 0 5000000)` tail loop | 2.99s | 0.05s | **~60×** |
| `fib(30)` | — | 0.29s | — |

See `bench/RESULTS.md` and `thoughts/shen-go-compiler-design.md` for the full
design write-up and methodology.

## Semantics preserved

The VM matches the interpreter's `evalFunction`/`eval` semantics, including
the Lisp-2 detail that **a global function binding takes precedence over a
same-named local in call position**. Other preserved behaviors: strict
boolean `if` (non-boolean condition errors), nested-`defun` lexical capture,
partial application, over-application, and `trap-error` (lowered to
`try-catch` over a `freeze`d body so panic/recover still has a real frame).

## Testing

- `go test ./...` passes, including new `TestBytecodeVM` cases covering
  closures (incl. multi-level upvalue chains), `let` shadowing, `trap-error`,
  tail recursion, currying, over-application, nested-defun capture, strict
  boolean `if`, global-vs-local precedence, and float comparisons.
- `go vet ./kl/` clean.
- The **full S39.2 kernel compiles and loads** (every `defun` goes through
  the compiler), and a suite of real Shen programs — pattern-matched
  `define`s with `where` guards, higher-order functions, Ackermann, deep
  (200k-iteration) tail recursion, string/float ops — all produce correct
  results.

## Notes for reviewers

- Arithmetic intrinsics inline `+`/`-`/etc., which means redefining those
  primitives globally would not be picked up by already-compiled code. This
  matches typical Lisp compiler behavior and the kernel never redefines them.
- `thoughts/shen-go-compiler-design.md` is included as design rationale —
  happy to drop it if you'd prefer it not live in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
